### PR TITLE
feat(chat): add semantic subscription filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ workflow.
 - Stream scoped channel replies through a durable, resumable
   `channels.subscribe` CLI gateway contract without per-message blocking waits
   (#1389)
+- Add bounded server-side semantic filters to durable channel subscriptions so
+  agent consumers can wait for principal or terminal replies without receiving
+  detail/tool traffic, while preserving safe resume cursors (#1390)
 - Correlate concurrent routed channel posts, replies, and terminal lifecycle
   updates through durable provider-neutral asynchronous run and target ids;
   idempotent post retries return the original run (#1391)

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -73,6 +73,11 @@ import {
   type RelayCliGatewayEnvelope,
   type RelayCliGatewayErrorCode,
 } from '../shared/cli-gateway-contract.js';
+import {
+  channelSubscriptionFilterValidationError,
+  normalizeChannelSubscriptionFilter,
+  type ChannelSubscriptionFilter,
+} from '../shared/channel-chat-protocol.js';
 import { retainOutputPredicateSuffix } from '../shared/cli-gateway-sessions-wait.js';
 import {
   gatewayCliInvalidArgumentError,
@@ -5353,6 +5358,12 @@ type ChannelCliValueFlag =
   | '--channel-id'
   | '--run-id'
   | '--thread-id'
+  | '--message-id'
+  | '--sender-id'
+  | '--mention-target-id'
+  | '--status'
+  | '--terminal-only'
+  | '--principal-only'
   | '--limit'
   | '--before-seq'
   | '--after-seq'
@@ -5440,6 +5451,51 @@ function validateChannelCliPagination(
       });
     }
   }
+}
+
+function readChannelSubscriptionFilter(
+  values: ReadonlyMap<ChannelCliValueFlag, string>
+): ChannelSubscriptionFilter | undefined {
+  const filter: ChannelSubscriptionFilter = {};
+  const stringFlags = [
+    ['--thread-id', 'threadId'],
+    ['--message-id', 'messageId'],
+    ['--sender-id', 'senderId'],
+    ['--mention-target-id', 'mentionTargetId'],
+    ['--status', 'status'],
+    ['--run-id', 'runId'],
+  ] as const;
+  for (const [flag, key] of stringFlags) {
+    const raw = values.get(flag);
+    if (raw === undefined) continue;
+    const value = raw.trim();
+    if (!value) {
+      gatewayInvalid('channels.subscribe', `${flag} must be non-empty`, {
+        field: key,
+      });
+    }
+    Object.assign(filter, { [key]: value });
+  }
+  for (const [flag, key] of [
+    ['--terminal-only', 'terminalOnly'],
+    ['--principal-only', 'principalOnly'],
+  ] as const) {
+    const value = values.get(flag);
+    if (value === undefined) continue;
+    if (value !== 'true' && value !== 'false') {
+      gatewayInvalid('channels.subscribe', `${flag} must be true or false`, {
+        field: key,
+        value,
+      });
+    }
+    Object.assign(filter, { [key]: value === 'true' });
+  }
+  if (Object.keys(filter).length === 0) return undefined;
+  const validationError = channelSubscriptionFilterValidationError(filter);
+  if (validationError) {
+    gatewayInvalid('channels.subscribe', validationError, { field: 'filter' });
+  }
+  return normalizeChannelSubscriptionFilter(filter);
 }
 
 function validateChannelPostCliInput(input: Record<string, unknown>): void {
@@ -5607,6 +5663,14 @@ async function runGatewayChannels(gatewayArgs: string[]): Promise<void> {
       '--after-seq',
       '--max-events',
       '--idle-timeout-ms',
+      '--thread-id',
+      '--message-id',
+      '--sender-id',
+      '--mention-target-id',
+      '--status',
+      '--run-id',
+      '--terminal-only',
+      '--principal-only',
     ]);
     const channelId = requiredChannelCliString(
       'channels.subscribe',
@@ -5636,11 +5700,13 @@ async function runGatewayChannels(gatewayArgs: string[]): Promise<void> {
     const afterSeq = readBoundedInt('--after-seq', 0, Number.MAX_SAFE_INTEGER);
     const maxEvents = readBoundedInt('--max-events', 1, 10000);
     const idleTimeoutMs = readBoundedInt('--idle-timeout-ms', 1, 300000);
+    const filter = readChannelSubscriptionFilter(values);
     return runGatewayChannelsSubscribe({
       channelId,
       ...(afterSeq !== undefined ? { afterSeq } : {}),
       ...(maxEvents !== undefined ? { maxEvents } : {}),
       ...(idleTimeoutMs !== undefined ? { idleTimeoutMs } : {}),
+      ...(filter ? { filter } : {}),
     });
   }
 
@@ -5731,6 +5797,7 @@ async function runGatewayChannelsSubscribe(input: {
   afterSeq?: number;
   maxEvents?: number;
   idleTimeoutMs?: number;
+  filter?: ChannelSubscriptionFilter;
 }): Promise<void> {
   const commandName = 'channels.subscribe' as const;
   const token = gatewayRequiredToken(commandName);
@@ -5738,6 +5805,11 @@ async function runGatewayChannelsSubscribe(input: {
   const query = new URLSearchParams();
   if (input.afterSeq !== undefined)
     query.set('afterSeq', String(input.afterSeq));
+  if (input.filter) {
+    for (const [key, value] of Object.entries(input.filter)) {
+      query.set(key, String(value));
+    }
+  }
   const controller = new AbortController();
   const stop = (): void => controller.abort();
   process.once('SIGINT', stop);
@@ -5745,7 +5817,7 @@ async function runGatewayChannelsSubscribe(input: {
   let res: Response;
   try {
     res = await fetch(
-      `http://127.0.0.1:${gatewayWsPort()}/channels/${encodeURIComponent(input.channelId)}/subscribe?${query.toString()}`,
+      `http://127.0.0.1:${gatewayWsPort()}/channels/${encodeURIComponent(input.channelId)}/subscribe${query.size ? `?${query}` : ''}`,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -110,6 +110,15 @@ frames carry a required reason plus retryability. A bounded consumer stops
 parsing immediately after its `--max-events` frame and cancels the upstream
 reader; stdout backpressure is drained rather than treated as a dropped frame.
 
+Agent consumers may request a bounded server-side semantic projection with
+thread (`root` or canonical root id), exact message, sender, mention target,
+message status, run id, terminal, and principal-prose filters. Predicates are
+ANDed. Filtering happens after the authenticated subscription boundary receives
+the hub event: the underlying durable cursor advances from the original event
+before any projected message/run rows are omitted. This preserves the
+register-before-replay handoff, replay gap behavior, and backpressure bounds;
+control frames and liveness heartbeats remain visible even when no row matches.
+
 ### Correlated asynchronous runs
 
 An accepted external `channels.post` that can route work creates one opaque,

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -145,6 +145,18 @@ stdout drain instead of dropping frames; a downstream closed pipe is treated as
 clean local cancellation and promptly cancels the upstream reader. The stream uses
 `context:read` plus the actor credential's exact `channelIds` scope.
 
+Subscriptions can reduce semantic noise at the server boundary without changing
+their resume semantics: `--thread-id <id|root>`, `--message-id`, `--sender-id`,
+`--mention-target-id`, `--status`, `--run-id`, `--terminal-only`, and
+`--principal-only` combine with AND. `root` selects top-level message/run
+scope; a concrete thread id selects that canonical root and its replies.
+`principal-only` excludes agent detail and image/tool rows; `terminal-only`
+selects terminal message or run state. A filtered-out committed row still
+advances the frame's `durableSeq`, so reconnecting from that value cannot skip
+a later matching row. Open, close, and heartbeat control frames are always
+delivered; snapshots retain their original truncation and cursor metadata while
+their message/run projections are filtered.
+
 ### Correlated async channel runs (#1391)
 
 `channels.post` returns an opaque Relay-owned `runId` for accepted routed work.

--- a/server/channel-subscription-router.ts
+++ b/server/channel-subscription-router.ts
@@ -1,7 +1,14 @@
 import { Router } from 'express';
 import type { Request, RequestHandler, Response } from 'express';
 
-import type { ChannelEventV1 } from '../shared/channel-chat-protocol.js';
+import {
+  channelAsyncRunMatchesSubscriptionFilter,
+  channelMessageMatchesSubscriptionFilter,
+  channelSubscriptionFilterValidationError,
+  normalizeChannelSubscriptionFilter,
+  type ChannelEventV1,
+  type ChannelSubscriptionFilter,
+} from '../shared/channel-chat-protocol.js';
 import { authenticatedCliGatewayActorCredential } from './cli-gateway-actor-auth.js';
 import type {
   ChannelEventSink,
@@ -62,6 +69,93 @@ function queryAfterSeq(req: Request): number | null | 'invalid' {
   }
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) ? parsed : 'invalid';
+}
+
+const SUBSCRIPTION_QUERY_KEYS = new Set([
+  'afterSeq',
+  'threadId',
+  'messageId',
+  'senderId',
+  'mentionTargetId',
+  'status',
+  'runId',
+  'terminalOnly',
+  'principalOnly',
+]);
+
+/** Decode the authenticated boundary once; duplicate/unknown keys fail closed. */
+function querySubscriptionFilter(
+  req: Request
+): ChannelSubscriptionFilter | 'invalid' {
+  const raw: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(req.query)) {
+    if (!SUBSCRIPTION_QUERY_KEYS.has(key) || Array.isArray(value))
+      return 'invalid';
+    if (key === 'afterSeq') continue;
+    if (typeof value !== 'string') return 'invalid';
+    if (key === 'terminalOnly' || key === 'principalOnly') {
+      if (value === 'true') raw[key] = true;
+      else if (value === 'false') raw[key] = false;
+      else return 'invalid';
+    } else {
+      raw[key] = value;
+    }
+  }
+  return channelSubscriptionFilterValidationError(raw) === undefined
+    ? normalizeChannelSubscriptionFilter(raw as ChannelSubscriptionFilter)
+    : 'invalid';
+}
+
+function filterIsEmpty(filter: ChannelSubscriptionFilter): boolean {
+  return Object.keys(filter).length === 0;
+}
+
+/**
+ * Preserve hub control and snapshot metadata while removing only row payloads.
+ * Cursor advancement happens before this function, from the original event.
+ */
+function projectEvent(
+  event: ChannelEventV1,
+  filter: ChannelSubscriptionFilter
+): ChannelEventV1 | null {
+  if (filterIsEmpty(filter)) return event;
+  switch (event.type) {
+    case 'channel-snapshot-v1':
+      return {
+        ...event,
+        messages: event.messages.filter((message) =>
+          channelMessageMatchesSubscriptionFilter(message, filter)
+        ),
+        ...(event.runs === undefined
+          ? {}
+          : {
+              runs: event.runs.filter((run) =>
+                channelAsyncRunMatchesSubscriptionFilter(run, filter)
+              ),
+            }),
+        // Semantic filters suppress deltas, so carrying an unfiltered in-flight
+        // reference would point at rows the actor never received.
+        inFlight: [],
+      };
+    case 'channel-message-created-v1':
+    case 'channel-message-updated-v1':
+    case 'channel-message-completed-v1':
+    case 'channel-message-edited-v1':
+    case 'channel-message-deleted-v1':
+      return channelMessageMatchesSubscriptionFilter(event.message, filter)
+        ? event
+        : null;
+    case 'channel-message-delta-v1':
+      // A delta has no durable row to evaluate and can expose provider/tool
+      // output, so a semantic projection never forwards it.
+      return null;
+    case 'channel-run-lifecycle-v1':
+      return channelAsyncRunMatchesSubscriptionFilter(event.run, filter)
+        ? event
+        : null;
+    case 'channel-resync-required-v1':
+      return event;
+  }
 }
 
 function requestHasContextRead(req: Request): boolean {
@@ -155,6 +249,16 @@ export function createChannelSubscriptionRouter(
           'INVALID_ARGUMENT',
           'afterSeq must be a non-negative safe integer',
           { field: 'afterSeq' }
+        );
+        return;
+      }
+      const filter = querySubscriptionFilter(req);
+      if (filter === 'invalid') {
+        sendError(
+          res,
+          400,
+          'INVALID_ARGUMENT',
+          'subscription filter has an invalid value'
         );
         return;
       }
@@ -328,14 +432,18 @@ export function createChannelSubscriptionRouter(
             finish('backpressure', undefined, true);
             return false;
           }
+          // This is intentionally before projection. A filtered subscription is
+          // a view over the same durable log, never a second cursor domain.
           durableSeq = advanceDurableCursor(durableSeq, event);
+          const projected = projectEvent(event, filter);
+          if (!projected) return true;
           return writeFrame({
             frame: 'event',
             schemaVersion: 1,
             channelId,
             sequence: sequence++,
             occurredAt: now().toISOString(),
-            payload: event,
+            payload: projected,
             durableSeq,
           });
         },

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -318,7 +318,9 @@ function subscriptionFilterStringIsValid(
     value.trim().length > 0 &&
     value.length <= CHANNEL_SUBSCRIPTION_FILTER_ID_MAX_CHARS &&
     (prefix === undefined ||
-      (value.startsWith(prefix) && value.length > prefix.length))
+      (value.startsWith(prefix) &&
+        value.length > prefix.length &&
+        value.slice(prefix.length).trim().length > 0))
   );
 }
 

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -27,6 +27,17 @@ export const CHANNEL_MESSAGE_BODY_MAX_BYTES = 256 * 1024;
 export const CHANNEL_AGENT_DETAIL_MAX_BYTES = 256 * 1024;
 /** Bounded display scalars carried with one agent-authored row. */
 export const CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS = 512;
+/** Individual opaque filter identifiers remain bounded independently. */
+export const CHANNEL_SUBSCRIPTION_FILTER_ID_MAX_CHARS = 512;
+/**
+ * The public schema permits five independently bounded opaque strings. A
+ * JavaScript character may expand to three UTF-8 bytes in the URL, and percent
+ * encoding can expand each such byte to three URL bytes. Keep the decoded
+ * aggregate ceiling above that worst-case schema-valid query shape (plus keys
+ * and JSON framing), so the authenticated boundary cannot reject it later.
+ */
+export const CHANNEL_SUBSCRIPTION_FILTER_MAX_BYTES =
+  CHANNEL_SUBSCRIPTION_FILTER_ID_MAX_CHARS * 5 * 3 * 3 + 1024;
 
 export type ChannelMessageId = `chm:${string}`;
 export type ChannelAttachmentId = `cha:${string}`;
@@ -100,12 +111,20 @@ export type ChannelMessagePart = ChannelImagePart;
 
 export type ChannelSenderKind = 'human' | 'agent' | 'system';
 export type ChannelMessageKind = 'message' | 'system';
-export type ChannelMessageStatus =
-  | 'streaming'
-  | 'complete'
-  | 'truncated'
-  | 'interrupted'
-  | 'failed';
+export const CHANNEL_MESSAGE_STATUSES = [
+  'streaming',
+  'complete',
+  'truncated',
+  'interrupted',
+  'failed',
+] as const;
+export type ChannelMessageStatus = (typeof CHANNEL_MESSAGE_STATUSES)[number];
+export const CHANNEL_TERMINAL_MESSAGE_STATUSES = [
+  'complete',
+  'truncated',
+  'interrupted',
+  'failed',
+] as const satisfies readonly ChannelMessageStatus[];
 export type ChannelTruncationReason =
   | 'size-limit'
   | 'missing-terminal'
@@ -237,6 +256,245 @@ export interface ChannelMessage {
   createdAt: string;
   updatedAt: string;
   completedAt?: string;
+}
+
+/**
+ * Server-enforced semantic narrowing for durable channel subscriptions.
+ *
+ * Every supplied predicate is ANDed. This is deliberately a flat, single-value
+ * filter: it keeps the URL/actor audit surface bounded and avoids turning the
+ * durable subscription lane into a query language. Omit it for the existing
+ * rich, unfiltered UI/diagnostics stream.
+ */
+export interface ChannelSubscriptionFilter {
+  /** A thread root id, or `'root'` for root-level messages and runs. */
+  threadId?: ChannelMessageId | 'root';
+  /** One exact durable message id. */
+  messageId?: ChannelMessageId;
+  /** One exact sender Actor id. */
+  senderId?: string;
+  /** One resolved profile Actor id or legacy provider id mentioned by a row. */
+  mentionTargetId?: string;
+  /** One exact message lifecycle state. */
+  status?: ChannelMessageStatus;
+  /** One Relay-owned correlated run id. */
+  runId?: ChannelAsyncRunId;
+  /** Keep only terminal message/run lifecycle states. */
+  terminalOnly?: boolean;
+  /** Keep principal prose rows, never detail/image activity rows. */
+  principalOnly?: boolean;
+}
+
+const CHANNEL_SUBSCRIPTION_FILTER_KEYS = new Set<
+  keyof ChannelSubscriptionFilter
+>([
+  'threadId',
+  'messageId',
+  'senderId',
+  'mentionTargetId',
+  'status',
+  'runId',
+  'terminalOnly',
+  'principalOnly',
+]);
+
+const TERMINAL_MESSAGE_STATUSES = new Set<ChannelMessageStatus>(
+  CHANNEL_TERMINAL_MESSAGE_STATUSES
+);
+const TERMINAL_RUN_STATES = new Set<ChannelAsyncRunState>([
+  'completed',
+  'failed',
+  'cancelled',
+  'rejected',
+]);
+
+function subscriptionFilterStringIsValid(
+  value: unknown,
+  prefix?: string
+): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.trim().length > 0 &&
+    value.length <= CHANNEL_SUBSCRIPTION_FILTER_ID_MAX_CHARS &&
+    (prefix === undefined ||
+      (value.startsWith(prefix) && value.length > prefix.length))
+  );
+}
+
+/**
+ * Returns a stable validation reason for the shared HTTP/CLI boundary.
+ * Callers must reject rather than silently discard malformed filter metadata.
+ */
+export function channelSubscriptionFilterValidationError(
+  value: unknown
+): string | undefined {
+  if (!isRecord(value)) return 'filter must be an object';
+  const unknown = Object.keys(value).find(
+    (key) =>
+      !CHANNEL_SUBSCRIPTION_FILTER_KEYS.has(
+        key as keyof ChannelSubscriptionFilter
+      )
+  );
+  if (unknown) return `${unknown} is not a supported subscription filter`;
+  const undefinedKey = Object.keys(value).find(
+    (key) => value[key] === undefined
+  );
+  if (undefinedKey) return `${undefinedKey} must not be undefined`;
+
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    return 'filter metadata must be serializable';
+  }
+  if (
+    new TextEncoder().encode(encoded).byteLength >
+    CHANNEL_SUBSCRIPTION_FILTER_MAX_BYTES
+  ) {
+    return `filter metadata exceeds ${CHANNEL_SUBSCRIPTION_FILTER_MAX_BYTES} bytes`;
+  }
+
+  if (
+    value.threadId !== undefined &&
+    value.threadId !== 'root' &&
+    !subscriptionFilterStringIsValid(value.threadId, 'chm:')
+  ) {
+    return 'threadId must be root or a non-empty chm: id';
+  }
+  if (
+    value.messageId !== undefined &&
+    !subscriptionFilterStringIsValid(value.messageId, 'chm:')
+  ) {
+    return 'messageId must be a non-empty chm: id';
+  }
+  for (const key of ['senderId', 'mentionTargetId'] as const) {
+    if (
+      value[key] !== undefined &&
+      !subscriptionFilterStringIsValid(value[key])
+    ) {
+      return `${key} must be a bounded non-empty string`;
+    }
+  }
+  if (
+    value.status !== undefined &&
+    (typeof value.status !== 'string' ||
+      !CHANNEL_MESSAGE_STATUSES.includes(value.status as ChannelMessageStatus))
+  ) {
+    return `status must be one of: ${CHANNEL_MESSAGE_STATUSES.join(', ')}`;
+  }
+  if (
+    value.runId !== undefined &&
+    !subscriptionFilterStringIsValid(value.runId, 'chrun:')
+  ) {
+    return 'runId must be a non-empty chrun: id';
+  }
+  for (const key of ['terminalOnly', 'principalOnly'] as const) {
+    if (value[key] !== undefined && typeof value[key] !== 'boolean') {
+      return `${key} must be boolean`;
+    }
+  }
+  return undefined;
+}
+
+export function isChannelSubscriptionFilter(
+  value: unknown
+): value is ChannelSubscriptionFilter {
+  return channelSubscriptionFilterValidationError(value) === undefined;
+}
+
+/**
+ * `false` means “do not narrow” for the two boolean predicates. Remove it
+ * before a subscription is classified, so an explicitly false-only filter is
+ * byte/event-equivalent to the unfiltered stream (including deltas).
+ */
+export function normalizeChannelSubscriptionFilter(
+  filter: ChannelSubscriptionFilter
+): ChannelSubscriptionFilter {
+  const { terminalOnly, principalOnly, ...predicates } = filter;
+  return {
+    ...predicates,
+    ...(terminalOnly === true ? { terminalOnly: true } : {}),
+    ...(principalOnly === true ? { principalOnly: true } : {}),
+  };
+}
+
+export function channelMessageIsPrincipalProse(
+  message: ChannelMessage
+): boolean {
+  return (
+    message.kind === 'message' &&
+    !isChannelMessageTombstone(message) &&
+    message.body.text.trim().length > 0 &&
+    message.agentDetail === undefined &&
+    (!message.parts || message.parts.length === 0)
+  );
+}
+
+export function channelMessageMatchesSubscriptionFilter(
+  message: ChannelMessage,
+  filter: ChannelSubscriptionFilter
+): boolean {
+  if (
+    filter.threadId !== undefined &&
+    (filter.threadId === 'root'
+      ? message.threadId !== null
+      : !(
+          (message.threadId === null && message.id === filter.threadId) ||
+          message.threadId === filter.threadId
+        ))
+  ) {
+    return false;
+  }
+  if (filter.messageId !== undefined && message.id !== filter.messageId)
+    return false;
+  if (filter.senderId !== undefined && message.sender.id !== filter.senderId)
+    return false;
+  if (
+    filter.mentionTargetId !== undefined &&
+    !message.mentions?.some(
+      (mention) =>
+        mention.profileId === filter.mentionTargetId ||
+        mention.providerId === filter.mentionTargetId
+    )
+  ) {
+    return false;
+  }
+  if (filter.status !== undefined && message.status !== filter.status)
+    return false;
+  if (filter.runId !== undefined && message.asyncRun?.runId !== filter.runId)
+    return false;
+  if (filter.terminalOnly && !TERMINAL_MESSAGE_STATUSES.has(message.status))
+    return false;
+  return !filter.principalOnly || channelMessageIsPrincipalProse(message);
+}
+
+/** Run projections never expose themselves through message-only filters. */
+export function channelAsyncRunMatchesSubscriptionFilter(
+  run: ChannelAsyncRun,
+  filter: ChannelSubscriptionFilter
+): boolean {
+  if (
+    filter.messageId !== undefined ||
+    filter.senderId !== undefined ||
+    filter.mentionTargetId !== undefined ||
+    filter.status !== undefined ||
+    filter.principalOnly === true
+  ) {
+    return false;
+  }
+  if (
+    filter.threadId !== undefined &&
+    (filter.threadId === 'root'
+      ? run.threadId !== null
+      : run.threadId === null
+        ? run.requestMessageId !== filter.threadId
+        : run.threadId !== filter.threadId)
+  ) {
+    return false;
+  }
+  if (filter.runId !== undefined && run.id !== filter.runId) return false;
+  return !filter.terminalOnly || TERMINAL_RUN_STATES.has(run.state);
 }
 
 export interface ChannelInFlightRef {
@@ -883,13 +1141,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 const SENDER_KINDS = new Set<string>(['human', 'agent', 'system']);
 const MESSAGE_KINDS = new Set<string>(['message', 'system']);
-const MESSAGE_STATUSES = new Set<string>([
-  'streaming',
-  'complete',
-  'truncated',
-  'interrupted',
-  'failed',
-]);
+const MESSAGE_STATUSES = new Set<string>(CHANNEL_MESSAGE_STATUSES);
 const BODY_FORMATS = new Set<string>(['markdown', 'text']);
 const IMAGE_MIMES = new Set<string>([
   'image/png',

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -189,6 +189,9 @@ export interface RelayJsonSchema {
   oneOf?: readonly RelayJsonSchema[];
   not?: RelayJsonSchema;
   format?: string;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
   minimum?: number;
   maximum?: number;
   default?: unknown;
@@ -3424,6 +3427,48 @@ const channelHistoryInputSchema: RelayJsonSchema = {
   not: { required: ['beforeSeq', 'afterSeq'] },
 };
 
+const channelSubscriptionOpaqueIdSchema: RelayJsonSchema = {
+  type: 'string',
+  minLength: 1,
+  maxLength: 512,
+  pattern: '\\S',
+};
+const channelSubscriptionMessageIdSchema: RelayJsonSchema = {
+  type: 'string',
+  minLength: 5,
+  maxLength: 512,
+  pattern: '^chm:.+',
+};
+const channelSubscriptionRunIdSchema: RelayJsonSchema = {
+  type: 'string',
+  minLength: 7,
+  maxLength: 512,
+  pattern: '^chrun:.+',
+};
+
+const channelSubscriptionFilterSchema: RelayJsonSchema = {
+  title: 'ChannelSubscriptionFilter',
+  description:
+    'Bounded semantic delivery filter. All supplied predicates are ANDed; omit for the rich unfiltered UI/diagnostics stream.',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    threadId: {
+      oneOf: [{ const: 'root' }, channelSubscriptionMessageIdSchema],
+    },
+    messageId: channelSubscriptionMessageIdSchema,
+    senderId: channelSubscriptionOpaqueIdSchema,
+    mentionTargetId: channelSubscriptionOpaqueIdSchema,
+    status: {
+      type: 'string',
+      enum: ['streaming', 'complete', 'truncated', 'interrupted', 'failed'],
+    },
+    runId: channelSubscriptionRunIdSchema,
+    terminalOnly: booleanSchema,
+    principalOnly: booleanSchema,
+  },
+};
+
 const channelSubscribeInputSchema: RelayJsonSchema = {
   title: 'ChannelsSubscribeInput',
   type: 'object',
@@ -3433,6 +3478,7 @@ const channelSubscribeInputSchema: RelayJsonSchema = {
     afterSeq: { type: 'integer', minimum: 0 },
     maxEvents: { type: 'integer', minimum: 1, maximum: 10000 },
     idleTimeoutMs: { type: 'integer', minimum: 1, maximum: 300000 },
+    filter: channelSubscriptionFilterSchema,
   },
   required: ['channelId'],
 };
@@ -6725,10 +6771,26 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       '<id>',
       '--after-seq',
       '<n>',
+      '--thread-id',
+      '<id|root>',
+      '--message-id',
+      '<id>',
+      '--sender-id',
+      '<id>',
+      '--mention-target-id',
+      '<id>',
+      '--status',
+      '<streaming|complete|truncated|interrupted|failed>',
+      '--run-id',
+      '<id>',
+      '--terminal-only',
+      '<true|false>',
+      '--principal-only',
+      '<true|false>',
       '--json',
     ],
     summary:
-      'Stream durable channel events after an exclusive sequence cursor; ephemeral deltas never advance the resume cursor.',
+      'Stream durable channel events after an exclusive sequence cursor, optionally narrowed server-side to bounded semantic reply predicates; ephemeral deltas never advance the resume cursor.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -3437,13 +3437,13 @@ const channelSubscriptionMessageIdSchema: RelayJsonSchema = {
   type: 'string',
   minLength: 5,
   maxLength: 512,
-  pattern: '^chm:.+',
+  pattern: '^chm:[\\s\\S]*\\S',
 };
 const channelSubscriptionRunIdSchema: RelayJsonSchema = {
   type: 'string',
   minLength: 7,
   maxLength: 512,
-  pattern: '^chrun:.+',
+  pattern: '^chrun:[\\s\\S]*\\S',
 };
 
 const channelSubscriptionFilterSchema: RelayJsonSchema = {

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -881,7 +881,10 @@ describe('ChannelSubscriptionFilter', () => {
     for (const filter of [
       { threadId: 'rooted' },
       { messageId: 'message:wrong-prefix' },
+      { threadId: 'chm:   ' },
+      { messageId: 'chm:\t' },
       { runId: 'run:wrong-prefix' },
+      { runId: 'chrun: \n' },
       { status: 'unknown' },
       { terminalOnly: 'true' },
       { extra: true },
@@ -889,6 +892,13 @@ describe('ChannelSubscriptionFilter', () => {
     ]) {
       expect(channelSubscriptionFilterValidationError(filter)).toBeDefined();
     }
+    expect(
+      channelSubscriptionFilterValidationError({
+        threadId: 'chm:root id',
+        messageId: 'chm:message id',
+        runId: 'chrun:run id',
+      })
+    ).toBeUndefined();
     // The aggregate runtime ceiling deliberately includes maximum-length
     // CJK/emoji values and their URL/JSON expansion, so schema-valid input
     // cannot be rejected later at the decoded boundary.

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   applyChannelEventV1,
+  channelAsyncRunMatchesSubscriptionFilter,
+  channelMessageMatchesSubscriptionFilter,
+  channelSubscriptionFilterValidationError,
+  normalizeChannelSubscriptionFilter,
+  CHANNEL_SUBSCRIPTION_FILTER_MAX_BYTES,
   CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
   CHANNEL_SEARCH_HIGHLIGHT_OPEN,
   parseChannelSearchSnippet,
@@ -9,6 +14,7 @@ import {
   isChannelEventV1,
   parseMentions,
   type ChannelEventV1,
+  type ChannelAsyncRun,
   type ChannelMessage,
   type ChannelMessageId,
   type ChannelReducerState,
@@ -842,6 +848,206 @@ describe('channel-message-deleted-v1', () => {
     );
     expect(renumbered.needsCatchup).toBe(true);
     expect(renumbered.byId['chm:1']?.body.text).toBe('hi');
+  });
+});
+
+describe('ChannelSubscriptionFilter', () => {
+  const run = (overrides: Partial<ChannelAsyncRun> = {}): ChannelAsyncRun => ({
+    id: 'chrun:review' as ChannelAsyncRun['id'],
+    channelId: CHANNEL,
+    threadId: null,
+    requestMessageId: 'chm:request' as ChannelMessageId,
+    requesterId: 'human:operator',
+    state: 'completed',
+    targets: [],
+    createdAt: '2026-08-12T00:00:00.000Z',
+    updatedAt: '2026-08-12T00:00:00.000Z',
+    ...overrides,
+  });
+
+  it('validates the bounded canonical filter and rejects malformed metadata', () => {
+    expect(
+      channelSubscriptionFilterValidationError({
+        threadId: 'chm:root',
+        messageId: 'chm:reply',
+        senderId: 'agent-profile:codex:default',
+        mentionTargetId: 'codex',
+        status: 'complete',
+        runId: 'chrun:review',
+        terminalOnly: true,
+        principalOnly: false,
+      })
+    ).toBeUndefined();
+    for (const filter of [
+      { threadId: 'rooted' },
+      { messageId: 'message:wrong-prefix' },
+      { runId: 'run:wrong-prefix' },
+      { status: 'unknown' },
+      { terminalOnly: 'true' },
+      { extra: true },
+      { senderId: 'x'.repeat(513) },
+    ]) {
+      expect(channelSubscriptionFilterValidationError(filter)).toBeDefined();
+    }
+    // The aggregate runtime ceiling deliberately includes maximum-length
+    // CJK/emoji values and their URL/JSON expansion, so schema-valid input
+    // cannot be rejected later at the decoded boundary.
+    expect(
+      channelSubscriptionFilterValidationError({
+        threadId: `chm:${'界'.repeat(508)}`,
+        messageId: `chm:${'語'.repeat(508)}`,
+        senderId: '漢'.repeat(512),
+        mentionTargetId: '🧪'.repeat(256),
+        runId: `chrun:${'字'.repeat(506)}`,
+        terminalOnly: true,
+        principalOnly: true,
+      })
+    ).toBeUndefined();
+    expect(
+      channelSubscriptionFilterValidationError({
+        senderId: 'x'.repeat(CHANNEL_SUBSCRIPTION_FILTER_MAX_BYTES),
+      })
+    ).toContain('exceeds');
+    expect(
+      normalizeChannelSubscriptionFilter({
+        terminalOnly: false,
+        principalOnly: false,
+      })
+    ).toEqual({});
+  });
+
+  it('ANDs message predicates and keeps principal semantics provider-neutral', () => {
+    const principal = message({
+      id: 'chm:reply' as ChannelMessageId,
+      threadId: 'chm:root' as ChannelMessageId,
+      sender: { kind: 'agent', id: 'agent-profile:codex:default' },
+      mentions: [{ raw: '@Codex', providerId: 'codex' }],
+      asyncRun: {
+        runId: 'chrun:review' as ChannelAsyncRun['id'],
+        targetId: 'agent-profile:codex:default',
+      },
+    });
+    const filter = {
+      threadId: 'chm:root' as ChannelMessageId,
+      messageId: 'chm:reply' as ChannelMessageId,
+      senderId: 'agent-profile:codex:default',
+      mentionTargetId: 'codex',
+      status: 'complete' as const,
+      runId: 'chrun:review' as ChannelAsyncRun['id'],
+      terminalOnly: true,
+      principalOnly: true,
+    };
+    expect(channelMessageMatchesSubscriptionFilter(principal, filter)).toBe(
+      true
+    );
+    expect(
+      channelMessageMatchesSubscriptionFilter(
+        message({
+          ...principal,
+          agentDetail: { itemId: 'detail', card: {} } as never,
+        }),
+        filter
+      )
+    ).toBe(false);
+    expect(
+      channelMessageMatchesSubscriptionFilter(
+        message({ ...principal, status: 'streaming' }),
+        filter
+      )
+    ).toBe(false);
+  });
+
+  it('treats root consistently and fail-closes lifecycle projections for message filters', () => {
+    const root = message({ id: 'chm:root' as ChannelMessageId });
+    const reply = message({
+      id: 'chm:reply' as ChannelMessageId,
+      threadId: root.id,
+    });
+    const sibling = message({
+      id: root.id,
+      threadId: 'chm:other-root' as ChannelMessageId,
+    });
+    expect(
+      channelMessageMatchesSubscriptionFilter(root, { threadId: 'root' })
+    ).toBe(true);
+    expect(
+      channelMessageMatchesSubscriptionFilter(root, {
+        threadId: 'chm:root' as ChannelMessageId,
+      })
+    ).toBe(true);
+    expect(
+      channelMessageMatchesSubscriptionFilter(reply, { threadId: root.id })
+    ).toBe(true);
+    expect(
+      channelMessageMatchesSubscriptionFilter(sibling, { threadId: root.id })
+    ).toBe(false);
+    expect(
+      channelAsyncRunMatchesSubscriptionFilter(
+        run({ requestMessageId: root.id }),
+        { threadId: root.id }
+      )
+    ).toBe(true);
+    expect(
+      channelAsyncRunMatchesSubscriptionFilter(
+        run({
+          threadId: root.id,
+          requestMessageId: 'chm:other-request' as ChannelMessageId,
+        }),
+        { threadId: root.id }
+      )
+    ).toBe(true);
+    expect(
+      channelAsyncRunMatchesSubscriptionFilter(
+        run({
+          threadId: 'chm:other-root' as ChannelMessageId,
+          requestMessageId: root.id,
+        }),
+        { threadId: root.id }
+      )
+    ).toBe(false);
+    expect(
+      channelAsyncRunMatchesSubscriptionFilter(
+        run({ requestMessageId: root.id }),
+        { threadId: 'root' }
+      )
+    ).toBe(true);
+    expect(
+      channelAsyncRunMatchesSubscriptionFilter(run(), { terminalOnly: true })
+    ).toBe(true);
+    expect(
+      channelAsyncRunMatchesSubscriptionFilter(run(), { principalOnly: false })
+    ).toBe(true);
+  });
+
+  it('only projects actual principal prose for created, completed, and deleted rows', () => {
+    const filter = { principalOnly: true };
+    expect(
+      channelMessageMatchesSubscriptionFilter(
+        message({ status: 'streaming' }),
+        filter
+      )
+    ).toBe(true);
+    expect(
+      channelMessageMatchesSubscriptionFilter(
+        message({ status: 'complete' }),
+        filter
+      )
+    ).toBe(true);
+    expect(
+      channelMessageMatchesSubscriptionFilter(
+        message({
+          body: { text: '', format: 'markdown' },
+          meta: { deletedAt: '2026-08-12T00:00:00.000Z' },
+        }),
+        filter
+      )
+    ).toBe(false);
+    expect(
+      channelMessageMatchesSubscriptionFilter(
+        message({ body: { text: '   ', format: 'markdown' } }),
+        filter
+      )
+    ).toBe(false);
   });
 });
 

--- a/test/channel-subscription-routes.test.ts
+++ b/test/channel-subscription-routes.test.ts
@@ -75,6 +75,9 @@ describe('channel subscription route', () => {
       'status=complete&status=failed',
       'unknownFilter=value',
       'terminalOnly=1',
+      'threadId=chm%3A%20%20%20',
+      'messageId=chm%3A%09',
+      'runId=chrun%3A%20%0A',
     ]) {
       const response = await fetch(
         `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?${query}`,

--- a/test/channel-subscription-routes.test.ts
+++ b/test/channel-subscription-routes.test.ts
@@ -43,6 +43,7 @@ async function listen(input: {
     createChannelSubscriptionRouter({
       hub,
       requireSubscribeAuth: (_req, _res, next) => next(),
+      now: () => new Date('2026-08-12T00:00:00.000Z'),
       heartbeatMs: input.heartbeatMs ?? 60_000,
       ...(input.drainTimeoutMs !== undefined
         ? { drainTimeoutMs: input.drainTimeoutMs }
@@ -62,6 +63,339 @@ async function listen(input: {
 }
 
 describe('channel subscription route', () => {
+  it('rejects duplicate, unknown, and malformed filter query values before subscribing', async () => {
+    let subscribed = false;
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: () => {
+        subscribed = true;
+      },
+    });
+    for (const query of [
+      'status=complete&status=failed',
+      'unknownFilter=value',
+      'terminalOnly=1',
+    ]) {
+      const response = await fetch(
+        `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?${query}`,
+        { headers: { 'x-relay-cli-gateway': 'v1' } }
+      );
+      expect(response.status).toBe(400);
+    }
+    expect(subscribed).toBe(false);
+  });
+
+  it('projects semantic replies without changing the durable cursor domain', async () => {
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: (sink) => {
+        sink.send({
+          type: 'channel-message-created-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-12T00:00:00.000Z',
+          message: {
+            id: 'chm:detail',
+            channelId: 'topic:a',
+            seq: 5,
+            kind: 'message',
+            status: 'streaming',
+            sender: { kind: 'agent', id: 'agent:one' },
+            body: { text: 'tool output', format: 'markdown' },
+            threadId: null,
+            parentMessageId: null,
+            agentDetail: {
+              itemId: 'item:tool',
+              card: { type: 'tool', name: 'x' },
+            },
+            createdAt: '2026-08-12T00:00:00.000Z',
+            updatedAt: '2026-08-12T00:00:00.000Z',
+          } as ChannelMessage,
+        });
+        sink.send({
+          type: 'channel-message-delta-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-12T00:00:00.000Z',
+          messageId: 'chm:detail',
+          deltaIndex: 1,
+          delta: { text: ' more tool output' },
+        });
+        sink.send({
+          type: 'channel-message-created-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-12T00:00:00.000Z',
+          message: {
+            id: 'chm:reply',
+            channelId: 'topic:a',
+            seq: 6,
+            kind: 'message',
+            status: 'complete',
+            sender: { kind: 'agent', id: 'agent:one' },
+            body: { text: 'semantic answer', format: 'markdown' },
+            threadId: null,
+            parentMessageId: null,
+            createdAt: '2026-08-12T00:00:00.000Z',
+            updatedAt: '2026-08-12T00:00:00.000Z',
+          } as ChannelMessage,
+        });
+        sink.close({ code: 'transport-closed' });
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=4&terminalOnly=true&principalOnly=true`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+
+    expect(frames.map((frame) => frame.durableSeq)).toEqual([4, 6, 6]);
+    expect(frames).toMatchObject([
+      { frame: 'open' },
+      {
+        frame: 'event',
+        payload: {
+          type: 'channel-message-created-v1',
+          message: { id: 'chm:reply', body: { text: 'semantic answer' } },
+        },
+      },
+      { frame: 'closed' },
+    ]);
+    expect(JSON.stringify(frames)).not.toContain('tool output');
+  });
+
+  it('projects snapshot rows but preserves its original cursor and replay metadata', async () => {
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: (sink) => {
+        sink.send({
+          type: 'channel-snapshot-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-12T00:00:00.000Z',
+          mode: 'catchup',
+          messages: [
+            {
+              id: 'chm:unmatched',
+              seq: 5,
+              kind: 'message',
+              status: 'streaming',
+              sender: { kind: 'agent', id: 'agent:one' },
+              threadId: null,
+              parentMessageId: null,
+              body: { text: 'intermediate', format: 'markdown' },
+            },
+            {
+              id: 'chm:matched',
+              seq: 6,
+              kind: 'message',
+              status: 'complete',
+              sender: { kind: 'agent', id: 'agent:one' },
+              threadId: null,
+              parentMessageId: null,
+              body: { text: 'answer', format: 'markdown' },
+            },
+          ] as ChannelMessage[],
+          runs: [
+            {
+              id: 'chrun:included',
+              channelId: 'topic:a',
+              threadId: null,
+              requestMessageId: 'chm:request',
+              requesterId: 'human:one',
+              state: 'completed',
+              targets: [],
+              createdAt: '2026-08-12T00:00:00.000Z',
+              updatedAt: '2026-08-12T00:00:00.000Z',
+            },
+          ],
+          members: [],
+          latestSeq: 9,
+          inFlight: [{ messageId: 'chm:unmatched', deltaIndex: 3 }],
+          truncated: false,
+        });
+        sink.close({ code: 'transport-closed' });
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?status=complete&terminalOnly=true`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(frames.map((frame) => frame.durableSeq)).toEqual([0, 9, 9]);
+    expect(frames[1].payload).toMatchObject({
+      type: 'channel-snapshot-v1',
+      messages: [{ id: 'chm:matched' }],
+      runs: [],
+      latestSeq: 9,
+      inFlight: [],
+      truncated: false,
+    });
+  });
+
+  it('treats explicit false booleans as the exact unfiltered stream', async () => {
+    const subscribe = (sink: ChannelEventSink) => {
+      sink.send({
+        type: 'channel-message-delta-v1',
+        channelId: 'topic:a',
+        timestamp: '2026-08-12T00:00:00.000Z',
+        messageId: 'chm:stream',
+        deltaIndex: 1,
+        delta: { text: 'delta' },
+      });
+      sink.close({ code: 'transport-closed' });
+    };
+    const unfilteredPort = await listen({ channelIds: ['topic:a'], subscribe });
+    const falsePort = await listen({ channelIds: ['topic:a'], subscribe });
+    const headers = { 'x-relay-cli-gateway': 'v1' };
+    const [unfiltered, falseOnly] = await Promise.all([
+      fetch(`http://127.0.0.1:${unfilteredPort}/channels/topic%3Aa/subscribe`, {
+        headers,
+      }).then((response) => response.text()),
+      fetch(
+        `http://127.0.0.1:${falsePort}/channels/topic%3Aa/subscribe?terminalOnly=false&principalOnly=false`,
+        { headers }
+      ).then((response) => response.text()),
+    ]);
+    expect(falseOnly).toBe(unfiltered);
+  });
+
+  it('projects only prose created/completed rows, never deleted tombstones', async () => {
+    const message = (
+      id: string,
+      seq: number,
+      status: 'streaming' | 'complete',
+      text: string,
+      meta?: Record<string, unknown>
+    ) =>
+      ({
+        id,
+        channelId: 'topic:a',
+        seq,
+        kind: 'message',
+        status,
+        sender: { kind: 'human', id: 'human:one' },
+        body: { text, format: 'markdown' },
+        threadId: null,
+        parentMessageId: null,
+        createdAt: '2026-08-12T00:00:00.000Z',
+        ...(meta ? { meta } : {}),
+      }) as ChannelMessage;
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: (sink) => {
+        sink.send({
+          type: 'channel-message-created-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-12T00:00:00.000Z',
+          message: message('chm:created', 1, 'streaming', 'draft'),
+        });
+        sink.send({
+          type: 'channel-message-completed-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-12T00:00:00.000Z',
+          message: message('chm:completed', 1, 'complete', 'answer'),
+        });
+        sink.send({
+          type: 'channel-message-deleted-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-12T00:00:00.000Z',
+          message: message('chm:deleted', 2, 'complete', '', {
+            deletedAt: '2026-08-12T00:00:00.000Z',
+          }),
+        });
+        sink.close({ code: 'transport-closed' });
+      },
+    });
+    const frames = (
+      await fetch(
+        `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?principalOnly=true`,
+        { headers: { 'x-relay-cli-gateway': 'v1' } }
+      ).then((response) => response.text())
+    )
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(
+      frames
+        .filter((frame) => frame.frame === 'event')
+        .map((frame) => frame.payload.message.id)
+    ).toEqual(['chm:created', 'chm:completed']);
+    // Created rows advance the durable append cursor; lifecycle replacements
+    // retain it even when their semantic projection is suppressed.
+    expect(frames.map((frame) => frame.durableSeq)).toEqual([0, 1, 1, 1]);
+  });
+
+  it('keeps heartbeat control frames when no semantic row matches', async () => {
+    const port = await listen({
+      channelIds: ['topic:a'],
+      heartbeatMs: 2,
+      subscribe: (sink) => {
+        sink.send({
+          type: 'channel-message-created-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-12T00:00:00.000Z',
+          message: { seq: 5, status: 'streaming' } as ChannelMessage,
+        });
+        setTimeout(() => sink.close({ code: 'transport-closed' }), 12);
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=4&status=complete`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(frames.map((frame) => frame.durableSeq)).toContain(5);
+    expect(
+      frames.some((frame) => frame.payload?.type === 'channel-heartbeat-v1')
+    ).toBe(true);
+    expect(
+      frames.some(
+        (frame) => frame.payload?.type === 'channel-message-created-v1'
+      )
+    ).toBe(false);
+  });
+
+  it('suppresses lifecycle projections under message-only filters', async () => {
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: (sink) => {
+        sink.send({
+          type: 'channel-run-lifecycle-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-12T00:00:00.000Z',
+          run: {
+            id: 'chrun:secret',
+            channelId: 'topic:a',
+            threadId: null,
+            requestMessageId: 'chm:request',
+            requesterId: 'human:one',
+            state: 'completed',
+            targets: [],
+            createdAt: '2026-08-12T00:00:00.000Z',
+            updatedAt: '2026-08-12T00:00:00.000Z',
+          },
+        });
+        sink.close({ code: 'transport-closed' });
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?senderId=agent%3Aone`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(frames.map((frame) => frame.frame)).toEqual(['open', 'closed']);
+    expect(JSON.stringify(frames)).not.toContain('chrun:secret');
+  });
+
   it('rejects an actor outside the exact channel scope before subscribing', async () => {
     let subscribed = false;
     const port = await listen({

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -75,6 +75,18 @@ function schemaNumberBoundsMatch(
   return aboveMinimum && belowMaximum;
 }
 
+function schemaStringBoundsMatch(
+  schema: RelayJsonSchema,
+  value: unknown
+): boolean {
+  if (schema.type !== 'string' || typeof value !== 'string') return true;
+  return (
+    (schema.minLength === undefined || value.length >= schema.minLength) &&
+    (schema.maxLength === undefined || value.length <= schema.maxLength) &&
+    (schema.pattern === undefined || new RegExp(schema.pattern).test(value))
+  );
+}
+
 function schemaObjectPropertiesMatch(
   schema: RelayJsonSchema,
   value: unknown
@@ -101,6 +113,7 @@ function schemaMatches(schema: RelayJsonSchema, value: unknown): boolean {
     (!schema.enum || schema.enum.includes(value as string)) &&
     schemaRequiredMatches(schema, value) &&
     schemaNumberBoundsMatch(schema, value) &&
+    schemaStringBoundsMatch(schema, value) &&
     schemaObjectPropertiesMatch(schema, value);
   if (!scalarMatches) return false;
   if (schema.anyOf?.some((branch) => schemaMatches(branch, value)) === false) {
@@ -321,12 +334,25 @@ describe('CLI gateway contract', () => {
         afterSeq: 0,
         maxEvents: 10,
         idleTimeoutMs: 1000,
+        filter: {
+          threadId: 'root',
+          senderId: 'agent-profile:codex:default',
+          status: 'complete',
+          terminalOnly: true,
+          principalOnly: true,
+        },
       })
     ).toBe(true);
     for (const input of [
       { channelId: 'channel-1', afterSeq: -1 },
       { channelId: 'channel-1', maxEvents: 0 },
       { channelId: 'channel-1', idleTimeoutMs: 300001 },
+      { channelId: 'channel-1', filter: { status: 'not-a-status' } },
+      { channelId: 'channel-1', filter: { threadId: 'not-a-thread' } },
+      { channelId: 'channel-1', filter: { messageId: 'chm:' } },
+      { channelId: 'channel-1', filter: { runId: 'chrun:' } },
+      { channelId: 'channel-1', filter: { senderId: '   ' } },
+      { channelId: 'channel-1', filter: { unknown: true } },
       { channelId: 'channel-1', unknown: true },
     ]) {
       expect(schemaAcceptsCommandInput('channels.subscribe', input)).toBe(

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -350,7 +350,10 @@ describe('CLI gateway contract', () => {
       { channelId: 'channel-1', filter: { status: 'not-a-status' } },
       { channelId: 'channel-1', filter: { threadId: 'not-a-thread' } },
       { channelId: 'channel-1', filter: { messageId: 'chm:' } },
+      { channelId: 'channel-1', filter: { threadId: 'chm:   ' } },
+      { channelId: 'channel-1', filter: { messageId: 'chm:\t' } },
       { channelId: 'channel-1', filter: { runId: 'chrun:' } },
+      { channelId: 'channel-1', filter: { runId: 'chrun: \n' } },
       { channelId: 'channel-1', filter: { senderId: '   ' } },
       { channelId: 'channel-1', filter: { unknown: true } },
       { channelId: 'channel-1', unknown: true },
@@ -359,6 +362,12 @@ describe('CLI gateway contract', () => {
         false
       );
     }
+    expect(
+      schemaAcceptsCommandInput('channels.subscribe', {
+        channelId: 'channel-1',
+        filter: { messageId: 'chm:message id', runId: 'chrun:run id' },
+      })
+    ).toBe(true);
     expect(commandSpec('channels.subscribe').outputSchema).toMatchObject({
       properties: {
         data: {

--- a/test/cli-gateway/channels-subscribe.test.ts
+++ b/test/cli-gateway/channels-subscribe.test.ts
@@ -101,10 +101,13 @@ describe('channels.subscribe CLI gateway command', () => {
 
   it.each([
     ['--thread-id', 'not-a-channel-message'],
+    ['--thread-id', 'chm:   '],
     ['--message-id', 'message:wrong-prefix'],
+    ['--message-id', 'chm:\t'],
     ['--status', 'unknown'],
     ['--terminal-only', '1'],
     ['--principal-only', 'TRUE'],
+    ['--run-id', 'chrun: \n'],
   ])(
     'rejects malformed bounded filter %s=%s before opening a stream',
     async (flag, value) => {

--- a/test/cli-gateway/channels-subscribe.test.ts
+++ b/test/cli-gateway/channels-subscribe.test.ts
@@ -78,10 +78,58 @@ describe('channels.subscribe CLI gateway command', () => {
         '<id>',
         '--after-seq',
         '<n>',
+        '--thread-id',
+        '<id|root>',
+        '--message-id',
+        '<id>',
+        '--sender-id',
+        '<id>',
+        '--mention-target-id',
+        '<id>',
+        '--status',
+        '<streaming|complete|truncated|interrupted|failed>',
+        '--run-id',
+        '<id>',
+        '--terminal-only',
+        '<true|false>',
+        '--principal-only',
+        '<true|false>',
         '--json',
       ],
     });
   });
+
+  it.each([
+    ['--thread-id', 'not-a-channel-message'],
+    ['--message-id', 'message:wrong-prefix'],
+    ['--status', 'unknown'],
+    ['--terminal-only', '1'],
+    ['--principal-only', 'TRUE'],
+  ])(
+    'rejects malformed bounded filter %s=%s before opening a stream',
+    async (flag, value) => {
+      await expect(
+        runCli(
+          [
+            'v1',
+            'channels',
+            'subscribe',
+            '--channel-id',
+            'topic:test',
+            flag,
+            value,
+            '--json',
+          ],
+          {
+            ...process.env,
+            RELAY_IDE_PORT: '1',
+            RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.test.[REDACTED]',
+            RELAY_IDE_BROWSER_TOKEN: '',
+          }
+        )
+      ).rejects.toThrow('INVALID_ARGUMENT');
+    }
+  );
 
   it('forwards frames incrementally with actor auth and an exclusive cursor', async () => {
     let request: http.IncomingMessage | undefined;
@@ -114,6 +162,12 @@ describe('channels.subscribe CLI gateway command', () => {
           'topic:test',
           '--after-seq',
           '4',
+          '--thread-id',
+          'root',
+          '--status',
+          'complete',
+          '--principal-only',
+          'true',
           '--json',
         ],
         {
@@ -151,13 +205,57 @@ describe('channels.subscribe CLI gateway command', () => {
           data: { frame: 'closed', durableSeq: 4 },
         },
       ]);
-      expect(request?.url).toBe('/channels/topic%3Atest/subscribe?afterSeq=4');
+      expect(request?.url).toBe(
+        '/channels/topic%3Atest/subscribe?afterSeq=4&threadId=root&status=complete&principalOnly=true'
+      );
       expect(request?.headers).toMatchObject({
         'x-relay-cli-gateway': 'v1',
         'x-relay-cli-command': 'channels.subscribe',
         'x-relay-cli-actor-token': 'v1',
         'x-relay-capabilities': 'context:read',
       });
+    } finally {
+      server.close();
+    }
+  });
+
+  it('omits false-only predicates so they retain the unfiltered subscription contract', async () => {
+    let request: http.IncomingMessage | undefined;
+    const server = http.createServer((req, res) => {
+      request = req;
+      res.writeHead(200, { 'content-type': 'application/x-ndjson' });
+      res.end(
+        `${JSON.stringify({ schemaVersion: 1, frame: 'closed', channelId: 'topic:test', sequence: 0, occurredAt: '2026-08-11T00:00:02.000Z', durableSeq: 0, reason: 'normal', retryable: false })}\n`
+      );
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve)
+    );
+    const address = server.address();
+    if (!address || typeof address === 'string')
+      throw new Error('missing port');
+    try {
+      await runCli(
+        [
+          'v1',
+          'channels',
+          'subscribe',
+          '--channel-id',
+          'topic:test',
+          '--terminal-only',
+          'false',
+          '--principal-only',
+          'false',
+          '--json',
+        ],
+        {
+          ...process.env,
+          RELAY_IDE_PORT: String(address.port),
+          RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.test.[REDACTED]',
+          RELAY_IDE_BROWSER_TOKEN: '',
+        }
+      );
+      expect(request?.url).toBe('/channels/topic%3Atest/subscribe');
     } finally {
       server.close();
     }


### PR DESCRIPTION
## Summary

- Adds a canonical, bounded `ChannelSubscriptionFilter` to `channels.subscribe` and the v1 CLI.
- Applies filter matching after the authenticated hub cursor advances: suppressed durable rows still advance `durableSeq`, while matching rows remain replay-safe.
- Preserves control frames, register-before-replay, backpressure, revocation checks, and unfiltered byte behavior.
- Enforces thread/root and async-run scope semantics, principal/terminal narrowing, strict duplicate/empty/unknown input rejection, and actor `context:read`/exact-channel scope.
- Filtered snapshots omit unsafe `inFlight` references; false-only booleans normalize to the unfiltered stream.
- Covers maximum schema-valid UTF-8/emoji filter metadata plus a bounded oversized runtime rejection.

## Validation

- Focused subscription suites: 84 tests passed.
- Full suite: 480 files, 6,606 tests passed.
- `npm run check` passed (existing warnings only).
- `npm run build` passed.
- `git diff --check` passed.

Closes #1390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added semantic filters for channel subscriptions, including thread, message, sender, mention target, status, run, terminal-only, and principal-only criteria.
  - Added corresponding CLI options with input validation and combined filtering support.
  - Filtered subscriptions preserve cursors, replay behavior, control frames, heartbeats, and backpressure.

- **Documentation**
  - Documented subscription filters, supported criteria, and filtering behavior.

- **Tests**
  - Expanded coverage for filter validation, projections, cursor handling, CLI options, and schema constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->