### PR TITLE
feat(chat): add correlated async runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ workflow.
 - Stream scoped channel replies through a durable, resumable
   `channels.subscribe` CLI gateway contract without per-message blocking waits
   (#1389)
+- Correlate concurrent routed channel posts, replies, and terminal lifecycle
+  updates through durable provider-neutral asynchronous run and target ids;
+  idempotent post retries return the original run (#1391)
 - Deliver durable, exactly-once upward completion callbacks for explicit
   agent-to-agent channel delegations, including restart recovery, busy-agent
   FIFO queueing, nested child fan-in, and explicit-return de-duplication (#1359)

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1595,6 +1595,7 @@ const CLI_GATEWAY_ACTOR_TOKEN_COMMANDS = new Set<RelayCliGatewayCommand>([
   'workspace-topics.archive',
   'channels.list',
   'channels.get',
+  'channels.run.get',
   'channels.history',
   'channels.subscribe',
   'channels.threads.history',
@@ -3508,6 +3509,7 @@ async function runGatewayWorkContexts(gatewayArgs: string[]): Promise<never> {
     });
     printGatewayEnvelope(gatewayOk('work-contexts.get', result), 0);
   }
+
   if (subcommand === 'resume') {
     const commandName: RelayCliGatewayCommand = 'work-contexts.resume';
     const id = gatewayArg(workContextArgs, '--id') ?? workContextArgs[0];
@@ -5349,6 +5351,7 @@ async function runGatewayWorkspaceTopics(
 
 type ChannelCliValueFlag =
   | '--channel-id'
+  | '--run-id'
   | '--thread-id'
   | '--limit'
   | '--before-seq'
@@ -5396,12 +5399,17 @@ function parseChannelCliFlags(
 function requiredChannelCliString(
   commandName: RelayCliGatewayCommand,
   values: ReadonlyMap<ChannelCliValueFlag, string>,
-  flag: '--channel-id' | '--thread-id'
+  flag: '--channel-id' | '--thread-id' | '--run-id'
 ): string {
   const value = values.get(flag)?.trim() ?? '';
   if (!value) {
     gatewayInvalid(commandName, `${flag} is required`, {
-      field: flag === '--channel-id' ? 'channelId' : 'threadId',
+      field:
+        flag === '--channel-id'
+          ? 'channelId'
+          : flag === '--thread-id'
+            ? 'threadId'
+            : 'runId',
     });
   }
   return value;
@@ -5525,6 +5533,33 @@ async function runGatewayChannels(gatewayArgs: string[]): Promise<void> {
       capabilities: ['context:read'],
     });
     printGatewayEnvelope(gatewayOk('channels.get', result), 0);
+  }
+
+  if (subcommand === 'run' && channelArgs[0] === 'get') {
+    const values = parseChannelCliFlags(
+      'channels.run.get',
+      channelArgs.slice(1),
+      ['--channel-id', '--run-id', '--thread-id']
+    );
+    const channelId = requiredChannelCliString(
+      'channels.run.get',
+      values,
+      '--channel-id'
+    );
+    const runId = requiredChannelCliString(
+      'channels.run.get',
+      values,
+      '--run-id'
+    );
+    const query = new URLSearchParams();
+    const threadId = values.get('--thread-id');
+    if (threadId) query.set('threadId', threadId);
+    const result = await gatewayHttpJson({
+      commandName: 'channels.run.get',
+      pathName: `/channels/${encodeURIComponent(channelId)}/runs/${encodeURIComponent(runId)}${query.size ? `?${query}` : ''}`,
+      capabilities: ['context:read'],
+    });
+    printGatewayEnvelope(gatewayOk('channels.run.get', result), 0);
   }
 
   if (subcommand === 'history') {

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -5553,7 +5553,15 @@ async function runGatewayChannels(gatewayArgs: string[]): Promise<void> {
     );
     const query = new URLSearchParams();
     const threadId = values.get('--thread-id');
-    if (threadId) query.set('threadId', threadId);
+    if (threadId !== undefined) {
+      const trimmedThreadId = threadId.trim();
+      if (!trimmedThreadId) {
+        gatewayInvalid('channels.run.get', '--thread-id must be non-empty', {
+          field: 'threadId',
+        });
+      }
+      query.set('threadId', trimmedThreadId);
+    }
     const result = await gatewayHttpJson({
       commandName: 'channels.run.get',
       pathName: `/channels/${encodeURIComponent(channelId)}/runs/${encodeURIComponent(runId)}${query.size ? `?${query}` : ''}`,

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -110,6 +110,44 @@ frames carry a required reason plus retryability. A bounded consumer stops
 parsing immediately after its `--max-events` frame and cancels the upstream
 reader; stdout backpressure is drained rather than treated as a dropped frame.
 
+### Correlated asynchronous runs
+
+An accepted external `channels.post` that can route work creates one opaque,
+Relay-owned `runId`. The returned post result carries that run, and the
+request message, principal replies, durable history, reconnect snapshots, and
+subscription lifecycle events retain the same public run reference. Clients
+must correlate with `runId` (and `targetId` for a particular intended agent),
+not by parsing provider runtime, turn, or item identifiers.
+
+`GET /channels/:channelId/runs/:runId` reads one run through the same scoped
+`context:read` lane as channel history. An optional `threadId` is an exact
+identity check, never a selector that can move a run between threads. Snapshots
+include the most recent run projections within explicit count and byte budgets;
+the lifecycle stream remains authoritative for subsequent changes.
+
+A run has immutable channel, canonical root-or-thread, requester, and request
+message scope. Its targets move independently through `queued`, `working`,
+`input-required`, `auth-required`, and one terminal state: `completed`,
+`failed`, `cancelled`, or `rejected`. The aggregate stays nonterminal while
+any target remains nonterminal; it completes only when all targets complete;
+failure wins mixed terminal results containing a failure or rejection; and a
+post without an eligible target is safely rejected. Approval metadata reserves
+`requested`, `resolved`, and `expired` without defining #1179's response API.
+
+Idempotent retries are keyed by `(channelId, server-derived sender,
+clientMessageId)`: a replay returns the original request message and run and
+does not route another target. A reconnecting client resumes from `durableSeq`
+and receives authoritative lifecycle state from the same durable log, so it may
+have many concurrent runs with no response-order assumption. Callback delivery
+to unavailable external requesters remains #1392's bounded `undeliverable`
+case; it must terminalize the affected run rather than create a requester
+runtime.
+
+Relay never redelivers a nonterminal run after process restart: recovery
+terminalizes its nonterminal targets as `cancelled` with `server-restarted`,
+preserving an inspectable outcome. Settled run rows have bounded retention and
+are removed with their channels during orphan cleanup.
+
 ### Read state and unread
 
 Unread is derived client-side; the _marker_ it derives from converges through

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -145,6 +145,38 @@ stdout drain instead of dropping frames; a downstream closed pipe is treated as
 clean local cancellation and promptly cancels the upstream reader. The stream uses
 `context:read` plus the actor credential's exact `channelIds` scope.
 
+### Correlated async channel runs (#1391)
+
+`channels.post` returns an opaque Relay-owned `runId` for accepted routed work.
+Persist it with the returned request message. Principal replies expose that
+same `runId` plus their durable `targetId`; run lifecycle frames report each
+target and the aggregate state. These are the public request/reply contract for
+multiple outstanding posts on one subscription. Provider runtime, turn, and
+item identifiers are optional diagnostics only and must never be parsed for
+correlation.
+
+`relay-ide v1 channels run get --channel-id <id> --run-id <id>
+[--thread-id <root-or-thread-id>] --json` reads one opaque run with
+`context:read`. The actor must be scoped to the exact channel; when supplied,
+`threadId` must exactly equal the run's immutable scope or the command returns
+`NOT_FOUND`.
+
+Use a stable `clientMessageId` when retrying a post after an ambiguous
+transport outcome. The same `(channelId, authenticated sender,
+clientMessageId)` returns the original message and run without rerouting. On
+reconnect, resume with the last `durableSeq` and reapply full-row and lifecycle
+frames idempotently; replies and terminal state can arrive in any order across
+different runs. Per-target states are `queued`, `working`, `input-required`,
+`auth-required`, `completed`, `failed`, `cancelled`, and `rejected`; aggregate
+state is terminal only when every target is terminal. Approval fields support
+`requested`, `resolved`, and `expired`, while #1179 owns any approval-response
+command.
+
+At startup Relay cancels rather than redelivers unfinished persisted targets,
+using the inspectable `server-restarted` reason. Reconnect snapshots project
+runs within fixed count and byte budgets; lifecycle events and this run-get
+command provide the authoritative durable status outside that snapshot window.
+
 The former public agent-session and terminal hand-back contracts are
 superseded. Public terminals are always human-driven. `sessions.input` and
 `supervisor.*` control terminal programs; they are not an alternate agent

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -2506,15 +2506,19 @@ export function createChannelAgentBinder(
       turnId,
       parentForTrigger(trigger) ?? null
     );
-    binding.requestMessageIdByTurn.set(turnId, trigger.id);
-    const asyncRun = store.getAsyncRunForRequestMessage(trigger.id);
-    if (asyncRun) {
-      const changed = store.transitionAsyncRunTarget({
-        runId: asyncRun.id,
-        targetId: binding.profileActorId,
-        state: 'working',
-      });
-      if (changed) hub.broadcastRunLifecycle(changed);
+    // Completion callbacks travel upward only. They must never inherit the
+    // triggering requester run or make callback prose look like a reply to it.
+    if (!completionCallback) {
+      binding.requestMessageIdByTurn.set(turnId, trigger.id);
+      const asyncRun = store.getAsyncRunForRequestMessage(trigger.id);
+      if (asyncRun) {
+        const changed = store.transitionAsyncRunTarget({
+          runId: asyncRun.id,
+          targetId: binding.profileActorId,
+          state: 'working',
+        });
+        if (changed) hub.broadcastRunLifecycle(changed);
+      }
     }
     if (completionCallback?.continuationParentCallbackId) {
       binding.continuationByTurn.set(turnId, {

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -47,9 +47,12 @@ import {
   isChannelMessageDeleted,
   parseMentions,
   CHANNEL_RETRY_OF_META_KEY,
+  type ChannelAsyncRunApprovalState,
+  type ChannelAsyncRunTargetState,
   type ChannelMention,
   type ChannelMessage,
   type ChannelPostSteering,
+  type ChannelSenderRef,
 } from '../shared/channel-chat-protocol.js';
 import type {
   AgentApprovalDecisionV2,
@@ -126,6 +129,12 @@ const DEFAULT_PRESENCE_SWEEP_MS = 30 * 1000;
 export const MAX_CONSECUTIVE_AGENT_TURNS = 4;
 /** Dedupe identical unavailable/cross-node system rows per (channel, agent). */
 const UNAVAILABLE_ROW_TTL_MS = 5 * 60 * 1000;
+/**
+ * Keep exact provider turn ids briefly after a bare-idle successor starts.
+ * These tombstones are deliberately never candidates for anonymous `turn-0`.
+ */
+const EXACT_TURN_TOMBSTONE_TTL_MS = 60 * 1000;
+const EXACT_TURN_TOMBSTONE_MAX = 16;
 /** How long a resolved framework-availability list is reused before re-probing. */
 const TARGETS_TTL_MS = 5 * 1000;
 /** Claim in bounded pages so a large recovered outbox cannot strand its tail. */
@@ -243,6 +252,17 @@ export interface ChannelAgentBinderDeps {
 }
 
 export interface ChannelAgentBinder {
+  /**
+   * Authoritative pre-persistence admission for a channel post. The router uses
+   * these profile actor ids in its one post+run transaction; routing below uses
+   * the same resolver, so a durable target is never invented or omitted.
+   */
+  resolvePostTargetIds(input: {
+    channelId: string;
+    sender: ChannelSenderRef;
+    text: string;
+    mentions: ChannelMention[];
+  }): string[];
   handleMessagePosted(
     message: ChannelMessage,
     mentions: ChannelMention[],
@@ -346,6 +366,12 @@ interface CallbackEdgeRequest {
   continuationParentCallbackId?: string;
 }
 
+interface ExactTurnTombstone {
+  parentMessageId: string | null;
+  requestMessageId: ChannelMessage['id'];
+  expiresAt: number;
+}
+
 export interface LiveBinding {
   channelId: string;
   /** Null is the root-channel execution scope. */
@@ -363,6 +389,10 @@ export interface LiveBinding {
   activeTurnId: string | null;
   /** Immediate thread parent keyed by routed turn; retained past binder idle. */
   parentMessageIdByTurn: Map<string, string | null>;
+  /** Exact accepted post that owns an async target turn (never provider-derived). */
+  requestMessageIdByTurn: Map<string, ChannelMessage['id']>;
+  /** Bounded exact-turn ancestry retained across a successor; never used by turn-0. */
+  exactTurnTombstones: Map<string, ExactTurnTombstone>;
   /** Last terminal prose row by turn, available before the terminal patch lands. */
   finalMessageByTurn: Map<string, ChannelMessage>;
   /** Child callback and ancestor edge awaited by its internal callback turn. */
@@ -699,6 +729,12 @@ export function createChannelAgentBinder(
     turnId: string
   ): string | undefined {
     if (binding.parentMessageIdByTurn.has(turnId)) return turnId;
+    // Exact provider turn ids can arrive after a bare-idle successor starts.
+    // Retain a bounded tombstone for that exact identity only; `turn-0` is an
+    // anonymous fallback label and must never borrow a predecessor tombstone.
+    if (turnId !== 'turn-0' && exactTurnTombstone(binding, turnId)) {
+      return turnId;
+    }
     // Hermes can label a late output item `turn-0` after clearing its current
     // turn. Use the retained parent only when there is exactly one possible
     // routed turn; ambiguity must fail closed rather than borrow a wrong thread.
@@ -713,6 +749,65 @@ export function createChannelAgentBinder(
     return undefined;
   }
 
+  function exactTurnTombstone(
+    binding: LiveBinding,
+    turnId: string
+  ): ExactTurnTombstone | undefined {
+    const tombstone = binding.exactTurnTombstones.get(turnId);
+    if (!tombstone) return undefined;
+    if (tombstone.expiresAt > now()) return tombstone;
+    binding.exactTurnTombstones.delete(turnId);
+    return undefined;
+  }
+
+  function parentMessageIdForTurnKey(
+    binding: LiveBinding,
+    turnId: string
+  ): string | null | undefined {
+    if (binding.parentMessageIdByTurn.has(turnId)) {
+      return binding.parentMessageIdByTurn.get(turnId);
+    }
+    return turnId === 'turn-0'
+      ? undefined
+      : exactTurnTombstone(binding, turnId)?.parentMessageId;
+  }
+
+  function requestMessageIdForTurnKey(
+    binding: LiveBinding,
+    turnId: string
+  ): ChannelMessage['id'] | undefined {
+    const active = binding.requestMessageIdByTurn.get(turnId);
+    if (active) return active;
+    return turnId === 'turn-0'
+      ? undefined
+      : exactTurnTombstone(binding, turnId)?.requestMessageId;
+  }
+
+  function retainExactTurnTombstones(binding: LiveBinding): void {
+    const expiresAt = now() + EXACT_TURN_TOMBSTONE_TTL_MS;
+    for (const [turnId, parentMessageId] of binding.parentMessageIdByTurn) {
+      const requestMessageId = binding.requestMessageIdByTurn.get(turnId);
+      // `turn-0` is a provider's anonymous fallback label, not a reliable
+      // exact identity. It is intentionally excluded from this retention lane.
+      if (turnId === 'turn-0' || !requestMessageId) continue;
+      binding.exactTurnTombstones.delete(turnId);
+      binding.exactTurnTombstones.set(turnId, {
+        parentMessageId,
+        requestMessageId,
+        expiresAt,
+      });
+    }
+    for (const [turnId, tombstone] of binding.exactTurnTombstones) {
+      if (tombstone.expiresAt <= now())
+        binding.exactTurnTombstones.delete(turnId);
+    }
+    while (binding.exactTurnTombstones.size > EXACT_TURN_TOMBSTONE_MAX) {
+      const oldest = binding.exactTurnTombstones.keys().next().value;
+      if (oldest === undefined) break;
+      binding.exactTurnTombstones.delete(oldest);
+    }
+  }
+
   function parentForTurn(
     binding: LiveBinding,
     turnId: string
@@ -721,7 +816,7 @@ export function createChannelAgentBinder(
     const triggerParent =
       key === undefined
         ? undefined
-        : (binding.parentMessageIdByTurn.get(key) ?? undefined);
+        : (parentMessageIdForTurnKey(binding, key) ?? undefined);
     // An ambiguous provider fallback must not borrow a possibly wrong trigger,
     // but a thread-scoped runtime still knows its durable conversation root.
     // Keep its output in that conversation rather than leaking it to the root
@@ -1380,6 +1475,8 @@ export function createChannelAgentBinder(
       status: 'idle',
       activeTurnId: null,
       parentMessageIdByTurn: new Map(),
+      requestMessageIdByTurn: new Map(),
+      exactTurnTombstones: new Map(),
       finalMessageByTurn: new Map(),
       continuationByTurn: new Map(),
       completionCallbackByTurn: new Map(),
@@ -1446,8 +1543,10 @@ export function createChannelAgentBinder(
       for (const turnId of existing.parentMessageIdByTurn.keys()) {
         if (turnId !== existing.activeTurnId) {
           existing.parentMessageIdByTurn.delete(turnId);
+          existing.requestMessageIdByTurn.delete(turnId);
         }
       }
+      existing.exactTurnTombstones.clear();
       // Removing the old adapter listeners establishes a hard boundary for
       // anonymous provider turn ids while retaining an exact active retry.
       existing.turnZeroFallbackUnsafe = false;
@@ -1483,6 +1582,20 @@ export function createChannelAgentBinder(
         ? { initialAgentAttribution: runtime.agentAttribution }
         : {}),
       parentMessageIdForTurn: (turnId) => parentForTurn(binding, turnId),
+      asyncRunReferenceForTurn: (turnId) => {
+        // Mirror the exact/fallback ancestry rules for the public run ref. A
+        // late Hermes `turn-0` can only borrow a retained generation when it is
+        // uniquely safe; ambiguity never leaks correlation across requests.
+        const key = parentKeyForTurn(binding, turnId);
+        const triggerId = key
+          ? requestMessageIdForTurnKey(binding, key)
+          : undefined;
+        if (!triggerId) return undefined;
+        const run = store.getAsyncRunForRequestMessage(triggerId);
+        return run
+          ? { runId: run.id, targetId: binding.profileActorId }
+          : undefined;
+      },
       onAssistantMessageFinalized: (message) =>
         handleAssistantFinalized(binding, message),
     });
@@ -2385,12 +2498,24 @@ export function createChannelAgentBinder(
       // safely; exact turn ids continue to work.
       binding.turnZeroFallbackUnsafe = true;
     }
+    retainExactTurnTombstones(binding);
     binding.parentMessageIdByTurn.clear();
+    binding.requestMessageIdByTurn.clear();
     binding.activeTurnId = turnId;
     binding.parentMessageIdByTurn.set(
       turnId,
       parentForTrigger(trigger) ?? null
     );
+    binding.requestMessageIdByTurn.set(turnId, trigger.id);
+    const asyncRun = store.getAsyncRunForRequestMessage(trigger.id);
+    if (asyncRun) {
+      const changed = store.transitionAsyncRunTarget({
+        runId: asyncRun.id,
+        targetId: binding.profileActorId,
+        state: 'working',
+      });
+      if (changed) hub.broadcastRunLifecycle(changed);
+    }
     if (completionCallback?.continuationParentCallbackId) {
       binding.continuationByTurn.set(turnId, {
         childCallbackId: completionCallback.id,
@@ -2762,6 +2887,15 @@ export function createChannelAgentBinder(
   ): void {
     const terminalTurnId = binding.activeTurnId;
     if (terminalTurnId === null) return;
+    transitionAsyncRunTargetForTurn(
+      binding,
+      terminalTurnId,
+      terminalReason === 'completed' || terminalReason === 'safe-idle'
+        ? 'completed'
+        : terminalReason === 'interrupt'
+          ? 'cancelled'
+          : 'failed'
+    );
     terminalizeCompletionCallback(binding, terminalTurnId, terminalReason);
     const callback = binding.completionCallbackByTurn.get(terminalTurnId);
     if (
@@ -2993,12 +3127,44 @@ export function createChannelAgentBinder(
     }
   }
 
+  function transitionAsyncRunTargetForTurn(
+    binding: LiveBinding,
+    turnId: string,
+    state: ChannelAsyncRunTargetState,
+    options?: {
+      reason?: string;
+      approvalState?: ChannelAsyncRunApprovalState;
+    }
+  ): void {
+    const requestMessageId = binding.requestMessageIdByTurn.get(turnId);
+    if (!requestMessageId) return;
+    const run = store.getAsyncRunForRequestMessage(requestMessageId);
+    if (!run) return;
+    const changed = store.transitionAsyncRunTarget({
+      runId: run.id,
+      targetId: binding.profileActorId,
+      state,
+      ...options,
+    });
+    if (changed) hub.broadcastRunLifecycle(changed);
+  }
+
   function handleApprovalStarted(
     binding: LiveBinding,
     item: AgentApprovalItemV2
   ): void {
     if (binding.announcedApprovals.has(item.requestId)) return;
     binding.announcedApprovals.add(item.requestId);
+    if (binding.activeTurnId !== null) {
+      transitionAsyncRunTargetForTurn(
+        binding,
+        binding.activeTurnId,
+        'input-required',
+        {
+          approvalState: 'requested',
+        }
+      );
+    }
     postSystemRow(
       binding.channelId,
       `@${binding.displayName} requests approval: ${item.description} (${item.target})`,
@@ -3023,6 +3189,14 @@ export function createChannelAgentBinder(
     if (!binding.announcedApprovals.has(item.requestId)) return;
     binding.announcedApprovals.delete(item.requestId);
     const kind = item.decision?.kind ?? 'resolved';
+    if (binding.activeTurnId !== null) {
+      transitionAsyncRunTargetForTurn(
+        binding,
+        binding.activeTurnId,
+        'working',
+        { approvalState: 'resolved' }
+      );
+    }
     postSystemRow(
       binding.channelId,
       `@${binding.displayName} approval ${kind}`,
@@ -3083,11 +3257,23 @@ export function createChannelAgentBinder(
         }
       };
       try {
+        const rejectAsyncTarget = (reason: string) => {
+          const run = store.getAsyncRunForRequestMessage(trigger.id);
+          if (!run) return;
+          const changed = store.transitionAsyncRunTarget({
+            runId: run.id,
+            targetId: profile.id,
+            state: 'rejected',
+            reason,
+          });
+          if (changed) hub.broadcastRunLifecycle(changed);
+        };
         const framework = profile.providerId;
         const target = await resolveTarget(framework);
         if (closed) return; // close() raced the availability probe
         if (!target) {
           releaseDeferredParent();
+          rejectAsyncTarget('target-unavailable');
           // Not a known framework. In a multi-party channel an unroutable
           // @name stays silent (§1). In a DM there is nobody ELSE to answer the
           // HUMAN, so silence reads as the product being broken — say so.
@@ -3116,6 +3302,7 @@ export function createChannelAgentBinder(
         const availability = availabilityForProfile(profile, target);
         if (!availability.available) {
           releaseDeferredParent();
+          rejectAsyncTarget('target-unavailable');
           const senderDisplayName =
             profile.displayName || target.displayName || framework;
           postUnavailableRow(
@@ -3138,6 +3325,9 @@ export function createChannelAgentBinder(
           if (err instanceof BinderClosedError) return; // shutdown — silent
           if (err instanceof ChannelBindingError) {
             releaseDeferredParent();
+            rejectAsyncTarget(
+              err.unavailable ? 'target-unavailable' : 'target-binding-failed'
+            );
             if (err.unavailable) {
               postUnavailableRow(
                 trigger.channelId,
@@ -3177,9 +3367,20 @@ export function createChannelAgentBinder(
             releaseDeferredParent();
           }
         }
+        if (!admitted) rejectAsyncTarget('target-not-admitted');
       } catch (err) {
         if (closed || err instanceof BinderClosedError) return;
         releaseDeferredParent();
+        const run = store.getAsyncRunForRequestMessage(trigger.id);
+        if (run) {
+          const changed = store.transitionAsyncRunTarget({
+            runId: run.id,
+            targetId: profile.id,
+            state: 'failed',
+            reason: 'target-routing-failed',
+          });
+          if (changed) hub.broadcastRunLifecycle(changed);
+        }
         logger.warn('channel binder route failed:', err);
       }
     })().finally(() => {
@@ -3192,7 +3393,7 @@ export function createChannelAgentBinder(
 
   /** Eligible profile-resolved, non-self mentions in routing order. */
   function eligibleProfiles(
-    message: ChannelMessage,
+    message: Pick<ChannelMessage, 'sender'>,
     mentions: ChannelMention[]
   ): AgentProfile[] {
     const seen = new Set<string>();
@@ -3218,7 +3419,7 @@ export function createChannelAgentBinder(
   }
 
   function currentProfileMentions(
-    message: ChannelMessage,
+    message: Pick<ChannelMessage, 'body'>,
     supplied: ChannelMention[]
   ): ChannelMention[] {
     if (!deps.agentProfileStore) return supplied;
@@ -3283,6 +3484,19 @@ export function createChannelAgentBinder(
     prepareContinuation?: () => string | undefined
   ): void {
     if (profiles.length === 0) return;
+    const rejectPreAdmittedTargets = (reason: string) => {
+      const run = store.getAsyncRunForRequestMessage(message.id);
+      if (!run) return;
+      for (const profile of profiles) {
+        const changed = store.transitionAsyncRunTarget({
+          runId: run.id,
+          targetId: profile.id,
+          state: 'rejected',
+          reason,
+        });
+        if (changed) hub.broadcastRunLifecycle(changed);
+      }
+    };
     const sourceRuntime = message.source?.runtimeId
       ? deps.runtimes.get(message.source.runtimeId)
       : undefined;
@@ -3322,10 +3536,14 @@ export function createChannelAgentBinder(
     // Pause is a per-dispatch safety check, not a turn-admission check. A turn
     // may legitimately finalize several assistant items, but none may route
     // after another turn has paused the channel.
-    if (state.paused) return;
+    if (state.paused) {
+      rejectPreAdmittedTargets('mention-chain-paused');
+      return;
+    }
     if (!state.allowedTurnKeys.has(turnKey)) {
       if (state.count >= MAX_CONSECUTIVE_AGENT_TURNS) {
         state.paused = true;
+        rejectPreAdmittedTargets('mention-chain-paused');
         // Bounds total agent-token spend between human turns. Reset happens
         // on the next human (browser / gateway-human) post.
         postSystemRow(
@@ -3361,6 +3579,40 @@ export function createChannelAgentBinder(
     }
   }
 
+  /**
+   * One resolver serves both pre-persistence run admission and post-persistence
+   * delivery. Explicit pinned mentions win; only an unmentioned human post can
+   * select a DM default or durable sole orchestrator.
+   */
+  function resolvedPostTargets(
+    message: Pick<ChannelMessage, 'channelId' | 'sender' | 'body'>,
+    mentions: ChannelMention[]
+  ): Array<{ profile: AgentProfile; requiredRole?: 'orchestrator' }> {
+    const routingMentions = currentProfileMentions(message, mentions);
+    const profiles = eligibleProfiles(message, routingMentions);
+    if (profiles.length > 0) return profiles.map((profile) => ({ profile }));
+    if (message.sender.kind !== 'human' || routingMentions.length > 0)
+      return [];
+    const implicit = implicitHumanRecipient(message.channelId);
+    return implicit ? [implicit] : [];
+  }
+
+  function resolvePostTargetIds(input: {
+    channelId: string;
+    sender: ChannelSenderRef;
+    text: string;
+    mentions: ChannelMention[];
+  }): string[] {
+    return resolvedPostTargets(
+      {
+        channelId: input.channelId,
+        sender: input.sender,
+        body: { text: input.text, format: 'markdown' },
+      },
+      input.mentions
+    ).map(({ profile }) => profile.id);
+  }
+
   function handleMessagePosted(
     message: ChannelMessage,
     mentions: ChannelMention[],
@@ -3380,14 +3632,16 @@ export function createChannelAgentBinder(
     // Without this a bound agent posting via `relay-ide v1 channels.post` would
     // both bypass the increment AND reset the brake, defeating the sole
     // token-spend guard between human turns (#1167 P1).
-    const routingMentions = currentProfileMentions(message, mentions);
-    const profiles = eligibleProfiles(message, routingMentions);
+    const targets = resolvedPostTargets(message, mentions);
     if (message.sender.kind === 'agent') {
       // Steering is deliberately dropped here, not honored-then-braked: the
       // sender kind is server-derived, so this is the ONE place that can promise
       // an agent post — including a CLI-gateway actor post — can never cancel
       // another agent's live turn. Agent traffic keeps its existing brake.
-      routeWithBrake(message, profiles);
+      routeWithBrake(
+        message,
+        targets.map(({ profile }) => profile)
+      );
       return;
     }
     // A message-shaped system row is not a normal production shape, but sender
@@ -3400,16 +3654,8 @@ export function createChannelAgentBinder(
     consecutiveAgentTurns.delete(
       conversationScopeKey(message.channelId, message.threadId)
     );
-    if (profiles.length === 0) {
-      // A durable/pinned mention may no longer resolve after a profile deletion.
-      // It is still explicit operator intent, so never fall through to a DM or
-      // orchestrator default and silently address somebody else.
-      if (routingMentions.length > 0) return;
-      routeImplicitHumanMessage(message, steering);
-      return;
-    }
-    for (const profile of profiles) {
-      void routeOne(message, profile, steering);
+    for (const { profile, requiredRole } of targets) {
+      void routeOne(message, profile, steering, requiredRole);
     }
   }
 
@@ -3490,30 +3736,6 @@ export function createChannelAgentBinder(
     }
     const profile = designatedOrchestratorProfile(channelId);
     return profile ? { profile, requiredRole: 'orchestrator' } : null;
-  }
-
-  /**
-   * An unmentioned human post uses the same `routeOne` queue/steer path as an
-   * explicit mention. Sender-kind and explicit-mention gates live at the caller,
-   * so agent/system output cannot self-trigger and named intent cannot fan out.
-   */
-  function routeImplicitHumanMessage(
-    message: ChannelMessage,
-    steering?: ChannelPostSteering
-  ): void {
-    const recipient = implicitHumanRecipient(message.channelId);
-    if (!recipient) {
-      // Legitimate in a multi-party channel with no designated orchestrator.
-      // Logged, never announced — a system row here would spam #general.
-      logger.debug(
-        `message posted, 0 profiles routed, channel=${message.channelId} message=${message.id}`
-      );
-      return;
-    }
-    logger.debug(
-      `implicit human route, channel=${message.channelId} provider=${recipient.profile.providerId} profile=${recipient.profile.id}`
-    );
-    void routeOne(message, recipient.profile, steering, recipient.requiredRole);
   }
 
   function consumeAncestorExplicitReturn(
@@ -3674,6 +3896,8 @@ export function createChannelAgentBinder(
     binding.patchUnlisten = null;
     binding.activeTurnId = null;
     binding.parentMessageIdByTurn.clear();
+    binding.requestMessageIdByTurn.clear();
+    binding.exactTurnTombstones.clear();
     binding.finalMessageByTurn.clear();
     binding.continuationByTurn.clear();
     binding.completionCallbackByTurn.clear();
@@ -4382,6 +4606,7 @@ export function createChannelAgentBinder(
     restartScope,
     isControlMessage,
     recoverCompletionCallbacks,
+    resolvePostTargetIds,
     setStatusBroadcaster(broadcaster) {
       statusBroadcaster = broadcaster;
     },
@@ -4394,6 +4619,8 @@ export function createChannelAgentBinder(
         binding.unbind?.();
         binding.patchUnlisten?.();
         binding.parentMessageIdByTurn.clear();
+        binding.requestMessageIdByTurn.clear();
+        binding.exactTurnTombstones.clear();
         binding.finalMessageByTurn.clear();
         binding.continuationByTurn.clear();
         binding.completionCallbackByTurn.clear();

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -27,6 +27,7 @@ import {
   type ChannelAgentAttribution,
   type ChannelImagePart,
   type ChannelMessage,
+  type ChannelAsyncRunReference,
   type ChannelSenderRef,
   type ChannelTruncationReason,
 } from '../shared/channel-chat-protocol.js';
@@ -296,6 +297,10 @@ export interface BindSessionToChannelInput {
   initialAgentAttribution?: ChannelAgentAttribution;
   /** Resolve the immediate parent for a routed turn, if it began in a thread. */
   parentMessageIdForTurn?: (turnId: string) => string | undefined;
+  /** Stable Relay correlation for principal prose emitted by this routed turn. */
+  asyncRunReferenceForTurn?: (
+    turnId: string
+  ) => ChannelAsyncRunReference | undefined;
   /**
    * Invoked in `finalize()` after `completeStreamBroadcast` for `status ===
    * 'complete'` rows ONLY (#1167 §8). Bridge-authored replies bypass
@@ -585,12 +590,14 @@ export function bindSessionToChannel(
     }
     const parentMessageId = input.parentMessageIdForTurn?.(turnId);
     const agentAttribution = attributionForTurn(turnId);
+    const asyncRun = input.asyncRunReferenceForTurn?.(turnId);
     const message = store.beginStream({
       channelId,
       sender,
       source: { runtimeId, turnId, itemId: canonicalItemId },
       ...(initialText ? { text: initialText } : {}),
       ...(agentAttribution ? { agentAttribution } : {}),
+      ...(asyncRun ? { meta: { asyncRun } } : {}),
       ...(parentMessageId ? { parentMessageId } : {}),
     });
     if (message.status !== 'streaming') {
@@ -647,11 +654,13 @@ export function bindSessionToChannel(
     const agentDetail = boundChannelAgentDetail(itemId, sourceCard);
     const parentMessageId = input.parentMessageIdForTurn?.(patch.turnId);
     const agentAttribution = attributionForTurn(patch.turnId);
+    const asyncRun = input.asyncRunReferenceForTurn?.(patch.turnId);
     const message = store.beginStream({
       channelId,
       sender,
       source: { runtimeId: patch.sessionId, turnId: patch.turnId, itemId },
       agentDetail,
+      ...(asyncRun ? { meta: { asyncRun } } : {}),
       ...(agentAttribution ? { agentAttribution } : {}),
       ...(parentMessageId ? { parentMessageId } : {}),
     });
@@ -950,6 +959,7 @@ export function bindSessionToChannel(
     if (closed) return false;
     const itemId = canonicalAssistantItemId(patch.item);
     const agentAttribution = attributionForTurn(patch.turnId);
+    const asyncRun = input.asyncRunReferenceForTurn?.(patch.turnId);
     const started = store.beginStream({
       channelId,
       sender,
@@ -957,6 +967,7 @@ export function bindSessionToChannel(
       text,
       ...(parts.length > 0 ? { parts } : {}),
       ...(agentAttribution ? { agentAttribution } : {}),
+      ...(asyncRun ? { meta: { asyncRun } } : {}),
       ...(parentMessageId ? { parentMessageId } : {}),
     });
     if (started.status !== 'streaming') return true;

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -654,13 +654,11 @@ export function bindSessionToChannel(
     const agentDetail = boundChannelAgentDetail(itemId, sourceCard);
     const parentMessageId = input.parentMessageIdForTurn?.(patch.turnId);
     const agentAttribution = attributionForTurn(patch.turnId);
-    const asyncRun = input.asyncRunReferenceForTurn?.(patch.turnId);
     const message = store.beginStream({
       channelId,
       sender,
       source: { runtimeId: patch.sessionId, turnId: patch.turnId, itemId },
       agentDetail,
-      ...(asyncRun ? { meta: { asyncRun } } : {}),
       ...(agentAttribution ? { agentAttribution } : {}),
       ...(parentMessageId ? { parentMessageId } : {}),
     });
@@ -959,7 +957,6 @@ export function bindSessionToChannel(
     if (closed) return false;
     const itemId = canonicalAssistantItemId(patch.item);
     const agentAttribution = attributionForTurn(patch.turnId);
-    const asyncRun = input.asyncRunReferenceForTurn?.(patch.turnId);
     const started = store.beginStream({
       channelId,
       sender,
@@ -967,7 +964,6 @@ export function bindSessionToChannel(
       text,
       ...(parts.length > 0 ? { parts } : {}),
       ...(agentAttribution ? { agentAttribution } : {}),
-      ...(asyncRun ? { meta: { asyncRun } } : {}),
       ...(parentMessageId ? { parentMessageId } : {}),
     });
     if (started.status !== 'streaming') return true;

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -972,8 +972,10 @@ function postToChannel(
       input.mentions,
       input.steering ? { steering: input.steering } : undefined
     );
-    hub.broadcastRunLifecycle(result.run);
   }
+  // A legacy request row can be replayed before its correlated run is created.
+  // Message replay is therefore not evidence that clients already saw lifecycle.
+  if (!result.runReplayed) hub.broadcastRunLifecycle(result.run);
   return result;
 }
 

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -936,9 +936,14 @@ function postToChannel(
      * an interrupt.
      */
     steering?: ChannelPostSteering;
+    targetIds: readonly string[];
   }
-): ChannelMessage {
-  const message = store.appendComplete({
+): {
+  message: ChannelMessage;
+  run: import('../shared/channel-chat-protocol.js').ChannelAsyncRun;
+  replayed: boolean;
+} {
+  const result = store.appendCompleteWithAsyncRun({
     channelId: input.channelId,
     sender: input.sender,
     text: input.text,
@@ -954,18 +959,22 @@ function postToChannel(
     ...(input.sourceRuntimeId
       ? { source: { runtimeId: input.sourceRuntimeId } }
       : {}),
+    targetIds: input.targetIds,
   });
-  store.upsertMember({
-    channelId: input.channelId,
-    kind: input.sender.kind === 'agent' ? 'agent' : 'human',
-    id: input.sender.id,
-  });
-  hub.broadcastCreated(
-    message,
-    input.mentions,
-    input.steering ? { steering: input.steering } : undefined
-  );
-  return message;
+  if (!result.replayed) {
+    store.upsertMember({
+      channelId: input.channelId,
+      kind: input.sender.kind === 'agent' ? 'agent' : 'human',
+      id: input.sender.id,
+    });
+    hub.broadcastCreated(
+      result.message,
+      input.mentions,
+      input.steering ? { steering: input.steering } : undefined
+    );
+    hub.broadcastRunLifecycle(result.run);
+  }
+  return result;
 }
 
 export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
@@ -976,6 +985,7 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
 
   const listAuth = deps.requireReadActorAuth?.('channels.list') ?? auth;
   const getAuth = deps.requireReadActorAuth?.('channels.get') ?? auth;
+  const runGetAuth = deps.requireReadActorAuth?.('channels.run.get') ?? auth;
   const historyAuth = deps.requireReadActorAuth?.('channels.history') ?? auth;
   // Search is a filtered read of the same durable message log `channels.history`
   // already grants, so it rides that verb rather than minting a new gateway
@@ -1315,6 +1325,51 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     } catch (error) {
       mapStoreError(res, error);
     }
+  });
+
+  router.get('/channels/:id/runs/:runId', runGetAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const id = req.params['id'] ?? '';
+    if (denyOutOfScopeChannel(req, res, id)) return;
+    if (!requirePersistedChannel(req, res)) return;
+    const runId = req.params['runId'] ?? '';
+    if (!runId.startsWith('chrun:')) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'runId must be a Relay run id',
+        false,
+        {
+          field: 'runId',
+        }
+      );
+      return;
+    }
+    const run = store.getAsyncRun(
+      runId as import('../shared/channel-chat-protocol.js').ChannelAsyncRunId
+    );
+    if (!run || run.channelId !== id) {
+      sendGatewayError(res, 'NOT_FOUND', 'run not found', false, {
+        channelId: id,
+        runId,
+      });
+      return;
+    }
+    const requestedThreadId = req.query['threadId'];
+    if (
+      requestedThreadId !== undefined &&
+      (typeof requestedThreadId !== 'string' ||
+        run.threadId !== requestedThreadId)
+    ) {
+      sendGatewayError(res, 'NOT_FOUND', 'run not found in thread', false, {
+        channelId: id,
+        runId,
+      });
+      return;
+    }
+    res.json({ run });
   });
 
   router.post('/channels/:id/attachments', auth, (req, res) => {
@@ -1727,19 +1782,6 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     // swallowing it silently would report an interrupt-and-send that did
     // neither. `steerExisting` applies the cancellation half only, and is a
     // no-op when the addressed binding has no live turn.
-    if (clientMessageId) {
-      const existing = store.findByClientMessage(
-        id,
-        sender.id,
-        clientMessageId
-      );
-      if (existing) {
-        if (steering) deps.binder?.steerExisting(existing, steering);
-        res.status(200).json({ message: existing });
-        return;
-      }
-    }
-
     const providerIds = [
       ...knownProviderIds,
       ...(topic.routingDefaults.providerId
@@ -1747,9 +1789,23 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         : []),
     ];
     const mentions = parseMentions(text, providerIds);
+    // Binder admission is the single target resolver for both persistence and
+    // delivery. In particular, an unmentioned human post can durably target a
+    // DM default or designated orchestrator before its post+run transaction.
+    // No binder means no admitted target, so the run truthfully terminalizes
+    // `no-eligible-target` rather than fabricating a provider-derived id.
+    const targetIds =
+      typeof deps.binder?.resolvePostTargetIds === 'function'
+        ? deps.binder.resolvePostTargetIds({
+            channelId: id,
+            sender,
+            text,
+            mentions,
+          })
+        : [];
 
     try {
-      const message = postToChannel(store, deps.hub, {
+      const result = postToChannel(store, deps.hub, {
         channelId: id,
         sender,
         ...(sourceRuntimeId ? { sourceRuntimeId } : {}),
@@ -1758,10 +1814,17 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         ...(parentMessageId ? { parentMessageId } : {}),
         ...(clientMessageId ? { clientMessageId } : {}),
         mentions,
+        targetIds,
         ...(parts.length ? { parts } : {}),
         ...(steering ? { steering } : {}),
       });
-      res.status(201).json({ message });
+      if (result.replayed && steering) {
+        deps.binder?.steerExisting(result.message, steering);
+      }
+      res.status(result.replayed ? 200 : 201).json({
+        message: result.message,
+        run: result.run,
+      });
     } catch (error) {
       mapStoreError(res, error);
     }

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -2,6 +2,7 @@ import { createLogger } from './logger.js';
 import type { ChannelMessageStore } from './channel-message-store.js';
 import {
   type ChannelEventV1,
+  type ChannelAsyncRun,
   type ChannelInFlightRef,
   type ChannelMemberRef,
   type ChannelMention,
@@ -43,6 +44,9 @@ const CATCHUP_MAX_ROWS = 500;
  * client paginates the remainder via `channels.history`.
  */
 const DEFAULT_SNAPSHOT_MAX_BYTES = 4 * 1024 * 1024;
+/** Run projections are independently bounded; older runs remain individually queryable. */
+const SNAPSHOT_RUN_MAX = 100;
+const SNAPSHOT_RUN_MAX_BYTES = 256 * 1024;
 /**
  * Defense-in-depth bounds for events produced re-entrantly while a subscriber's
  * connect-time snapshot is being sent. In production the better-sqlite3 snapshot
@@ -164,6 +168,8 @@ export interface ChannelHub {
     sink: ChannelEventSink,
     input: { channelId: string; afterSeq: number | null }
   ): () => void;
+  /** Broadcast a durable run projection; it carries no message seq cursor. */
+  broadcastRunLifecycle(run: ChannelAsyncRun): void;
   broadcastCreated(
     message: ChannelMessage,
     mentions?: ChannelMention[],
@@ -466,12 +472,29 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       return message;
     });
 
+    const runs: ChannelAsyncRun[] = [];
+    let runBytes = 0;
+    // The store returns a stable oldest→newest projection. Pack from newest so
+    // one individually oversized old run cannot starve recent small status,
+    // then restore stable chronological order for reducer determinism.
+    const newestFirst = store
+      ? store.listAsyncRuns(channelId, SNAPSHOT_RUN_MAX).reverse()
+      : [];
+    for (const run of newestFirst) {
+      const bytes = Buffer.byteLength(JSON.stringify(run), 'utf8');
+      if (runBytes + bytes > SNAPSHOT_RUN_MAX_BYTES) continue;
+      runBytes += bytes;
+      runs.push(run);
+    }
+    runs.reverse();
+
     return {
       type: 'channel-snapshot-v1',
       channelId,
       timestamp: nowIso(),
       mode,
       messages,
+      runs,
       members,
       latestSeq: snapshotLatestSeq,
       inFlight,
@@ -665,6 +688,15 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
           logger.warn('onMessagePosted handler error:', err);
         }
       }
+    },
+
+    broadcastRunLifecycle(run) {
+      broadcast(run.channelId, {
+        type: 'channel-run-lifecycle-v1',
+        channelId: run.channelId,
+        timestamp: nowIso(),
+        run,
+      });
     },
 
     beginStreamBroadcast(message) {

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -28,6 +28,12 @@ import {
   parseMentions,
   type ChannelAgentDetail,
   type ChannelAgentAttribution,
+  type ChannelAsyncRun,
+  type ChannelAsyncRunId,
+  type ChannelAsyncRunState,
+  type ChannelAsyncRunTarget,
+  type ChannelAsyncRunTargetState,
+  type ChannelAsyncRunApprovalState,
   type ChannelMessageSearchHit,
   type ChannelSearchUnavailableReason,
   type ChannelBodyFormat,
@@ -61,7 +67,8 @@ import {
 //    catch-up window, and thread parent stays valid. Nothing in this file may
 //    ever issue `DELETE FROM channel_messages` for an operator action.
 
-const SCHEMA_VERSION = 14;
+const SCHEMA_VERSION = 15;
+const ASYNC_RUN_SETTLED_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
@@ -836,6 +843,33 @@ WHERE continuation_parent_callback_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_chcc_settled_retention
 ON channel_completion_callbacks(state, consumed_at, undeliverable_at)
 WHERE state IN ('consumed','undeliverable');
+
+CREATE TABLE IF NOT EXISTS channel_async_runs (
+  id                 TEXT PRIMARY KEY,
+  channel_id         TEXT NOT NULL,
+  thread_id          TEXT,
+  request_message_id TEXT NOT NULL UNIQUE,
+  requester_id       TEXT NOT NULL,
+  state              TEXT NOT NULL,
+  reason             TEXT,
+  created_at         TEXT NOT NULL,
+  updated_at         TEXT NOT NULL,
+  completed_at       TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_char_channel_thread_created
+  ON channel_async_runs(channel_id, thread_id, created_at);
+CREATE TABLE IF NOT EXISTS channel_async_run_targets (
+  run_id             TEXT NOT NULL,
+  target_id          TEXT NOT NULL,
+  state              TEXT NOT NULL,
+  reason             TEXT,
+  approval_state     TEXT,
+  updated_at         TEXT NOT NULL,
+  completed_at       TEXT,
+  PRIMARY KEY(run_id, target_id)
+);
+CREATE INDEX IF NOT EXISTS idx_chart_run_state
+  ON channel_async_run_targets(run_id, state);
 `;
 
 interface ChannelMessageRow {
@@ -952,6 +986,29 @@ interface CompletionCallbackRow {
   updated_at: string;
 }
 
+interface AsyncRunRow {
+  id: string;
+  channel_id: string;
+  thread_id: string | null;
+  request_message_id: string;
+  requester_id: string;
+  state: ChannelAsyncRunState;
+  reason: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+interface AsyncRunTargetRow {
+  run_id: string;
+  target_id: string;
+  state: ChannelAsyncRunTargetState;
+  reason: string | null;
+  approval_state: ChannelAsyncRunApprovalState | null;
+  updated_at: string;
+  completed_at: string | null;
+}
+
 export interface ChannelMessageMeta {
   mentions?: ChannelMention[];
   parts?: ChannelMessagePart[];
@@ -960,6 +1017,7 @@ export interface ChannelMessageMeta {
   truncated?: boolean;
   agentDetail?: ChannelAgentDetail;
   agentAttribution?: ChannelAgentAttribution;
+  asyncRun?: { runId: ChannelAsyncRunId; targetId: string };
   /** Internal lifecycle marker; stripped before rows cross the wire. */
   agentDetailTerminalAuthority?: 'provisional' | 'explicit';
   [key: string]: unknown;
@@ -980,6 +1038,11 @@ export interface AppendCompleteInput {
   source?: Pick<ChannelMessageSource, 'runtimeId'>;
 }
 
+export interface CreateChannelAsyncRunPostInput extends AppendCompleteInput {
+  /** Resolved Relay profile actors; provider ids are not persisted publicly. */
+  targetIds: readonly string[];
+}
+
 export interface BeginStreamInput {
   channelId: string;
   sender: ChannelSenderRef;
@@ -991,6 +1054,8 @@ export interface BeginStreamInput {
   agentDetail?: ChannelAgentDetail;
   /** Immutable provider config snapshot for an agent-authored row. */
   agentAttribution?: ChannelAgentAttribution;
+  /** Durable, public-safe correlation carried from the bound Relay turn. */
+  meta?: ChannelMessageMeta;
 }
 
 export interface FinalizeStreamInput {
@@ -1346,6 +1411,28 @@ export function createChannelOrchestratorConflictError(input: {
 export interface ChannelMessageStore {
   close(): void;
   appendComplete(input: AppendCompleteInput): ChannelMessage;
+  /** Atomically creates (or replays) one requester post and its public run. */
+  appendCompleteWithAsyncRun(input: CreateChannelAsyncRunPostInput): {
+    message: ChannelMessage;
+    run: ChannelAsyncRun;
+    replayed: boolean;
+  };
+  getAsyncRun(id: ChannelAsyncRunId): ChannelAsyncRun | null;
+  getAsyncRunForRequestMessage(
+    messageId: ChannelMessageId
+  ): ChannelAsyncRun | null;
+  /** Current durable run projections for reconnect snapshots; no provider data. */
+  listAsyncRuns(channelId: string, limit?: number): ChannelAsyncRun[];
+  /** Startup-only safe disposition; nonterminal runs are never redelivered. */
+  recoverAsyncRuns(): ChannelAsyncRun[];
+  /** CAS one public target outcome and deterministically derives aggregate state. */
+  transitionAsyncRunTarget(input: {
+    runId: ChannelAsyncRunId;
+    targetId: string;
+    state: ChannelAsyncRunTargetState;
+    reason?: string;
+    approvalState?: ChannelAsyncRunApprovalState;
+  }): ChannelAsyncRun | null;
   beginStream(input: BeginStreamInput): ChannelMessage;
   updateStreamText(id: string, text: string): ChannelMessage | null;
   updateAgentDetail(
@@ -1800,6 +1887,17 @@ function rowToMessage(row: ChannelMessageRow): ChannelMessage {
   }
   if (isAgentAttribution(meta?.agentAttribution)) {
     message.agentAttribution = meta.agentAttribution;
+  }
+  if (
+    meta?.asyncRun &&
+    typeof meta.asyncRun === 'object' &&
+    typeof meta.asyncRun.runId === 'string' &&
+    typeof meta.asyncRun.targetId === 'string'
+  ) {
+    message.asyncRun = {
+      runId: meta.asyncRun.runId as ChannelAsyncRunId,
+      targetId: meta.asyncRun.targetId,
+    };
   }
   // Surface app-level meta (e.g. #1167 approval payloads) while keeping the
   // internal routing keys off the wire — providerId rides `sender.providerId`,
@@ -3021,6 +3119,31 @@ function runSchemaMigrations(db: Database.Database): void {
       db.prepare('UPDATE schema_version SET version = 14').run();
     })();
   }
+  if (current < 15) {
+    db.transaction(() => {
+      // Run records are a separate durable projection: message sequence remains
+      // the subscription cursor, while lifecycle may change in place without
+      // inventing provider ids or a second transcript row.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS channel_async_runs (
+          id TEXT PRIMARY KEY, channel_id TEXT NOT NULL, thread_id TEXT,
+          request_message_id TEXT NOT NULL UNIQUE, requester_id TEXT NOT NULL,
+          state TEXT NOT NULL, reason TEXT, created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL, completed_at TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_char_channel_thread_created
+          ON channel_async_runs(channel_id, thread_id, created_at);
+        CREATE TABLE IF NOT EXISTS channel_async_run_targets (
+          run_id TEXT NOT NULL, target_id TEXT NOT NULL, state TEXT NOT NULL,
+          reason TEXT, approval_state TEXT, updated_at TEXT NOT NULL,
+          completed_at TEXT, PRIMARY KEY(run_id, target_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_chart_run_state
+          ON channel_async_run_targets(run_id, state);
+      `);
+      db.prepare('UPDATE schema_version SET version = 15').run();
+    })();
+  }
 }
 
 export function initChannelMessageStore(
@@ -3573,6 +3696,243 @@ export function createChannelMessageStore(
     if (threadId !== null) touchThreadRecord(input.channelId, threadId, now);
     return rowToMessage(row);
   }
+
+  const selectAsyncRun = db.prepare(
+    'SELECT * FROM channel_async_runs WHERE id = ?'
+  );
+  const selectAsyncRunForRequest = db.prepare(
+    'SELECT * FROM channel_async_runs WHERE request_message_id = ?'
+  );
+  const selectAsyncRunTargets = db.prepare(
+    'SELECT * FROM channel_async_run_targets WHERE run_id = ? ORDER BY target_id ASC'
+  );
+
+  function asyncRunFromRow(row: AsyncRunRow): ChannelAsyncRun {
+    const targets = selectAsyncRunTargets.all(row.id) as AsyncRunTargetRow[];
+    return {
+      id: row.id as ChannelAsyncRunId,
+      channelId: row.channel_id,
+      threadId: row.thread_id as ChannelMessageId | null,
+      requestMessageId: row.request_message_id as ChannelMessageId,
+      requesterId: row.requester_id,
+      state: row.state,
+      ...(row.reason ? { reason: row.reason } : {}),
+      targets: targets.map(
+        (target): ChannelAsyncRunTarget => ({
+          targetId: target.target_id,
+          state: target.state,
+          ...(target.reason ? { reason: target.reason } : {}),
+          ...(target.approval_state
+            ? { approvalState: target.approval_state }
+            : {}),
+          updatedAt: target.updated_at,
+          ...(target.completed_at ? { completedAt: target.completed_at } : {}),
+        })
+      ),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      ...(row.completed_at ? { completedAt: row.completed_at } : {}),
+    };
+  }
+
+  function aggregateAsyncRunState(
+    targets: readonly AsyncRunTargetRow[]
+  ): ChannelAsyncRunState {
+    if (targets.length === 0) return 'rejected';
+    if (
+      targets.some(
+        (target) =>
+          !['completed', 'failed', 'cancelled', 'rejected'].includes(
+            target.state
+          )
+      )
+    ) {
+      if (targets.some((target) => target.state === 'auth-required'))
+        return 'auth-required';
+      if (targets.some((target) => target.state === 'input-required'))
+        return 'input-required';
+      return targets.some((target) => target.state === 'working')
+        ? 'working'
+        : 'submitted';
+    }
+    if (targets.every((target) => target.state === 'completed'))
+      return 'completed';
+    if (targets.every((target) => target.state === 'rejected'))
+      return 'rejected';
+    if (
+      targets.some(
+        (target) => target.state === 'failed' || target.state === 'rejected'
+      )
+    )
+      return 'failed';
+    return 'cancelled';
+  }
+
+  const appendCompleteWithAsyncRunImpl = db.transaction(
+    (input: CreateChannelAsyncRunPostInput) => {
+      let existing: ChannelMessage | null = null;
+      if (input.clientMessageId) {
+        const row = selectByClientId.get({
+          channelId: input.channelId,
+          senderId: input.sender.id,
+          clientMessageId: input.clientMessageId,
+        }) as ChannelMessageRow | undefined;
+        if (row) existing = rowToMessage(row);
+      }
+      const message = existing ?? appendCompleteImpl(input);
+      const known = selectAsyncRunForRequest.get(message.id) as
+        | AsyncRunRow
+        | undefined;
+      if (known) {
+        return { message, run: asyncRunFromRow(known), replayed: true };
+      }
+      const now = nowIso();
+      const targetIds = [...new Set(input.targetIds)].sort();
+      const state: ChannelAsyncRunState =
+        targetIds.length === 0 ? 'rejected' : 'submitted';
+      const runId = `chrun:${crypto.randomUUID()}` as ChannelAsyncRunId;
+      db.prepare(
+        `INSERT INTO channel_async_runs
+           (id, channel_id, thread_id, request_message_id, requester_id, state, reason, created_at, updated_at, completed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        runId,
+        message.channelId,
+        message.threadId,
+        message.id,
+        message.sender.id,
+        state,
+        targetIds.length === 0 ? 'no-eligible-target' : null,
+        now,
+        now,
+        targetIds.length === 0 ? now : null
+      );
+      const insertTarget = db.prepare(
+        `INSERT INTO channel_async_run_targets
+           (run_id, target_id, state, reason, approval_state, updated_at, completed_at)
+         VALUES (?, ?, ?, NULL, NULL, ?, NULL)`
+      );
+      for (const targetId of targetIds)
+        insertTarget.run(runId, targetId, 'queued', now);
+      const row = selectAsyncRun.get(runId) as AsyncRunRow;
+      return {
+        message,
+        run: asyncRunFromRow(row),
+        replayed: existing !== null,
+      };
+    }
+  );
+
+  const transitionAsyncRunTargetImpl = db.transaction(
+    (input: {
+      runId: ChannelAsyncRunId;
+      targetId: string;
+      state: ChannelAsyncRunTargetState;
+      reason?: string;
+      approvalState?: ChannelAsyncRunApprovalState;
+    }): ChannelAsyncRun | null => {
+      const run = selectAsyncRun.get(input.runId) as AsyncRunRow | undefined;
+      if (!run) return null;
+      const now = nowIso();
+      const terminal = [
+        'completed',
+        'failed',
+        'cancelled',
+        'rejected',
+      ].includes(input.state);
+      const changed = db
+        .prepare(
+          `UPDATE channel_async_run_targets
+            SET state = ?, reason = ?, approval_state = ?, updated_at = ?,
+                completed_at = CASE WHEN ? THEN ? ELSE NULL END
+          WHERE run_id = ? AND target_id = ?
+            AND state NOT IN ('completed','failed','cancelled','rejected')`
+        )
+        .run(
+          input.state,
+          input.reason ?? null,
+          input.approvalState ?? null,
+          now,
+          terminal ? 1 : 0,
+          terminal ? now : null,
+          input.runId,
+          input.targetId
+        );
+      if (changed.changes === 0) return asyncRunFromRow(run);
+      const targets = selectAsyncRunTargets.all(
+        input.runId
+      ) as AsyncRunTargetRow[];
+      const state = aggregateAsyncRunState(targets);
+      const runTerminal = [
+        'completed',
+        'failed',
+        'cancelled',
+        'rejected',
+      ].includes(state);
+      db.prepare(
+        `UPDATE channel_async_runs SET state = ?, updated_at = ?,
+          completed_at = CASE WHEN ? THEN ? ELSE NULL END WHERE id = ?`
+      ).run(state, now, runTerminal ? 1 : 0, runTerminal ? now : null, run.id);
+      return asyncRunFromRow(selectAsyncRun.get(run.id) as AsyncRunRow);
+    }
+  );
+
+  const recoverAsyncRunsImpl = db.transaction((): ChannelAsyncRun[] => {
+    const rows = db
+      .prepare(
+        `SELECT * FROM channel_async_runs
+          WHERE state NOT IN ('completed','failed','cancelled','rejected')`
+      )
+      .all() as AsyncRunRow[];
+    if (rows.length === 0) return [];
+    const now = nowIso();
+    const cancelTarget = db.prepare(
+      `UPDATE channel_async_run_targets
+          SET state = 'cancelled', reason = 'server-restarted', updated_at = ?,
+              completed_at = ?
+        WHERE run_id = ?
+          AND state NOT IN ('completed','failed','cancelled','rejected')`
+    );
+    const updateRun = db.prepare(
+      `UPDATE channel_async_runs
+          SET state = ?, reason = 'server-restarted', updated_at = ?, completed_at = ?
+        WHERE id = ?`
+    );
+    for (const row of rows) {
+      cancelTarget.run(now, now, row.id);
+      const targets = selectAsyncRunTargets.all(row.id) as AsyncRunTargetRow[];
+      const state = aggregateAsyncRunState(targets);
+      updateRun.run(state, now, now, row.id);
+    }
+    return rows.map((row) =>
+      asyncRunFromRow(selectAsyncRun.get(row.id) as AsyncRunRow)
+    );
+  });
+
+  const pruneSettledAsyncRunsImpl = db.transaction(
+    (olderThanMs: number): number => {
+      const cutoff = new Date(Date.now() - olderThanMs).toISOString();
+      const ids = db
+        .prepare(
+          `SELECT id FROM channel_async_runs
+          WHERE state IN ('completed','failed','cancelled','rejected')
+            AND completed_at IS NOT NULL AND completed_at < ?`
+        )
+        .all(cutoff) as Array<{ id: string }>;
+      if (ids.length === 0) return 0;
+      const deleteTargets = db.prepare(
+        'DELETE FROM channel_async_run_targets WHERE run_id = ?'
+      );
+      const deleteRun = db.prepare(
+        'DELETE FROM channel_async_runs WHERE id = ?'
+      );
+      for (const { id } of ids) {
+        deleteTargets.run(id);
+        deleteRun.run(id);
+      }
+      return ids.length;
+    }
+  );
 
   function getBindingImpl(
     channelId: string,
@@ -4233,6 +4593,12 @@ export function createChannelMessageStore(
     }
   );
 
+  // Relay does not retain a process-owned delivery queue across a restart.
+  // Reconcile before exposing this store so snapshots can never advertise work
+  // that a fresh binder will not redeliver.
+  recoverAsyncRunsImpl();
+  pruneSettledAsyncRunsImpl(ASYNC_RUN_SETTLED_RETENTION_MS);
+
   return {
     close() {
       db.close();
@@ -4240,6 +4606,45 @@ export function createChannelMessageStore(
 
     appendComplete(input) {
       return appendCompleteImpl(input);
+    },
+
+    appendCompleteWithAsyncRun(input) {
+      return appendCompleteWithAsyncRunImpl(input);
+    },
+
+    getAsyncRun(id) {
+      const row = selectAsyncRun.get(id) as AsyncRunRow | undefined;
+      return row ? asyncRunFromRow(row) : null;
+    },
+
+    getAsyncRunForRequestMessage(messageId) {
+      const row = selectAsyncRunForRequest.get(messageId) as
+        | AsyncRunRow
+        | undefined;
+      return row ? asyncRunFromRow(row) : null;
+    },
+
+    listAsyncRuns(channelId, limit = 100) {
+      return (
+        db
+          .prepare(
+            `SELECT * FROM channel_async_runs WHERE channel_id = ?
+             ORDER BY created_at DESC, id DESC LIMIT ?`
+          )
+          .all(channelId, Math.max(1, Math.floor(limit))) as AsyncRunRow[]
+      )
+        .map(asyncRunFromRow)
+        .reverse();
+    },
+
+    recoverAsyncRuns() {
+      const recovered = recoverAsyncRunsImpl();
+      pruneSettledAsyncRunsImpl(ASYNC_RUN_SETTLED_RETENTION_MS);
+      return recovered;
+    },
+
+    transitionAsyncRunTarget(input) {
+      return transitionAsyncRunTargetImpl(input);
     },
 
     beginStream(input) {
@@ -4256,6 +4661,9 @@ export function createChannelMessageStore(
       assertMessagePayloadSize(initialText, input.agentDetail);
       assertAgentAttribution(input.agentAttribution);
       assertMessageParts(input.parts);
+      assertMessageParts(input.meta?.parts);
+      assertAgentDetail(input.meta?.agentDetail);
+      assertAgentAttribution(input.meta?.agentAttribution);
       const threadId = resolveThread(input.channelId, input.parentMessageId);
       const now = nowIso();
       const id = createMessageId();
@@ -4274,9 +4682,10 @@ export function createChannelMessageStore(
         metaJson: buildMeta({
           ...(input.mentions ? { mentions: input.mentions } : {}),
           ...(input.parts ? { parts: input.parts } : {}),
-          ...(input.agentDetail || input.agentAttribution
+          ...(input.meta || input.agentDetail || input.agentAttribution
             ? {
                 extra: {
+                  ...(input.meta ?? {}),
                   ...(input.agentDetail
                     ? { agentDetail: input.agentDetail }
                     : {}),
@@ -5244,6 +5653,7 @@ export function createChannelMessageStore(
         'channel_members',
         'channel_agent_bindings',
         'channel_completion_callbacks',
+        'channel_async_runs',
         // Read marks are swept for the same reason bindings are: a channel the
         // topic store no longer knows about is gone, and its marker would
         // otherwise be resurrected verbatim by a channel later created under the
@@ -5278,6 +5688,13 @@ export function createChannelMessageStore(
           db.prepare(
             'DELETE FROM channel_completion_callbacks WHERE channel_id = ?'
           ).run(id);
+          db.prepare(
+            `DELETE FROM channel_async_run_targets
+              WHERE run_id IN (SELECT id FROM channel_async_runs WHERE channel_id = ?)`
+          ).run(id);
+          db.prepare('DELETE FROM channel_async_runs WHERE channel_id = ?').run(
+            id
+          );
           db.prepare(
             `DELETE FROM ${CHANNEL_READ_STATE_TABLE} WHERE channel_id = ?`
           ).run(id);

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -67,7 +67,7 @@ import {
 //    catch-up window, and thread parent stays valid. Nothing in this file may
 //    ever issue `DELETE FROM channel_messages` for an operator action.
 
-const SCHEMA_VERSION = 15;
+const SCHEMA_VERSION = 16;
 const ASYNC_RUN_SETTLED_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
@@ -850,18 +850,18 @@ CREATE TABLE IF NOT EXISTS channel_async_runs (
   thread_id          TEXT,
   request_message_id TEXT NOT NULL UNIQUE,
   requester_id       TEXT NOT NULL,
-  state              TEXT NOT NULL,
+  state              TEXT NOT NULL CHECK (state IN ('submitted','working','input-required','auth-required','completed','failed','cancelled','rejected')),
   reason             TEXT,
   created_at         TEXT NOT NULL,
   updated_at         TEXT NOT NULL,
   completed_at       TEXT
 );
-CREATE INDEX IF NOT EXISTS idx_char_channel_thread_created
-  ON channel_async_runs(channel_id, thread_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_char_channel_created
+  ON channel_async_runs(channel_id, created_at, id);
 CREATE TABLE IF NOT EXISTS channel_async_run_targets (
   run_id             TEXT NOT NULL,
   target_id          TEXT NOT NULL,
-  state              TEXT NOT NULL,
+  state              TEXT NOT NULL CHECK (state IN ('queued','working','input-required','auth-required','completed','failed','cancelled','rejected')),
   reason             TEXT,
   approval_state     TEXT,
   updated_at         TEXT NOT NULL,
@@ -1416,6 +1416,8 @@ export interface ChannelMessageStore {
     message: ChannelMessage;
     run: ChannelAsyncRun;
     replayed: boolean;
+    /** True only when the durable run already existed before this call. */
+    runReplayed: boolean;
   };
   getAsyncRun(id: ChannelAsyncRunId): ChannelAsyncRun | null;
   getAsyncRunForRequestMessage(
@@ -1910,6 +1912,7 @@ function rowToMessage(row: ChannelMessageRow): ChannelMessage {
       agentDetail: _agentDetail,
       agentAttribution: _agentAttribution,
       agentDetailTerminalAuthority: _agentDetailTerminalAuthority,
+      asyncRun: _asyncRun,
       truncated: _t,
       ...rest
     } = meta;
@@ -3144,12 +3147,51 @@ function runSchemaMigrations(db: Database.Database): void {
       db.prepare('UPDATE schema_version SET version = 15').run();
     })();
   }
+  if (current < 16) {
+    db.transaction(() => {
+      // SQLite CHECK constraints and index key order require a rebuild. Keep
+      // the v15 rows verbatim while making illegal target states impossible.
+      db.exec(`
+        DROP INDEX IF EXISTS idx_char_channel_thread_created;
+        CREATE TABLE channel_async_runs_v16 (
+          id TEXT PRIMARY KEY, channel_id TEXT NOT NULL, thread_id TEXT,
+          request_message_id TEXT NOT NULL UNIQUE, requester_id TEXT NOT NULL,
+          state TEXT NOT NULL CHECK (state IN ('submitted','working','input-required','auth-required','completed','failed','cancelled','rejected')),
+          reason TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+          completed_at TEXT
+        );
+        INSERT INTO channel_async_runs_v16 SELECT * FROM channel_async_runs;
+        DROP TABLE channel_async_runs;
+        ALTER TABLE channel_async_runs_v16 RENAME TO channel_async_runs;
+        CREATE INDEX idx_char_channel_created
+          ON channel_async_runs(channel_id, created_at, id);
+        CREATE TABLE channel_async_run_targets_v16 (
+          run_id TEXT NOT NULL, target_id TEXT NOT NULL,
+          state TEXT NOT NULL CHECK (state IN ('queued','working','input-required','auth-required','completed','failed','cancelled','rejected')),
+          reason TEXT, approval_state TEXT, updated_at TEXT NOT NULL,
+          completed_at TEXT, PRIMARY KEY(run_id, target_id)
+        );
+        INSERT INTO channel_async_run_targets_v16 SELECT * FROM channel_async_run_targets;
+        DROP TABLE channel_async_run_targets;
+        ALTER TABLE channel_async_run_targets_v16 RENAME TO channel_async_run_targets;
+        CREATE INDEX idx_chart_run_state
+          ON channel_async_run_targets(run_id, state);
+      `);
+      db.prepare('UPDATE schema_version SET version = 16').run();
+    })();
+  }
 }
 
 export function initChannelMessageStore(
   configDir: string
 ): ChannelMessageStore {
-  return createChannelMessageStore(path.join(configDir, 'channel-chat.db'));
+  const store = createChannelMessageStore(
+    path.join(configDir, 'channel-chat.db')
+  );
+  // Only the hub owner observes a restart. Additional handles must not cancel
+  // work which is still live in the owner process.
+  store.recoverAsyncRuns();
+  return store;
 }
 
 export interface ChannelMessageStoreOptions {
@@ -3707,8 +3749,10 @@ export function createChannelMessageStore(
     'SELECT * FROM channel_async_run_targets WHERE run_id = ? ORDER BY target_id ASC'
   );
 
-  function asyncRunFromRow(row: AsyncRunRow): ChannelAsyncRun {
-    const targets = selectAsyncRunTargets.all(row.id) as AsyncRunTargetRow[];
+  function asyncRunFromRow(
+    row: AsyncRunRow,
+    targets = selectAsyncRunTargets.all(row.id) as AsyncRunTargetRow[]
+  ): ChannelAsyncRun {
     return {
       id: row.id as ChannelAsyncRunId,
       channelId: row.channel_id,
@@ -3784,7 +3828,12 @@ export function createChannelMessageStore(
         | AsyncRunRow
         | undefined;
       if (known) {
-        return { message, run: asyncRunFromRow(known), replayed: true };
+        return {
+          message,
+          run: asyncRunFromRow(known),
+          replayed: existing !== null,
+          runReplayed: true,
+        };
       }
       const now = nowIso();
       const targetIds = [...new Set(input.targetIds)].sort();
@@ -3819,6 +3868,7 @@ export function createChannelMessageStore(
         message,
         run: asyncRunFromRow(row),
         replayed: existing !== null,
+        runReplayed: false,
       };
     }
   );
@@ -4593,12 +4643,6 @@ export function createChannelMessageStore(
     }
   );
 
-  // Relay does not retain a process-owned delivery queue across a restart.
-  // Reconcile before exposing this store so snapshots can never advertise work
-  // that a fresh binder will not redeliver.
-  recoverAsyncRunsImpl();
-  pruneSettledAsyncRunsImpl(ASYNC_RUN_SETTLED_RETENTION_MS);
-
   return {
     close() {
       db.close();
@@ -4625,15 +4669,28 @@ export function createChannelMessageStore(
     },
 
     listAsyncRuns(channelId, limit = 100) {
-      return (
-        db
-          .prepare(
-            `SELECT * FROM channel_async_runs WHERE channel_id = ?
-             ORDER BY created_at DESC, id DESC LIMIT ?`
-          )
-          .all(channelId, Math.max(1, Math.floor(limit))) as AsyncRunRow[]
-      )
-        .map(asyncRunFromRow)
+      const rows = db
+        .prepare(
+          `SELECT * FROM channel_async_runs WHERE channel_id = ?
+           ORDER BY created_at DESC, id DESC LIMIT ?`
+        )
+        .all(channelId, Math.max(1, Math.floor(limit))) as AsyncRunRow[];
+      if (rows.length === 0) return [];
+      const targetRows = db
+        .prepare(
+          `SELECT * FROM channel_async_run_targets
+           WHERE run_id IN (${rows.map(() => '?').join(',')})
+           ORDER BY run_id ASC, target_id ASC`
+        )
+        .all(...rows.map((row) => row.id)) as AsyncRunTargetRow[];
+      const byRun = new Map<string, AsyncRunTargetRow[]>();
+      for (const target of targetRows) {
+        const targets = byRun.get(target.run_id) ?? [];
+        targets.push(target);
+        byRun.set(target.run_id, targets);
+      }
+      return rows
+        .map((row) => asyncRunFromRow(row, byRun.get(row.id) ?? []))
         .reverse();
     },
 

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -71,6 +71,7 @@ export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
   'workspace-topics.get',
   'channels.list',
   'channels.get',
+  'channels.run.get',
   'channels.history',
   'channels.subscribe',
   'channels.threads.history',
@@ -351,6 +352,7 @@ export function cliGatewayActorCommandCapabilities(
   if (
     command === 'channels.list' ||
     command === 'channels.get' ||
+    command === 'channels.run.get' ||
     command === 'channels.history' ||
     command === 'channels.subscribe' ||
     command === 'channels.threads.history' ||

--- a/server/index.ts
+++ b/server/index.ts
@@ -2642,6 +2642,7 @@ async function main(): Promise<void> {
           ...(command === 'channels.list'
             ? { scopeForRequest: channelListScopeFromCredential }
             : command === 'channels.get' ||
+                command === 'channels.run.get' ||
                 command === 'channels.history' ||
                 command === 'channels.threads.history' ||
                 command === 'channels.roster'

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -30,6 +30,51 @@ export const CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS = 512;
 
 export type ChannelMessageId = `chm:${string}`;
 export type ChannelAttachmentId = `cha:${string}`;
+/** Opaque Relay-owned correlation id; never derived from a provider turn/item. */
+export type ChannelAsyncRunId = `chrun:${string}`;
+export type ChannelAsyncRunState =
+  | 'submitted'
+  | 'working'
+  | 'input-required'
+  | 'auth-required'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'rejected';
+/** Targets expose queued admission separately from aggregate run lifecycle. */
+export type ChannelAsyncRunTargetState = ChannelAsyncRunState | 'queued';
+export type ChannelAsyncRunApprovalState = 'requested' | 'resolved' | 'expired';
+
+/** Public, provider-neutral target projection. `targetId` is a Relay profile actor id. */
+export interface ChannelAsyncRunTarget {
+  targetId: string;
+  state: ChannelAsyncRunTargetState;
+  reason?: string;
+  approvalState?: ChannelAsyncRunApprovalState;
+  updatedAt: string;
+  completedAt?: string;
+}
+
+/** One immutable requester post and its durable per-target outcomes. */
+export interface ChannelAsyncRun {
+  id: ChannelAsyncRunId;
+  channelId: string;
+  threadId: ChannelMessageId | null;
+  requestMessageId: ChannelMessageId;
+  requesterId: string;
+  state: ChannelAsyncRunState;
+  reason?: string;
+  targets: ChannelAsyncRunTarget[];
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+}
+
+/** Principal prose references are stable public correlation, never provider diagnostics. */
+export interface ChannelAsyncRunReference {
+  runId: ChannelAsyncRunId;
+  targetId: string;
+}
 
 export type ChannelImageMime =
   | 'image/png'
@@ -175,6 +220,8 @@ export interface ChannelMessage {
   agentDetail?: ChannelAgentDetail;
   /** Model/effort snapshot for an agent-authored prose or detail row. */
   agentAttribution?: ChannelAgentAttribution;
+  /** Present on principal agent prose produced for a correlated async target. */
+  asyncRun?: ChannelAsyncRunReference;
   /**
    * Opaque row metadata surfaced to clients (#1167). System rows carry actionable
    * payloads here — e.g. an approval request `{ approvalRequestId, agentId,
@@ -735,6 +782,8 @@ export interface ChannelSnapshotEventV1 extends ChannelEventBaseV1 {
   mode: 'full' | 'catchup';
   /** seq-ascending; streaming rows carry accumulated in-memory text */
   messages: ChannelMessage[];
+  /** Durable current run projections; reconnect replaces this map when present. */
+  runs?: ChannelAsyncRun[];
   members: ChannelMemberRef[];
   latestSeq: number;
   inFlight: ChannelInFlightRef[];
@@ -806,6 +855,12 @@ export interface ChannelResyncRequiredEventV1 extends ChannelEventBaseV1 {
   latestSeq: number;
 }
 
+/** Authoritative durable run projection; clients replace it by `run.id`. */
+export interface ChannelRunLifecycleEventV1 extends ChannelEventBaseV1 {
+  type: 'channel-run-lifecycle-v1';
+  run: ChannelAsyncRun;
+}
+
 export type ChannelEventV1 =
   | ChannelSnapshotEventV1
   | ChannelMessageCreatedEventV1
@@ -814,7 +869,8 @@ export type ChannelEventV1 =
   | ChannelMessageCompletedEventV1
   | ChannelMessageEditedEventV1
   | ChannelMessageDeletedEventV1
-  | ChannelResyncRequiredEventV1;
+  | ChannelResyncRequiredEventV1
+  | ChannelRunLifecycleEventV1;
 
 // ── runtime validators ──────────────────────────────────────────────────────
 
@@ -986,6 +1042,15 @@ export function isChannelMessage(value: unknown): value is ChannelMessage {
   ) {
     return false;
   }
+  if (
+    value.asyncRun !== undefined &&
+    (!isRecord(value.asyncRun) ||
+      typeof value.asyncRun.runId !== 'string' ||
+      !value.asyncRun.runId.startsWith('chrun:') ||
+      typeof value.asyncRun.targetId !== 'string')
+  ) {
+    return false;
+  }
   if (value.threadId !== null && typeof value.threadId !== 'string')
     return false;
   if (
@@ -1024,6 +1089,41 @@ function isInFlightArray(value: unknown): value is ChannelInFlightRef[] {
   );
 }
 
+export function isChannelAsyncRun(value: unknown): value is ChannelAsyncRun {
+  const runStates = new Set<string>([
+    'submitted',
+    'working',
+    'input-required',
+    'auth-required',
+    'completed',
+    'failed',
+    'cancelled',
+    'rejected',
+  ]);
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    value.id.startsWith('chrun:') &&
+    typeof value.channelId === 'string' &&
+    (value.threadId === null || typeof value.threadId === 'string') &&
+    typeof value.requestMessageId === 'string' &&
+    typeof value.requesterId === 'string' &&
+    typeof value.state === 'string' &&
+    runStates.has(value.state) &&
+    Array.isArray(value.targets) &&
+    value.targets.every(
+      (target) =>
+        isRecord(target) &&
+        typeof target.targetId === 'string' &&
+        typeof target.state === 'string' &&
+        (target.state === 'queued' || runStates.has(target.state)) &&
+        typeof target.updatedAt === 'string'
+    ) &&
+    typeof value.createdAt === 'string' &&
+    typeof value.updatedAt === 'string'
+  );
+}
+
 export function isChannelEventV1(value: unknown): value is ChannelEventV1 {
   if (!isRecord(value)) return false;
   if (typeof value.type !== 'string') return false;
@@ -1034,6 +1134,8 @@ export function isChannelEventV1(value: unknown): value is ChannelEventV1 {
       return (
         (value.mode === 'full' || value.mode === 'catchup') &&
         isMessageArray(value.messages) &&
+        (value.runs === undefined ||
+          (Array.isArray(value.runs) && value.runs.every(isChannelAsyncRun))) &&
         Array.isArray(value.members) &&
         value.members.every(isMemberRef) &&
         typeof value.latestSeq === 'number' &&
@@ -1073,6 +1175,8 @@ export function isChannelEventV1(value: unknown): value is ChannelEventV1 {
       );
     case 'channel-resync-required-v1':
       return typeof value.latestSeq === 'number';
+    case 'channel-run-lifecycle-v1':
+      return isChannelAsyncRun(value.run);
     default:
       return false;
   }
@@ -1085,6 +1189,8 @@ export interface ChannelReducerState {
   /** seq-ordered */
   messages: ChannelMessage[];
   byId: Record<string, ChannelMessage>;
+  /** Provider-neutral correlated async runs, keyed by opaque run id. */
+  runs: Record<string, ChannelAsyncRun>;
   lastSeq: number;
   /** last applied deltaIndex per streaming message */
   inFlightDelta: Record<string, number>;
@@ -1101,6 +1207,7 @@ export function initialChannelReducerState(
     channelId,
     messages: [],
     byId: {},
+    runs: {},
     lastSeq: 0,
     inFlightDelta: {},
     quarantined: {},
@@ -1154,6 +1261,9 @@ export function applyChannelEventV1(
           channelId: state.channelId,
           messages,
           byId: rebuildById(messages),
+          runs: Object.fromEntries(
+            (event.runs ?? []).map((run) => [run.id, run])
+          ),
           lastSeq: event.latestSeq,
           inFlightDelta: inFlightFromRefs(event.inFlight),
           quarantined: {},
@@ -1171,6 +1281,10 @@ export function applyChannelEventV1(
         ...state,
         messages,
         byId: rebuildById(messages),
+        runs: {
+          ...state.runs,
+          ...Object.fromEntries((event.runs ?? []).map((run) => [run.id, run])),
+        },
         lastSeq: Math.max(state.lastSeq, event.latestSeq),
         inFlightDelta: inFlightFromRefs(event.inFlight),
         quarantined: {},
@@ -1316,6 +1430,12 @@ export function applyChannelEventV1(
 
     case 'channel-resync-required-v1':
       return { ...state, needsCatchup: true };
+
+    case 'channel-run-lifecycle-v1':
+      // Run updates intentionally do not touch the message sequence cursor:
+      // snapshots carry the durable projection after reconnect, and a replayed
+      // lifecycle notification is idempotent by opaque run id.
+      return { ...state, runs: { ...state.runs, [event.run.id]: event.run } };
 
     default:
       return state;

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -42,7 +42,10 @@ export type ChannelAsyncRunState =
   | 'cancelled'
   | 'rejected';
 /** Targets expose queued admission separately from aggregate run lifecycle. */
-export type ChannelAsyncRunTargetState = ChannelAsyncRunState | 'queued';
+/** Targets are admitted locally before delivery; they are never independently submitted. */
+export type ChannelAsyncRunTargetState =
+  | Exclude<ChannelAsyncRunState, 'submitted'>
+  | 'queued';
 export type ChannelAsyncRunApprovalState = 'requested' | 'resolved' | 'expired';
 
 /** Public, provider-neutral target projection. `targetId` is a Relay profile actor id. */
@@ -1077,6 +1080,27 @@ function isMessageArray(value: unknown): value is ChannelMessage[] {
   return Array.isArray(value) && value.every(isChannelMessage);
 }
 
+const ASYNC_RUN_STATES = new Set<ChannelAsyncRunState>([
+  'submitted',
+  'working',
+  'input-required',
+  'auth-required',
+  'completed',
+  'failed',
+  'cancelled',
+  'rejected',
+]);
+const ASYNC_RUN_TARGET_STATES = new Set<ChannelAsyncRunTargetState>([
+  'queued',
+  'working',
+  'input-required',
+  'auth-required',
+  'completed',
+  'failed',
+  'cancelled',
+  'rejected',
+]);
+
 function isInFlightArray(value: unknown): value is ChannelInFlightRef[] {
   return (
     Array.isArray(value) &&
@@ -1090,16 +1114,6 @@ function isInFlightArray(value: unknown): value is ChannelInFlightRef[] {
 }
 
 export function isChannelAsyncRun(value: unknown): value is ChannelAsyncRun {
-  const runStates = new Set<string>([
-    'submitted',
-    'working',
-    'input-required',
-    'auth-required',
-    'completed',
-    'failed',
-    'cancelled',
-    'rejected',
-  ]);
   return (
     isRecord(value) &&
     typeof value.id === 'string' &&
@@ -1109,14 +1123,16 @@ export function isChannelAsyncRun(value: unknown): value is ChannelAsyncRun {
     typeof value.requestMessageId === 'string' &&
     typeof value.requesterId === 'string' &&
     typeof value.state === 'string' &&
-    runStates.has(value.state) &&
+    ASYNC_RUN_STATES.has(value.state as ChannelAsyncRunState) &&
     Array.isArray(value.targets) &&
     value.targets.every(
       (target) =>
         isRecord(target) &&
         typeof target.targetId === 'string' &&
         typeof target.state === 'string' &&
-        (target.state === 'queued' || runStates.has(target.state)) &&
+        ASYNC_RUN_TARGET_STATES.has(
+          target.state as ChannelAsyncRunTargetState
+        ) &&
         typeof target.updatedAt === 'string'
     ) &&
     typeof value.createdAt === 'string' &&
@@ -1261,9 +1277,12 @@ export function applyChannelEventV1(
           channelId: state.channelId,
           messages,
           byId: rebuildById(messages),
-          runs: Object.fromEntries(
-            (event.runs ?? []).map((run) => [run.id, run])
-          ),
+          // Old hubs legitimately omit this optional projection.  Omission is
+          // not an empty projection; an explicit [] is the authoritative clear.
+          runs:
+            event.runs === undefined
+              ? state.runs
+              : Object.fromEntries(event.runs.map((run) => [run.id, run])),
           lastSeq: event.latestSeq,
           inFlightDelta: inFlightFromRefs(event.inFlight),
           quarantined: {},

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -97,6 +97,7 @@ export type RelayCliGatewayCommand =
   | 'workspace-topics.archive'
   | 'channels.list'
   | 'channels.get'
+  | 'channels.run.get'
   | 'channels.history'
   | 'channels.subscribe'
   | 'channels.threads.history'
@@ -3289,14 +3290,91 @@ const channelPostInputSchema: RelayJsonSchema = {
   required: ['channelId', 'text'],
 };
 
+const channelAsyncRunStateSchema: RelayJsonSchema = {
+  type: 'string',
+  enum: [
+    'submitted',
+    'working',
+    'input-required',
+    'auth-required',
+    'completed',
+    'failed',
+    'cancelled',
+    'rejected',
+  ],
+};
+
+const channelAsyncRunTargetSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    targetId: stringSchema,
+    state: {
+      type: 'string',
+      enum: [
+        'queued',
+        'submitted',
+        'working',
+        'input-required',
+        'auth-required',
+        'completed',
+        'failed',
+        'cancelled',
+        'rejected',
+      ],
+    },
+    reason: stringSchema,
+    approvalState: {
+      type: 'string',
+      enum: ['requested', 'resolved', 'expired'],
+    },
+    updatedAt: { type: 'string', format: 'date-time' },
+    completedAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['targetId', 'state', 'updatedAt'],
+};
+
+const channelAsyncRunSchema: RelayJsonSchema = {
+  title: 'ChannelAsyncRun',
+  description:
+    'Relay-owned opaque request correlation. targetId is a Relay profile actor id, never a provider turn/item id.',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    id: stringSchema,
+    channelId: stringSchema,
+    threadId: nullableStringSchema,
+    requestMessageId: stringSchema,
+    requesterId: stringSchema,
+    state: channelAsyncRunStateSchema,
+    reason: stringSchema,
+    targets: { type: 'array', items: channelAsyncRunTargetSchema },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+    completedAt: { type: 'string', format: 'date-time' },
+  },
+  required: [
+    'id',
+    'channelId',
+    'threadId',
+    'requestMessageId',
+    'requesterId',
+    'state',
+    'targets',
+    'createdAt',
+    'updatedAt',
+  ],
+};
+
 const channelPostOutputDataSchema: RelayJsonSchema = {
   title: 'ChannelsPostData',
   type: 'object',
   additionalProperties: false,
   properties: {
     message: { type: 'object', additionalProperties: true },
+    run: channelAsyncRunSchema,
   },
-  required: ['message'],
+  required: ['message', 'run'],
 };
 
 const channelObjectSchema: RelayJsonSchema = {
@@ -3319,6 +3397,18 @@ const channelGetInputSchema: RelayJsonSchema = {
     channelId: stringSchema,
   },
   required: ['channelId'],
+};
+
+const channelRunGetInputSchema: RelayJsonSchema = {
+  title: 'ChannelRunGetInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    channelId: stringSchema,
+    runId: stringSchema,
+    threadId: stringSchema,
+  },
+  required: ['channelId', 'runId'],
 };
 
 const channelHistoryInputSchema: RelayJsonSchema = {
@@ -6523,6 +6613,41 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     capabilityHints: ['context:read'],
     inputSchema: channelGetInputSchema,
     outputSchema: okOutput('ChannelsGetOutput', channelGetOutputDataSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'SERVER_UNAVAILABLE',
+    ],
+  },
+  {
+    name: 'channels.run.get',
+    cli: [
+      'relay-ide',
+      'v1',
+      'channels',
+      'run',
+      'get',
+      '--channel-id',
+      '<id>',
+      '--run-id',
+      '<id>',
+      '--json',
+    ],
+    summary:
+      'Read one Relay-owned correlated channel run in an actor-scoped channel; optional threadId verifies its immutable scope.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:read'],
+    inputSchema: channelRunGetInputSchema,
+    outputSchema: okOutput('ChannelRunGetOutput', {
+      type: 'object',
+      additionalProperties: false,
+      properties: { run: channelAsyncRunSchema },
+      required: ['run'],
+    }),
     errorCodes: [
       'UNAUTHORIZED',
       'FORBIDDEN',

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -3313,7 +3313,6 @@ const channelAsyncRunTargetSchema: RelayJsonSchema = {
       type: 'string',
       enum: [
         'queued',
-        'submitted',
         'working',
         'input-required',
         'auth-required',
@@ -3476,10 +3475,33 @@ const channelSubscribeFrameSchema: RelayJsonSchema = {
         occurredAt: stringSchema,
         durableSeq: { type: 'integer', minimum: 0 },
         payload: {
-          type: 'object',
-          additionalProperties: true,
-          properties: { type: stringSchema },
-          required: ['type'],
+          oneOf: [
+            {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                type: { const: 'channel-run-lifecycle-v1' },
+                channelId: stringSchema,
+                timestamp: stringSchema,
+                run: channelAsyncRunSchema,
+              },
+              required: ['type', 'channelId', 'timestamp', 'run'],
+            },
+            {
+              // Other event variants retain their established versioned
+              // validator in the protocol layer. Do not let this escape hatch
+              // silently accept a malformed lifecycle projection.
+              type: 'object',
+              additionalProperties: true,
+              properties: { type: stringSchema },
+              required: ['type'],
+              not: {
+                type: 'object',
+                properties: { type: { const: 'channel-run-lifecycle-v1' } },
+                required: ['type'],
+              },
+            },
+          ],
         },
       },
       required: [

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -169,6 +169,7 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'workspace-topics.archive': 'archive workspace topic',
   'channels.list': 'list channels',
   'channels.get': 'channel details',
+  'channels.run.get': 'correlated channel run',
   'channels.history': 'channel message history',
   'channels.subscribe': 'subscribe to channel messages',
   'channels.threads.history': 'channel thread history',

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1365,6 +1365,27 @@ function post(
   return message;
 }
 
+function postWithAsyncRun(
+  store: ChannelMessageStore,
+  binder: ChannelAgentBinder,
+  text: string,
+  knownIds: string[],
+  sender: ChannelSenderRef = OPERATOR,
+  parentMessageId?: string
+) {
+  const mentions = parseMentions(text, knownIds);
+  const result = store.appendCompleteWithAsyncRun({
+    channelId: CH,
+    sender,
+    text,
+    ...(mentions.length ? { mentions } : {}),
+    ...(parentMessageId ? { parentMessageId } : {}),
+    targetIds: mentions.map((mention) => builtInAgentProfileId(mention.id)),
+  });
+  binder.handleMessagePosted(result.message, result.message.mentions ?? []);
+  return result;
+}
+
 function postAgentTurnRow(
   store: ChannelMessageStore,
   binder: ChannelAgentBinder,
@@ -2460,6 +2481,7 @@ function makeBinder(cfg: {
   agentProfileStore?: AgentProfileStore | null;
   processEnv?: NodeJS.ProcessEnv;
   storePath?: string;
+  now?: () => number;
 }): {
   binder: ChannelAgentBinder;
   store: ChannelMessageStore;
@@ -2494,6 +2516,7 @@ function makeBinder(cfg: {
       : {}),
     ...(cfg.yolo !== undefined ? { yolo: cfg.yolo } : {}),
     ...(cfg.processEnv !== undefined ? { processEnv: cfg.processEnv } : {}),
+    ...(cfg.now !== undefined ? { now: cfg.now } : {}),
   });
   cleanup.push(() => binder.close());
   return { binder, store, hub, sessions };
@@ -3556,7 +3579,7 @@ describe('channel-agent-binder — lifecycle', () => {
         sender: OPERATOR,
         text: 'root',
       });
-      const trigger = post(
+      const { message: trigger, run } = postWithAsyncRun(
         store,
         binder,
         '@mock threaded',
@@ -3569,6 +3592,10 @@ describe('channel-agent-binder — lifecycle', () => {
       expect(trigger.threadId).toBe(root.id);
       expect(reply.threadId).toBe(root.id);
       expect(reply.parentMessageId).toBe(trigger.id);
+      expect(reply.asyncRun).toEqual({
+        runId: run.id,
+        targetId: builtInAgentProfileId('mock'),
+      });
     }
   );
 
@@ -3628,15 +3655,102 @@ describe('channel-agent-binder — lifecycle', () => {
       sender: OPERATOR,
       text: 'root one',
     });
-    post(store, binder, '@mock one', ['mock'], OPERATOR, rootOne.id);
-    post(store, binder, '@mock two', ['mock'], OPERATOR, rootOne.id);
+    postWithAsyncRun(
+      store,
+      binder,
+      '@mock one',
+      ['mock'],
+      OPERATOR,
+      rootOne.id
+    );
+    postWithAsyncRun(
+      store,
+      binder,
+      '@mock two',
+      ['mock'],
+      OPERATOR,
+      rootOne.id
+    );
     await waitFor(() => agentReplies(store, 'mock').length === 2);
     for (const reply of agentReplies(store, 'mock')) {
       expect(reply.threadId).toBe(rootOne.id);
       // The two provider fallback rows cannot safely borrow either trigger,
       // but the runtime itself is scoped to this durable conversation.
       expect(reply.parentMessageId).toBe(rootOne.id);
+      expect(reply.asyncRun).toBeUndefined();
     }
+  });
+
+  it('retains a bounded exact-turn tombstone across a bare-idle successor', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => new ManualBareIdleAdapter(agentType),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    const first = postWithAsyncRun(
+      store,
+      binder,
+      '@mock A',
+      ['mock'],
+      OPERATOR,
+      root.id
+    );
+    postWithAsyncRun(store, binder, '@mock B', ['mock'], OPERATOR, root.id);
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ManualBareIdleAdapter;
+    await waitFor(() => adapter.sendCalls.length === 2);
+
+    // A bare idle terminalized A, then B started and displaced A from the live
+    // fallback slot. A late row with A's exact provider id must still carry A's
+    // public run reference; an anonymous turn-0 never gets this tombstone.
+    adapter.emitLate(adapter.sendCalls[0]!, 'late exact A');
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(agentReplies(store, 'mock')[0]).toMatchObject({
+      parentMessageId: first.message.id,
+      asyncRun: {
+        runId: first.run.id,
+        targetId: builtInAgentProfileId('mock'),
+      },
+    });
+  });
+
+  it('expires an exact-turn tombstone without granting it to anonymous fallback', async () => {
+    let clock = 0;
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => new ManualBareIdleAdapter(agentType),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      now: () => clock,
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    postWithAsyncRun(store, binder, '@mock A', ['mock'], OPERATOR, root.id);
+    postWithAsyncRun(store, binder, '@mock B', ['mock'], OPERATOR, root.id);
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ManualBareIdleAdapter;
+    await waitFor(() => adapter.sendCalls.length === 2);
+    clock = 60 * 1000 + 1;
+
+    adapter.emitLate(adapter.sendCalls[0]!, 'expired exact A');
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(agentReplies(store, 'mock')[0]).toMatchObject({
+      parentMessageId: root.id,
+    });
+    expect(agentReplies(store, 'mock')[0]?.asyncRun).toBeUndefined();
+    const binding = await binder.ensureBinding(CH, 'mock', root.id);
+    expect(binding.exactTurnTombstones.has(adapter.sendCalls[0]!)).toBe(false);
   });
 
   it('bounds retained parents across many bare-idle turns', async () => {
@@ -3661,6 +3775,7 @@ describe('channel-agent-binder — lifecycle', () => {
     const binding = await binder.ensureBinding(CH, 'mock');
     expect(binding.activeTurnId).toBeNull();
     expect(binding.parentMessageIdByTurn.size).toBeLessThanOrEqual(1);
+    expect(binding.exactTurnTombstones.size).toBeLessThanOrEqual(16);
   });
 
   it('prunes predecessors so an exact late successor recovers from fallback poisoning', async () => {

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1380,7 +1380,13 @@ function postWithAsyncRun(
     text,
     ...(mentions.length ? { mentions } : {}),
     ...(parentMessageId ? { parentMessageId } : {}),
-    targetIds: mentions.map((mention) => builtInAgentProfileId(mention.id)),
+    targetIds: mentions.flatMap((mention) =>
+      mention.profileId
+        ? [mention.profileId]
+        : mention.providerId
+          ? [builtInAgentProfileId(mention.providerId)]
+          : []
+    ),
   });
   binder.handleMessagePosted(result.message, result.message.mentions ?? []);
   return result;
@@ -3749,7 +3755,7 @@ describe('channel-agent-binder — lifecycle', () => {
       parentMessageId: root.id,
     });
     expect(agentReplies(store, 'mock')[0]?.asyncRun).toBeUndefined();
-    const binding = await binder.ensureBinding(CH, 'mock', root.id);
+    const binding = await binder.ensureBinding(CH, 'mock');
     expect(binding.exactTurnTombstones.has(adapter.sendCalls[0]!)).toBe(false);
   });
 

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -547,6 +547,51 @@ describe('applyChannelEventV1 reducer', () => {
     expect(state.lastSeq).toBe(3);
   });
 
+  it('preserves omitted run projections but clears an explicit empty projection', () => {
+    const run = {
+      id: 'chrun:retained',
+      channelId: CHANNEL,
+      threadId: null,
+      requestMessageId: 'chm:request',
+      requesterId: 'human:operator',
+      state: 'submitted' as const,
+      targets: [],
+      createdAt: 't',
+      updatedAt: 't',
+    };
+    let state = applyChannelEventV1(initialChannelReducerState(CHANNEL), {
+      type: 'channel-run-lifecycle-v1',
+      channelId: CHANNEL,
+      timestamp: 't',
+      run,
+    });
+    state = applyChannelEventV1(state, {
+      type: 'channel-snapshot-v1',
+      channelId: CHANNEL,
+      timestamp: 't',
+      mode: 'full',
+      messages: [],
+      members: [],
+      latestSeq: 0,
+      inFlight: [],
+      truncated: false,
+    });
+    expect(state.runs[run.id]).toEqual(run);
+    state = applyChannelEventV1(state, {
+      type: 'channel-snapshot-v1',
+      channelId: CHANNEL,
+      timestamp: 't',
+      mode: 'full',
+      messages: [],
+      runs: [],
+      members: [],
+      latestSeq: 0,
+      inFlight: [],
+      truncated: false,
+    });
+    expect(state.runs).toEqual({});
+  });
+
   it('is deterministic under replay', () => {
     const events: ChannelEventV1[] = [
       created(

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -121,6 +121,30 @@ describe('isChannelEventV1 validator matrix', () => {
       truncated: false,
     };
     expect(isChannelEventV1(snapshot)).toBe(true);
+    expect(
+      isChannelEventV1({
+        type: 'channel-run-lifecycle-v1',
+        channelId: CHANNEL,
+        timestamp: 't',
+        run: {
+          id: 'chrun:queued',
+          channelId: CHANNEL,
+          threadId: null,
+          requestMessageId: 'chm:request',
+          requesterId: 'human:operator',
+          state: 'submitted',
+          targets: [
+            {
+              targetId: 'agent-profile:mock:default',
+              state: 'queued',
+              updatedAt: 't',
+            },
+          ],
+          createdAt: 't',
+          updatedAt: 't',
+        },
+      })
+    ).toBe(true);
     expect(isChannelEventV1(created(message()))).toBe(true);
     expect(isChannelEventV1(delta('chm:1', 0, 'x'))).toBe(true);
     expect(isChannelEventV1(updated(message({ status: 'streaming' })))).toBe(
@@ -169,6 +193,30 @@ describe('isChannelEventV1 validator matrix', () => {
       isChannelEventV1(
         created({ ...message(), sender: { kind: 'ghost' } as never })
       )
+    ).toBe(false);
+    expect(
+      isChannelEventV1({
+        type: 'channel-run-lifecycle-v1',
+        channelId: CHANNEL,
+        timestamp: 't',
+        run: {
+          id: 'chrun:bad-target-state',
+          channelId: CHANNEL,
+          threadId: null,
+          requestMessageId: 'chm:request',
+          requesterId: 'human:operator',
+          state: 'submitted',
+          targets: [
+            {
+              targetId: 'agent-profile:mock:default',
+              state: 'not-a-run-state',
+              updatedAt: 't',
+            },
+          ],
+          createdAt: 't',
+          updatedAt: 't',
+        },
+      })
     ).toBe(false);
     expect(
       isChannelEventV1(created({ ...message(), body: { text: 1 } as never }))

--- a/test/channel-hub.test.ts
+++ b/test/channel-hub.test.ts
@@ -425,6 +425,83 @@ describe('channel-hub fan-out', () => {
 });
 
 describe('channel-hub snapshot correctness', () => {
+  it('bounds durable run snapshots by count and byte budget', async () => {
+    const s = store();
+    for (let index = 0; index < 101; index += 1) {
+      s.appendCompleteWithAsyncRun({
+        channelId: 'topic:runs',
+        sender: HUMAN,
+        text: `request ${index}`,
+        targetIds: [`agent-profile:mock:${index}`],
+      });
+    }
+    const countHub = hubWith(s);
+    const countSocket = fakeSocket();
+    countHub.handleConnection(countSocket, {
+      channelId: 'topic:runs',
+      sinceSeq: null,
+    });
+    const countSnapshot = countSocket.sent[0];
+    if (countSnapshot?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+    expect(countSnapshot.runs).toHaveLength(100);
+
+    s.appendCompleteWithAsyncRun({
+      channelId: 'topic:large-run',
+      sender: HUMAN,
+      text: 'large projected run',
+      targetIds: Array.from(
+        { length: 300 },
+        (_, index) => `agent-profile:mock:${index}:${'x'.repeat(1024)}`
+      ),
+    });
+    const byteHub = hubWith(s);
+    const byteSocket = fakeSocket();
+    byteHub.handleConnection(byteSocket, {
+      channelId: 'topic:large-run',
+      sinceSeq: null,
+    });
+    const byteSnapshot = byteSocket.sent[0];
+    if (byteSnapshot?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+    expect(byteSnapshot.runs).toEqual([]);
+    expect(
+      Buffer.byteLength(JSON.stringify(byteSnapshot.runs), 'utf8')
+    ).toBeLessThanOrEqual(256 * 1024);
+
+    const oversizedOlder = s.appendCompleteWithAsyncRun({
+      channelId: 'topic:fair-runs',
+      sender: HUMAN,
+      text: 'oversized old projection',
+      targetIds: Array.from(
+        { length: 300 },
+        (_, index) => `agent-profile:mock:older:${index}:${'x'.repeat(1024)}`
+      ),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const recentSmall = s.appendCompleteWithAsyncRun({
+      channelId: 'topic:fair-runs',
+      sender: HUMAN,
+      text: 'recent small projection',
+      targetIds: ['agent-profile:mock:recent'],
+    });
+    const fairHub = hubWith(s);
+    const fairSocket = fakeSocket();
+    fairHub.handleConnection(fairSocket, {
+      channelId: 'topic:fair-runs',
+      sinceSeq: null,
+    });
+    const fairSnapshot = fairSocket.sent[0];
+    if (fairSnapshot?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+    expect(fairSnapshot.runs.map((run) => run.id)).toEqual([
+      recentSmall.run.id,
+    ]);
+    expect(fairSnapshot.runs.map((run) => run.id)).not.toContain(
+      oversizedOlder.run.id
+    );
+  });
+
   it('does not duplicate pending accumulator text for a subscriber that connects mid-coalesce window', () => {
     vi.useFakeTimers();
     const s = store();

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -56,6 +56,7 @@ import {
 import {
   channelTurnId,
   parseMentions,
+  type ChannelAsyncRun,
   type ChannelMessage,
 } from '../shared/channel-chat-protocol.js';
 import type { ChannelAgentRuntime } from '../server/channel-agent-runtime.js';
@@ -253,6 +254,7 @@ function makeSessions(
         threadId: params.threadId ?? null,
         providerId: params.providerId,
         profileActorId: params.profileActorId,
+        role: params.role,
         status: 'active',
         adapter,
         cwd: params.cwd,
@@ -804,7 +806,7 @@ describe('mention routing — real scoped-actor auth composition (P2 #1180)', ()
       'x-relay-cli-command': 'channels.post',
     };
     const postOnce = (text: string) =>
-      req<{ message: ChannelMessage }>({
+      req<{ message: ChannelMessage; run: ChannelAsyncRun }>({
         port: h.port,
         method: 'POST',
         url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
@@ -828,9 +830,16 @@ describe('mention routing — real scoped-actor auth composition (P2 #1180)', ()
     // Brake accounting: further agent-sender posts count toward the cap. Posting
     // past MAX trips the pause row — a browser (human) sender never would, proving
     // the actor post is accounted as an agent turn end-to-end.
+    let pausedPost:
+      | {
+          status: number;
+          body: { message: ChannelMessage; run: ChannelAsyncRun };
+        }
+      | undefined;
     for (let i = 1; i <= 4; i++) {
       const res = await postOnce(`@mock brief ${i}`);
       expect(res.status).toBe(201);
+      if (i === 4) pausedPost = res;
     }
     await waitFor(() =>
       h.store
@@ -847,6 +856,173 @@ describe('mention routing — real scoped-actor auth composition (P2 #1180)', ()
           m.kind === 'system' && m.body.text.includes('Mention chain paused')
       );
     expect(paused).toHaveLength(1);
+    // The router admitted this target atomically with the message before the
+    // binder observed the cap. The brake must close that durable target, not
+    // strand a client-visible queued run forever.
+    await waitFor(
+      () =>
+        pausedPost !== undefined &&
+        h.store.getAsyncRun(pausedPost.body.run.id)?.state === 'rejected'
+    );
+    expect(h.store.getAsyncRun(pausedPost!.body.run.id)).toMatchObject({
+      state: 'rejected',
+      targets: [
+        {
+          targetId: builtInAgentProfileId('mock'),
+          state: 'rejected',
+          reason: 'mention-chain-paused',
+        },
+      ],
+    });
+  });
+
+  it('correlates concurrent scoped-actor requests with their durable replies and terminal runs', async () => {
+    const registry = createCliGatewayActorRegistry();
+    const h = await harness(undefined, { actorRegistry: registry });
+    const issued = issueCliGatewayActorCredential(registry, {
+      actor: { type: 'agent', id: 'concurrent-client' },
+      capabilities: ['context:read', 'context:write'],
+      scope: { channelIds: [h.channelId] },
+    });
+    const headers = {
+      authorization: `Bearer ${issued.token}`,
+      'x-relay-cli-actor-token': 'v1',
+      'x-relay-cli-command': 'channels.post',
+    };
+    const post = (clientMessageId: string) =>
+      req<{ message: ChannelMessage; run: ChannelAsyncRun }>({
+        port: h.port,
+        method: 'POST',
+        url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+        body: { text: '@mock answer this', clientMessageId },
+        headers,
+      });
+
+    const [first, second] = await Promise.all([
+      post('concurrent-1'),
+      post('concurrent-2'),
+    ]);
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(first.body.run.id).not.toBe(second.body.run.id);
+    expect(first.body.run.requestMessageId).toBe(first.body.message.id);
+    expect(second.body.run.requestMessageId).toBe(second.body.message.id);
+
+    await waitFor(() => agentReply(h.store, h.channelId).length === 2);
+    const replies = agentReply(h.store, h.channelId);
+    for (const run of [first.body.run, second.body.run]) {
+      expect(replies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            asyncRun: {
+              runId: run.id,
+              targetId: builtInAgentProfileId('mock'),
+            },
+          }),
+        ])
+      );
+      await waitFor(() => h.store.getAsyncRun(run.id)?.state === 'completed');
+    }
+
+    // Exercise the real external-client read surface: it can correlate the
+    // durable rows without a provider turn/item id or a requester profile.
+    const history = await req<{ messages: ChannelMessage[] }>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages?limit=20`,
+      headers: { ...headers, 'x-relay-cli-command': 'channels.history' },
+    });
+    expect(history.status).toBe(200);
+    expect(
+      history.body.messages.filter((message) => message.asyncRun !== undefined)
+    ).toEqual(
+      expect.arrayContaining(
+        [first.body.run, second.body.run].map((run) =>
+          expect.objectContaining({
+            asyncRun: expect.objectContaining({ runId: run.id }),
+          })
+        )
+      )
+    );
+  });
+
+  it('admits a bare human post to its designated orchestrator and correlates its reply', async () => {
+    const h = await harness(
+      (provider) =>
+        new RecordingAdapter(provider, 'implicit orchestrator reply')
+    );
+    await h.binder.ensureOrchestrator(h.channelId, 'mock');
+
+    const post = await req<{ message: ChannelMessage; run: ChannelAsyncRun }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: 'continue the plan' },
+    });
+    expect(post.status).toBe(201);
+    expect(post.body.run).toMatchObject({
+      state: 'submitted',
+      requestMessageId: post.body.message.id,
+      targets: [{ targetId: builtInAgentProfileId('mock'), state: 'queued' }],
+    });
+
+    await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    expect(agentReply(h.store, h.channelId)[0]).toMatchObject({
+      body: { text: 'implicit orchestrator reply' },
+      asyncRun: {
+        runId: post.body.run.id,
+        targetId: builtInAgentProfileId('mock'),
+      },
+    });
+    await waitFor(
+      () => h.store.getAsyncRun(post.body.run.id)?.state === 'completed'
+    );
+  });
+
+  it('terminalizes an unmentioned human post when no implicit recipient is designated', async () => {
+    const h = await harness();
+    const post = await req<{ message: ChannelMessage; run: ChannelAsyncRun }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: 'continue the plan' },
+    });
+    expect(post.status).toBe(201);
+    expect(post.body.run).toMatchObject({
+      state: 'rejected',
+      reason: 'no-eligible-target',
+      requestMessageId: post.body.message.id,
+      targets: [],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(agentReply(h.store, h.channelId)).toEqual([]);
+  });
+
+  it('terminalizes an admitted but unavailable target instead of leaving its run queued', async () => {
+    const h = await harness();
+    const post = await req<{ message: ChannelMessage; run: ChannelAsyncRun }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: '@codex continue the plan' },
+    });
+    expect(post.status).toBe(201);
+    expect(post.body.run.targets).toEqual([
+      expect.objectContaining({ targetId: builtInAgentProfileId('codex') }),
+    ]);
+    await waitFor(
+      () => h.store.getAsyncRun(post.body.run.id)?.state === 'rejected'
+    );
+    expect(h.store.getAsyncRun(post.body.run.id)).toMatchObject({
+      state: 'rejected',
+      targets: [
+        {
+          targetId: builtInAgentProfileId('codex'),
+          state: 'rejected',
+          reason: 'target-unavailable',
+        },
+      ],
+    });
   });
 
   it('lets an external scoped actor observe the durable reply without a requester profile', async () => {
@@ -867,7 +1043,7 @@ describe('mention routing — real scoped-actor auth composition (P2 #1180)', ()
       capabilities: ['context:read', 'context:write'],
       scope: { channelIds: [h.channelId] },
     });
-    const post = await req<{ message: ChannelMessage }>({
+    const post = await req<{ message: ChannelMessage; run: ChannelAsyncRun }>({
       port: h.port,
       method: 'POST',
       url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
@@ -883,11 +1059,30 @@ describe('mention routing — real scoped-actor auth composition (P2 #1180)', ()
       kind: 'agent',
       id: 'agent:codex-desktop-dogfood',
     });
+    expect(post.body.run).toMatchObject({
+      id: expect.stringMatching(/^chrun:/),
+      requestMessageId: post.body.message.id,
+      requesterId: 'agent:codex-desktop-dogfood',
+      state: 'submitted',
+      targets: [
+        {
+          targetId: builtInAgentProfileId('mock'),
+          state: 'queued',
+        },
+      ],
+    });
     await waitFor(() => agentReply(h.store, h.channelId).length === 1);
     expect(agentReply(h.store, h.channelId)[0]).toMatchObject({
       body: { text: 'durable external reply' },
       sender: { id: 'agent-profile:mock:default' },
+      asyncRun: {
+        runId: post.body.run.id,
+        targetId: builtInAgentProfileId('mock'),
+      },
     });
+    await waitFor(
+      () => h.store.getAsyncRun(post.body.run.id)?.state === 'completed'
+    );
     // Verify the actor's real authorization surface, not the test's internal
     // store: this is the durable history contract external requesters use to
     // observe replies without acquiring an installed requester profile.
@@ -907,9 +1102,41 @@ describe('mention routing — real scoped-actor auth composition (P2 #1180)', ()
         expect.objectContaining({
           body: expect.objectContaining({ text: 'durable external reply' }),
           sender: expect.objectContaining({ id: 'agent-profile:mock:default' }),
+          asyncRun: {
+            runId: post.body.run.id,
+            targetId: builtInAgentProfileId('mock'),
+          },
         }),
       ])
     );
+    const runStatus = await req<{ run: ChannelAsyncRun }>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/${encodeURIComponent(h.channelId)}/runs/${encodeURIComponent(post.body.run.id)}`,
+      headers: {
+        authorization: `Bearer ${issued.token}`,
+        'x-relay-cli-actor-token': 'v1',
+        'x-relay-cli-command': 'channels.run.get',
+      },
+    });
+    expect(runStatus.status).toBe(200);
+    expect(runStatus.body.run).toMatchObject({
+      id: post.body.run.id,
+      channelId: h.channelId,
+      threadId: null,
+      state: 'completed',
+    });
+    const wrongThread = await req<{ error: { code: string } }>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/${encodeURIComponent(h.channelId)}/runs/${encodeURIComponent(post.body.run.id)}?threadId=chm:other`,
+      headers: {
+        authorization: `Bearer ${issued.token}`,
+        'x-relay-cli-actor-token': 'v1',
+        'x-relay-cli-command': 'channels.run.get',
+      },
+    });
+    expect(wrongThread.status).toBe(404);
     const callbackId = `chcb:${channelTurnId(
       post.body.message.id,
       builtInAgentProfileId('mock')

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -135,7 +135,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(14);
+    ).toBe(15);
     expect(
       (
         inspect
@@ -605,7 +605,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(14);
+    ).toBe(15);
     expect(
       (
         inspect.prepare('PRAGMA table_info(channel_messages)').all() as Array<{
@@ -793,7 +793,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(14);
+    ).toBe(15);
     expect(
       inspect
         .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
@@ -1007,6 +1007,51 @@ describe('channel-message-store schema migration', () => {
       migrated.history('topic:wal-heal', { limit: 20 }).map((m) => m.id)
     ).toEqual(['chm:wal-keeper']);
     expect(migrated.getMessage('chm:wal-duplicate')).toBeNull();
+  });
+});
+
+describe('channel-message-store async-run migration (#1391)', () => {
+  it('upgrades a v14 store with its existing durable transcript intact', () => {
+    const file = dbPath();
+    const seeded = createChannelMessageStore(file);
+    seeded.appendComplete({
+      channelId: 'topic:migrate-run',
+      sender: HUMAN,
+      text: 'existing durable row',
+    });
+    seeded.close();
+    const legacy = new Database(file);
+    legacy.exec(`
+      DROP INDEX idx_chart_run_state;
+      DROP INDEX idx_char_channel_thread_created;
+      DROP TABLE channel_async_run_targets;
+      DROP TABLE channel_async_runs;
+      UPDATE schema_version SET version = 14;
+    `);
+    legacy.close();
+
+    const migrated = store(file);
+    expect(migrated.history('topic:migrate-run')).toMatchObject([
+      { body: { text: 'existing durable row' } },
+    ]);
+    const inspect = new Database(file, { readonly: true });
+    cleanup.push(() => inspect.close());
+    expect(inspect.prepare('SELECT version FROM schema_version').get()).toEqual(
+      { version: 15 }
+    );
+    expect(
+      inspect
+        .prepare(
+          `SELECT name FROM sqlite_master
+             WHERE type = 'table' AND name IN
+               ('channel_async_runs', 'channel_async_run_targets')
+             ORDER BY name`
+        )
+        .all()
+    ).toEqual([
+      { name: 'channel_async_run_targets' },
+      { name: 'channel_async_runs' },
+    ]);
   });
 });
 
@@ -1729,6 +1774,164 @@ describe('channel-message-store streaming lifecycle', () => {
         .listResyncRows('topic:c', Number.MAX_SAFE_INTEGER, 500)
         .find((message) => message.id === root.id)?.replyCount
     ).toBe(4);
+  });
+});
+
+describe('channel-message-store async runs (#1391)', () => {
+  it('atomically creates and replays one requester post/run without re-routing', () => {
+    const file = dbPath();
+    const s = store(file);
+    const first = s.appendCompleteWithAsyncRun({
+      channelId: 'topic:async',
+      sender: HUMAN,
+      text: '@a @b compare plans',
+      clientMessageId: 'client-async-1',
+      targetIds: ['agent-profile:b:default', 'agent-profile:a:default'],
+    });
+
+    expect(first).toMatchObject({
+      replayed: false,
+      message: {
+        channelId: 'topic:async',
+        clientMessageId: 'client-async-1',
+      },
+      run: {
+        id: expect.stringMatching(/^chrun:/),
+        channelId: 'topic:async',
+        requesterId: HUMAN.id,
+        state: 'submitted',
+        targets: [
+          { targetId: 'agent-profile:a:default', state: 'queued' },
+          { targetId: 'agent-profile:b:default', state: 'queued' },
+        ],
+      },
+    });
+    expect(first.run.requestMessageId).toBe(first.message.id);
+
+    const replay = s.appendCompleteWithAsyncRun({
+      channelId: 'topic:async',
+      sender: HUMAN,
+      text: 'this replacement must not be persisted',
+      clientMessageId: 'client-async-1',
+      targetIds: ['agent-profile:unexpected:default'],
+    });
+    expect(replay.replayed).toBe(true);
+    expect(replay.message).toEqual(first.message);
+    expect(replay.run).toEqual(first.run);
+    expect(s.history('topic:async')).toEqual([first.message]);
+    expect(s.getAsyncRun(first.run.id)).toEqual(first.run);
+    expect(s.getAsyncRunForRequestMessage(first.message.id)).toEqual(first.run);
+
+    // A reopen proves the correlation is a durable store projection rather
+    // than a router-local map and remains queryable from history/reconnect.
+    s.close();
+    const reopened = store(file);
+    expect(reopened.getAsyncRun(first.run.id)).toMatchObject({
+      id: first.run.id,
+      state: 'cancelled',
+      reason: 'server-restarted',
+      targets: [
+        { targetId: 'agent-profile:a:default', state: 'cancelled' },
+        { targetId: 'agent-profile:b:default', state: 'cancelled' },
+      ],
+    });
+  });
+
+  it('derives aggregate terminal state from durable per-target CAS outcomes', () => {
+    const s = store();
+    const { run } = s.appendCompleteWithAsyncRun({
+      channelId: 'topic:async',
+      sender: HUMAN,
+      text: '@a @b investigate',
+      targetIds: ['agent-profile:a:default', 'agent-profile:b:default'],
+    });
+
+    const working = s.transitionAsyncRunTarget({
+      runId: run.id,
+      targetId: 'agent-profile:a:default',
+      state: 'working',
+    })!;
+    expect(working.state).toBe('working');
+    expect(working.targets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          targetId: 'agent-profile:a:default',
+          state: 'working',
+        }),
+      ])
+    );
+
+    s.transitionAsyncRunTarget({
+      runId: run.id,
+      targetId: 'agent-profile:a:default',
+      state: 'completed',
+    });
+    const awaitingInput = s.transitionAsyncRunTarget({
+      runId: run.id,
+      targetId: 'agent-profile:b:default',
+      state: 'input-required',
+      approvalState: 'requested',
+    })!;
+    expect(awaitingInput).toMatchObject({
+      state: 'input-required',
+      targets: expect.arrayContaining([
+        expect.objectContaining({
+          targetId: 'agent-profile:b:default',
+          state: 'input-required',
+          approvalState: 'requested',
+        }),
+      ]),
+    });
+
+    const failed = s.transitionAsyncRunTarget({
+      runId: run.id,
+      targetId: 'agent-profile:b:default',
+      state: 'rejected',
+      reason: 'target-revoked',
+    })!;
+    expect(failed).toMatchObject({
+      state: 'failed',
+      completedAt: expect.any(String),
+      targets: expect.arrayContaining([
+        expect.objectContaining({
+          targetId: 'agent-profile:a:default',
+          state: 'completed',
+          completedAt: expect.any(String),
+        }),
+        expect.objectContaining({
+          targetId: 'agent-profile:b:default',
+          state: 'rejected',
+          reason: 'target-revoked',
+          completedAt: expect.any(String),
+        }),
+      ]),
+    });
+
+    // A terminal target is a CAS fence: a late provider patch cannot rewrite
+    // its terminal result or alter the already-derived aggregate state.
+    expect(
+      s.transitionAsyncRunTarget({
+        runId: run.id,
+        targetId: 'agent-profile:b:default',
+        state: 'completed',
+      })
+    ).toEqual(failed);
+  });
+
+  it('rejects a run with no eligible target without inventing a provider identity', () => {
+    const s = store();
+    const { run } = s.appendCompleteWithAsyncRun({
+      channelId: 'topic:async',
+      sender: HUMAN,
+      text: 'nobody eligible',
+      targetIds: [],
+    });
+    expect(run).toMatchObject({
+      state: 'rejected',
+      reason: 'no-eligible-target',
+      completedAt: expect.any(String),
+      targets: [],
+    });
   });
 });
 
@@ -3375,7 +3578,7 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
       .get() as { version: number };
     counted.close();
     expect(rows.count).toBe(1);
-    expect(version.version).toBe(14);
+    expect(version.version).toBe(15);
   });
 
   it('backfills across more than one batch without dropping or duplicating rows', () => {
@@ -3773,6 +3976,28 @@ describe('channel-message-store read state (#1308 slice 3 item 1)', () => {
     expect(s.listReadState().map((row) => row.channelId)).toEqual([
       'topic:live',
     ]);
+  });
+
+  it('sweeps a channel whose only surviving durable rows are async runs', () => {
+    const file = dbPath();
+    const s = store(file);
+    const { run } = s.appendCompleteWithAsyncRun({
+      channelId: 'topic:run-only',
+      sender: HUMAN,
+      text: 'orphaned request',
+      targetIds: ['agent-profile:mock:default'],
+    });
+    const raw = new Database(file);
+    raw
+      .prepare('DELETE FROM channel_messages WHERE channel_id = ?')
+      .run('topic:run-only');
+    raw.close();
+
+    expect(s.getAsyncRun(run.id)?.id).toBe(run.id);
+    expect(s.sweepOrphans(new Set()).channelsDeleted).toEqual([
+      'topic:run-only',
+    ]);
+    expect(s.getAsyncRun(run.id)).toBeNull();
   });
 
   it('survives a reopen and repairs a dropped read-state table', () => {

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -135,7 +135,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(15);
+    ).toBe(16);
     expect(
       (
         inspect
@@ -605,7 +605,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(15);
+    ).toBe(16);
     expect(
       (
         inspect.prepare('PRAGMA table_info(channel_messages)').all() as Array<{
@@ -793,7 +793,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(15);
+    ).toBe(16);
     expect(
       inspect
         .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
@@ -1023,7 +1023,7 @@ describe('channel-message-store async-run migration (#1391)', () => {
     const legacy = new Database(file);
     legacy.exec(`
       DROP INDEX idx_chart_run_state;
-      DROP INDEX idx_char_channel_thread_created;
+      DROP INDEX idx_char_channel_created;
       DROP TABLE channel_async_run_targets;
       DROP TABLE channel_async_runs;
       UPDATE schema_version SET version = 14;
@@ -1037,7 +1037,7 @@ describe('channel-message-store async-run migration (#1391)', () => {
     const inspect = new Database(file, { readonly: true });
     cleanup.push(() => inspect.close());
     expect(inspect.prepare('SELECT version FROM schema_version').get()).toEqual(
-      { version: 15 }
+      { version: 16 }
     );
     expect(
       inspect
@@ -1822,10 +1822,12 @@ describe('channel-message-store async runs (#1391)', () => {
     expect(s.getAsyncRun(first.run.id)).toEqual(first.run);
     expect(s.getAsyncRunForRequestMessage(first.message.id)).toEqual(first.run);
 
-    // A reopen proves the correlation is a durable store projection rather
-    // than a router-local map and remains queryable from history/reconnect.
+    // An additional handle is not a restart owner and must not cancel live
+    // work. The boot owner performs the explicit, safe no-redelivery recovery.
     s.close();
     const reopened = store(file);
+    expect(reopened.getAsyncRun(first.run.id)?.state).toBe('submitted');
+    expect(reopened.recoverAsyncRuns()).toHaveLength(1);
     expect(reopened.getAsyncRun(first.run.id)).toMatchObject({
       id: first.run.id,
       state: 'cancelled',
@@ -3578,7 +3580,7 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
       .get() as { version: number };
     counted.close();
     expect(rows.count).toBe(1);
-    expect(version.version).toBe(15);
+    expect(version.version).toBe(16);
   });
 
   it('backfills across more than one batch without dropping or duplicating rows', () => {

--- a/test/channel-subscription-routes.test.ts
+++ b/test/channel-subscription-routes.test.ts
@@ -110,6 +110,48 @@ describe('channel subscription route', () => {
     ]);
   });
 
+  it('keeps the message cursor stable for a durable run lifecycle projection', async () => {
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: (sink, afterSeq) => {
+        expect(afterSeq).toBe(4);
+        sink.send({
+          type: 'channel-run-lifecycle-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-11T00:00:00.000Z',
+          run: {
+            id: 'chrun:opaque',
+            channelId: 'topic:a',
+            threadId: null,
+            requestMessageId: 'chm:request',
+            requesterId: 'actor:external',
+            state: 'working',
+            targets: [],
+            createdAt: '2026-08-11T00:00:00.000Z',
+            updatedAt: '2026-08-11T00:00:00.000Z',
+          },
+        });
+        sink.close({ code: 'transport-closed' });
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=4`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(frames.map((frame) => frame.durableSeq)).toEqual([4, 4, 4]);
+    expect(frames[1]).toMatchObject({
+      frame: 'event',
+      payload: {
+        type: 'channel-run-lifecycle-v1',
+        run: { id: 'chrun:opaque' },
+      },
+    });
+  });
+
   it('closes before delivery when the actor is revoked mid-stream', async () => {
     let authorized = true;
     const port = await listen({

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -445,6 +445,7 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
     'workspace-topics.get',
     'channels.list',
     'channels.get',
+    'channels.run.get',
     'channels.history',
     'channels.subscribe',
     'channels.threads.history',

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -368,10 +368,42 @@ describe('CLI gateway contract', () => {
           type: 'channel-run-lifecycle-v1',
           channelId: 'channel-1',
           timestamp: '2026-08-11T00:00:02.000Z',
-          run: { id: 'chrun:opaque' },
+          run: {
+            id: 'chrun:opaque',
+            channelId: 'channel-1',
+            threadId: null,
+            requestMessageId: 'chm:request',
+            requesterId: 'actor:external',
+            state: 'submitted',
+            targets: [
+              {
+                targetId: 'agent-profile:mock',
+                state: 'queued',
+                updatedAt: '2026-08-11T00:00:02.000Z',
+              },
+            ],
+            createdAt: '2026-08-11T00:00:00.000Z',
+            updatedAt: '2026-08-11T00:00:02.000Z',
+          },
         },
       })
     ).toBe(true);
+    expect(
+      schemaAcceptsChannelsSubscribeFrame({
+        schemaVersion: 1,
+        frame: 'event',
+        channelId: 'channel-1',
+        sequence: 3,
+        occurredAt: '2026-08-11T00:00:03.000Z',
+        durableSeq: 0,
+        payload: {
+          type: 'channel-run-lifecycle-v1',
+          channelId: 'channel-1',
+          timestamp: '2026-08-11T00:00:03.000Z',
+          run: { id: 'chrun:opaque' },
+        },
+      })
+    ).toBe(false);
     expect(
       schemaAcceptsChannelsSubscribeFrame({
         schemaVersion: 1,

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -245,6 +245,7 @@ describe('CLI gateway contract', () => {
       'workspace-topics.archive',
       'channels.list',
       'channels.get',
+      'channels.run.get',
       'channels.history',
       'channels.subscribe',
       'channels.threads.history',
@@ -272,6 +273,7 @@ describe('CLI gateway contract', () => {
     const readVerbs = [
       'channels.list',
       'channels.get',
+      'channels.run.get',
       'channels.history',
       'channels.subscribe',
       'channels.threads.history',
@@ -352,6 +354,24 @@ describe('CLI gateway contract', () => {
         durableSeq: 0,
       })
     ).toBe(true);
+    // Lifecycle is durable state, but carries no message sequence: consumers
+    // retain their last message cursor while replacing this run projection.
+    expect(
+      schemaAcceptsChannelsSubscribeFrame({
+        schemaVersion: 1,
+        frame: 'event',
+        channelId: 'channel-1',
+        sequence: 2,
+        occurredAt: '2026-08-11T00:00:02.000Z',
+        durableSeq: 0,
+        payload: {
+          type: 'channel-run-lifecycle-v1',
+          channelId: 'channel-1',
+          timestamp: '2026-08-11T00:00:02.000Z',
+          run: { id: 'chrun:opaque' },
+        },
+      })
+    ).toBe(true);
     expect(
       schemaAcceptsChannelsSubscribeFrame({
         schemaVersion: 1,
@@ -412,6 +432,30 @@ describe('CLI gateway contract', () => {
     ]) {
       expect(schemaAcceptsChannelsSubscribeFrame(invalidFrame)).toBe(false);
     }
+  });
+
+  it('declares the Relay-owned async run returned by channels.post', () => {
+    const data = commandSpec('channels.post').outputSchema.properties?.['data'];
+    if (!data) throw new Error('channels.post output data schema is missing');
+    const run = {
+      id: 'chrun:opaque',
+      channelId: 'channel-1',
+      threadId: null,
+      requestMessageId: 'chm:request',
+      requesterId: 'actor:external',
+      state: 'submitted',
+      targets: [
+        {
+          targetId: 'agent-profile:mock:default',
+          state: 'queued',
+          updatedAt: '2026-08-11T00:00:00.000Z',
+        },
+      ],
+      createdAt: '2026-08-11T00:00:00.000Z',
+      updatedAt: '2026-08-11T00:00:00.000Z',
+    };
+    expect(schemaMatches(data, { message: {}, run })).toBe(true);
+    expect(schemaMatches(data, { message: {} })).toBe(false);
   });
 
   it('models channel pagination inputs and directional cursors exactly', () => {

--- a/test/cli-gateway/channels-post.test.ts
+++ b/test/cli-gateway/channels-post.test.ts
@@ -169,7 +169,14 @@ describe('channels.post CLI gateway command', () => {
     expect(envelope).toMatchObject({
       ok: true,
       command: 'channels.post',
-      data: { message: { id: 'chm:test' } },
+      data: {
+        message: { id: 'chm:test' },
+        run: {
+          id: 'chrun:test',
+          requestMessageId: 'chm:test',
+          state: 'submitted',
+        },
+      },
     });
     expect(request).toMatchObject({
       method: 'POST',
@@ -191,6 +198,44 @@ describe('channels.post CLI gateway command', () => {
       },
     });
     expect(request.body).not.toHaveProperty('channelId');
+  });
+
+  it('gets one opaque run through the context-read actor lane', async () => {
+    const { envelope, request } = await runCli(
+      [
+        'v1',
+        'channels',
+        'run',
+        'get',
+        '--channel-id',
+        'product/main',
+        '--run-id',
+        'chrun:test',
+        '--thread-id',
+        'chm:root',
+        '--json',
+      ],
+      {
+        ...process.env,
+        RELAY_IDE_PORT: '4567',
+        RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.test-actor.[REDACTED]',
+        RELAY_IDE_BROWSER_TOKEN: '',
+      }
+    );
+
+    expect(envelope).toMatchObject({
+      ok: true,
+      command: 'channels.run.get',
+      data: { run: { id: 'chrun:test' } },
+    });
+    expect(request).toMatchObject({
+      method: 'GET',
+      url: 'http://127.0.0.1:4567/channels/product%2Fmain/runs/chrun%3Atest?threadId=chm%3Aroot',
+      headers: expect.objectContaining({
+        'x-relay-cli-command': 'channels.run.get',
+        'x-relay-capabilities': 'context:read',
+      }),
+    });
   });
 
   it.each([

--- a/test/cli-gateway/channels-subscribe.test.ts
+++ b/test/cli-gateway/channels-subscribe.test.ts
@@ -92,10 +92,10 @@ describe('channels.subscribe CLI gateway command', () => {
         `${JSON.stringify({ schemaVersion: 1, frame: 'open', channelId: 'topic:test', sequence: 0, durableSeq: 4 })}\n`
       );
       res.write(
-        `${JSON.stringify({ schemaVersion: 1, frame: 'event', channelId: 'topic:test', sequence: 1, occurredAt: '2026-08-11T00:00:01.000Z', durableSeq: 5, payload: { type: 'channel-message-created-v1' } })}\n`
+        `${JSON.stringify({ schemaVersion: 1, frame: 'event', channelId: 'topic:test', sequence: 1, occurredAt: '2026-08-11T00:00:01.000Z', durableSeq: 4, payload: { type: 'channel-run-lifecycle-v1', run: { id: 'chrun:test' } } })}\n`
       );
       res.end(
-        `${JSON.stringify({ schemaVersion: 1, frame: 'closed', channelId: 'topic:test', sequence: 2, occurredAt: '2026-08-11T00:00:02.000Z', durableSeq: 5, reason: 'normal', retryable: false })}\n`
+        `${JSON.stringify({ schemaVersion: 1, frame: 'closed', channelId: 'topic:test', sequence: 2, occurredAt: '2026-08-11T00:00:02.000Z', durableSeq: 4, reason: 'normal', retryable: false })}\n`
       );
     });
     await new Promise<void>((resolve) =>
@@ -136,12 +136,19 @@ describe('channels.subscribe CLI gateway command', () => {
         {
           ok: true,
           command: 'channels.subscribe',
-          data: { frame: 'event', durableSeq: 5 },
+          data: {
+            frame: 'event',
+            durableSeq: 4,
+            payload: {
+              type: 'channel-run-lifecycle-v1',
+              run: { id: 'chrun:test' },
+            },
+          },
         },
         {
           ok: true,
           command: 'channels.subscribe',
-          data: { frame: 'closed', durableSeq: 5 },
+          data: { frame: 'closed', durableSeq: 4 },
         },
       ]);
       expect(request?.url).toBe('/channels/topic%3Atest/subscribe?afterSeq=4');

--- a/test/fixtures/cli-gateway/mock-fetch.mjs
+++ b/test/fixtures/cli-gateway/mock-fetch.mjs
@@ -19,7 +19,20 @@ globalThis.fetch = async (url, init = {}) => {
     })
   );
   const data = String(url).includes('/channels/')
-    ? { message: { id: 'chm:test' } }
+    ? {
+        message: { id: 'chm:test' },
+        run: {
+          id: 'chrun:test',
+          channelId: 'topic:test',
+          threadId: null,
+          requestMessageId: 'chm:test',
+          requesterId: 'actor:test',
+          state: 'submitted',
+          targets: [],
+          createdAt: '2026-08-12T00:00:00.000Z',
+          updatedAt: '2026-08-12T00:00:00.000Z',
+        },
+      }
     : {
         id: 'worker-session',
         type: 'terminal',


### PR DESCRIPTION
## Summary

- Adds one opaque Relay-owned async run per accepted routed channel post, with durable per-target outcomes and idempotent post replay.
- Correlates principal replies and lifecycle snapshots/subscriptions without provider runtime, turn, or item identifiers.
- Adds actor-scoped `GET /channels/:channelId/runs/:runId` and `relay-ide v1 channels run get`; preserves immutable channel/thread scope.

## Durability and security

- SQLite schema v15 adds run/target projections with CAS terminal transitions, bounded snapshot packing, settled retention, and orphan cleanup.
- Startup cancels unfinished runs with `server-restarted` rather than redelivering; late exact-turn reply mapping is bounded and anonymous Hermes `turn-0` remains fail-closed.
- Public read access requires `context:read` and exact channel scope; optional thread identity is exact-match only.

## Validation

- Focused/integrated #1391: 549 tests passed.
- Full suite: 480 files / 6,588 tests passed.
- `npm run check` passed (0 errors; existing warnings only).
- `npm run build` and `git diff --check` passed.

Closes #1391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel posts now return a durable run ID for tracking asynchronous processing.
  * Added run lifecycle updates, target status, approval information, and completion details.
  * Added `channels.run.get` to retrieve run status by channel and run ID.
  * Added idempotent retries and reliable correlation across replies, reconnects, and lifecycle events.

* **Documentation**
  * Documented asynchronous channel runs, lifecycle states, retries, retention, reconnect behavior, and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->