### PR TITLE
fix(chat): make subscription resume duplicate-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ workflow.
 
 #### Fixed
 
+- Filtered channel subscriptions now resume without duplicate delivery by
+  applying streamed catch-up state replacements to already-known messages
+  (#1398)
 - Terminalize completion callbacks to unavailable requester profiles as durable,
   inspectable `undeliverable` rows instead of repeatedly retrying or spawning a
   fabricated external requester runtime; scoped external actors continue to

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -155,7 +155,13 @@ selects terminal message or run state. A filtered-out committed row still
 advances the frame's `durableSeq`, so reconnecting from that value cannot skip
 a later matching row. Open, close, and heartbeat control frames are always
 delivered; snapshots retain their original truncation and cursor metadata while
-their message/run projections are filtered.
+their message/run projections are filtered. On an explicit resume,
+`channel-snapshot-v1.messages` contains only durable rows with `seq > afterSeq`.
+An optional `stateReplacements` collection carries authoritative updates for
+already-acknowledged rows (such as a stream that completed while disconnected);
+each entry is a state mutation, not a new delivery, and never advances
+`durableSeq`. Consumers that keep a timeline apply a replacement by existing
+message id/seq; consumers that only react to new work must read `messages`.
 
 ### Correlated async channel runs (#1391)
 

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -385,6 +385,9 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       : [];
     let mode: 'full' | 'catchup';
     let assembled: { rows: ChannelMessage[]; truncated: boolean };
+    // Replacements update rows the reconnecting client already acknowledges.
+    // They deliberately ride a separate snapshot field from fresh durable rows.
+    let resyncRows: ChannelMessage[] = [];
     // The head advertised to the client. Normally the true channel head; capped
     // to the last row actually delivered when a catch-up is byte-truncated, so
     // the reducer's `lastSeq` never skips undelivered rows.
@@ -440,10 +443,10 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
         remainingBytes > 0
           ? assembleWithBudget(resync, 'tail', remainingBytes, false)
           : { rows: [], truncated: resync.length > 0, bytes: 0 };
+      resyncRows = resyncAssembled.rows;
       assembled = {
-        rows: [...resyncAssembled.rows, ...freshAssembled.rows].sort(
-          (a, b) => a.seq - b.seq
-        ),
+        // `messages` is exclusively durable progress after `sinceSeq`.
+        rows: freshAssembled.rows,
         truncated: freshAssembled.truncated || resyncAssembled.truncated,
       };
       // Only a fresh-row truncation leaves an undelivered seq above the cursor.
@@ -455,22 +458,34 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       }
     }
 
-    const rows = assembled.rows;
-
     // Overlay the hub's in-memory accumulated text onto streaming rows — it is
     // authoritative over the DB flush lag — and record each open stream's index.
     // Any pending (accumulated-but-unemitted) delta text was flushed before this
     // read (see flushPendingForChannel), so `acc.deltaIndex` is the exact index
     // whose text is already reflected in `acc.text`.
     const inFlight: ChannelInFlightRef[] = [];
-    const messages = rows.map((message) => {
+    const materialize = (
+      message: ChannelMessage
+    ): {
+      message: ChannelMessage;
+      inFlight?: ChannelInFlightRef;
+    } => {
       const acc = accumulators.get(message.id);
       if (acc && message.status === 'streaming') {
-        inFlight.push({ messageId: message.id, deltaIndex: acc.deltaIndex });
-        return { ...message, body: { ...message.body, text: acc.text } };
+        const ref = { messageId: message.id, deltaIndex: acc.deltaIndex };
+        return {
+          message: { ...message, body: { ...message.body, text: acc.text } },
+          inFlight: ref,
+        };
       }
-      return message;
+      return { message };
+    };
+    const messages = assembled.rows.map((row) => {
+      const materialized = materialize(row);
+      if (materialized.inFlight) inFlight.push(materialized.inFlight);
+      return materialized.message;
     });
+    const stateReplacements = resyncRows.map(materialize);
 
     const runs: ChannelAsyncRun[] = [];
     let runBytes = 0;
@@ -494,6 +509,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       timestamp: nowIso(),
       mode,
       messages,
+      ...(stateReplacements.length > 0 ? { stateReplacements } : {}),
       runs,
       members,
       latestSeq: snapshotLatestSeq,
@@ -605,6 +621,18 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       sub.snapshotLatestSeq = snapshot.latestSeq;
       for (const ref of snapshot.inFlight) {
         sub.snapshotInFlight.set(ref.messageId, ref.deltaIndex);
+      }
+      // Catch-up replacements deliberately stay out of `messages`, but an
+      // active replacement still carries the authoritative stream cursor. Seed
+      // the connect-time dedupe map from it too, otherwise the queued flush
+      // which caused the replacement is re-delivered after the snapshot.
+      for (const replacement of snapshot.stateReplacements ?? []) {
+        if (replacement.inFlight) {
+          sub.snapshotInFlight.set(
+            replacement.inFlight.messageId,
+            replacement.inFlight.deltaIndex
+          );
+        }
       }
     }
     deliver(sub, snapshot);

--- a/server/channel-subscription-router.ts
+++ b/server/channel-subscription-router.ts
@@ -118,14 +118,32 @@ function projectEvent(
   event: ChannelEventV1,
   filter: ChannelSubscriptionFilter
 ): ChannelEventV1 | null {
-  if (filterIsEmpty(filter)) return event;
+  if (event.type !== 'channel-snapshot-v1' && filterIsEmpty(filter)) {
+    return event;
+  }
   switch (event.type) {
-    case 'channel-snapshot-v1':
+    case 'channel-snapshot-v1': {
+      if (filterIsEmpty(filter)) {
+        return event;
+      }
       return {
         ...event,
         messages: event.messages.filter((message) =>
           channelMessageMatchesSubscriptionFilter(message, filter)
         ),
+        ...(event.stateReplacements === undefined
+          ? {}
+          : {
+              // Replacements are state mutations, not new deliveries. They
+              // still obey semantic visibility, so a filtered consumer never
+              // receives a row it would not be allowed to observe.
+              stateReplacements: event.stateReplacements.filter((replacement) =>
+                channelMessageMatchesSubscriptionFilter(
+                  replacement.message,
+                  filter
+                )
+              ),
+            }),
         ...(event.runs === undefined
           ? {}
           : {
@@ -137,6 +155,7 @@ function projectEvent(
         // reference would point at rows the actor never received.
         inFlight: [],
       };
+    }
     case 'channel-message-created-v1':
     case 'channel-message-updated-v1':
     case 'channel-message-completed-v1':

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -1039,12 +1039,33 @@ interface ChannelEventBaseV1 {
   timestamp: string;
 }
 
+/**
+ * An authoritative in-place refresh for a row at or below a reconnect cursor.
+ *
+ * Catch-up `messages` are exclusively durable progress after that cursor. A
+ * state replacement instead updates a row the client already has (for example
+ * a stream that completed while it was away), so it must never create a new
+ * timeline item or advance the durable cursor.
+ */
+export interface ChannelSnapshotStateReplacementV1 {
+  /** Full current durable row, keyed by the row already held by the client. */
+  message: ChannelMessage;
+  /** Present only when the replacement is an active stream with a live delta cursor. */
+  inFlight?: ChannelInFlightRef;
+}
+
 export interface ChannelSnapshotEventV1 extends ChannelEventBaseV1 {
   type: 'channel-snapshot-v1';
   /** full: replace state; catchup: merge by seq/id */
   mode: 'full' | 'catchup';
   /** seq-ascending; streaming rows carry accumulated in-memory text */
   messages: ChannelMessage[];
+  /**
+   * Catch-up-only in-place row refreshes. Kept distinct from `messages` so an
+   * exclusive reconnect cursor cannot mistake a changed old row for a replayed
+   * durable delivery. Older hubs omit this optional additive field.
+   */
+  stateReplacements?: ChannelSnapshotStateReplacementV1[];
   /** Durable current run projections; reconnect replaces this map when present. */
   runs?: ChannelAsyncRun[];
   members: ChannelMemberRef[];
@@ -1367,6 +1388,21 @@ function isInFlightArray(value: unknown): value is ChannelInFlightRef[] {
   );
 }
 
+function isSnapshotStateReplacement(
+  value: unknown
+): value is ChannelSnapshotStateReplacementV1 {
+  return (
+    isRecord(value) &&
+    isChannelMessage(value.message) &&
+    (value.inFlight === undefined ||
+      (value.message.status === 'streaming' &&
+        isRecord(value.inFlight) &&
+        typeof value.inFlight.messageId === 'string' &&
+        typeof value.inFlight.deltaIndex === 'number' &&
+        value.inFlight.messageId === value.message.id))
+  );
+}
+
 export function isChannelAsyncRun(value: unknown): value is ChannelAsyncRun {
   return (
     isRecord(value) &&
@@ -1404,6 +1440,10 @@ export function isChannelEventV1(value: unknown): value is ChannelEventV1 {
       return (
         (value.mode === 'full' || value.mode === 'catchup') &&
         isMessageArray(value.messages) &&
+        (value.stateReplacements === undefined ||
+          (value.mode === 'catchup' &&
+            Array.isArray(value.stateReplacements) &&
+            value.stateReplacements.every(isSnapshotStateReplacement))) &&
         (value.runs === undefined ||
           (Array.isArray(value.runs) && value.runs.every(isChannelAsyncRun))) &&
         Array.isArray(value.members) &&
@@ -1512,6 +1552,48 @@ function inFlightFromRefs(
   return map;
 }
 
+function applySnapshotStateReplacements(
+  messages: ChannelMessage[],
+  byId: Record<string, ChannelMessage>,
+  existingById: Record<string, ChannelMessage>,
+  inFlightDelta: Record<string, number>,
+  quarantined: Record<string, true>,
+  replacements: ChannelSnapshotStateReplacementV1[]
+): Pick<
+  ChannelReducerState,
+  'messages' | 'byId' | 'inFlightDelta' | 'quarantined'
+> {
+  let nextMessages = messages;
+  let nextById = byId;
+  let nextInFlightDelta = inFlightDelta;
+  const nextQuarantined = { ...quarantined };
+  for (const replacement of replacements) {
+    const existing = existingById[replacement.message.id];
+    if (!existing || existing.seq !== replacement.message.seq) continue;
+    nextMessages = nextMessages.map((message) =>
+      message.id === replacement.message.id ? replacement.message : message
+    );
+    nextById = { ...nextById, [replacement.message.id]: replacement.message };
+    delete nextQuarantined[replacement.message.id];
+    if (replacement.inFlight) {
+      nextInFlightDelta = {
+        ...nextInFlightDelta,
+        [replacement.message.id]: replacement.inFlight.deltaIndex,
+      };
+      continue;
+    }
+    const withoutReplacement = { ...nextInFlightDelta };
+    delete withoutReplacement[replacement.message.id];
+    nextInFlightDelta = withoutReplacement;
+  }
+  return {
+    messages: nextMessages,
+    byId: nextById,
+    inFlightDelta: nextInFlightDelta,
+    quarantined: nextQuarantined,
+  };
+}
+
 /**
  * Pure reducer for `ChannelEventV1`. It is self-diagnosing: it can never silently
  * render a corrupted timeline. On any gap or unknown-id surprise it sets
@@ -1543,24 +1625,34 @@ export function applyChannelEventV1(
           needsCatchup: false,
         };
       }
-      // catchup: merge ascending
+      // catchup: merge durable progress ascending. State replacements are a
+      // separate lane: they only overwrite rows already present in local state
+      // and deliberately never alter `lastSeq` or create a new message.
       let messages = state.messages;
       for (const message of [...event.messages].sort((a, b) => a.seq - b.seq)) {
         if (state.byId[message.id] || message.seq > state.lastSeq) {
           messages = sortedInsert(messages, message);
         }
       }
+      const replacementState = applySnapshotStateReplacements(
+        messages,
+        rebuildById(messages),
+        state.byId,
+        inFlightFromRefs(event.inFlight),
+        state.quarantined,
+        event.stateReplacements ?? []
+      );
       return {
         ...state,
-        messages,
-        byId: rebuildById(messages),
+        messages: replacementState.messages,
+        byId: replacementState.byId,
         runs: {
           ...state.runs,
           ...Object.fromEntries((event.runs ?? []).map((run) => [run.id, run])),
         },
         lastSeq: Math.max(state.lastSeq, event.latestSeq),
-        inFlightDelta: inFlightFromRefs(event.inFlight),
-        quarantined: {},
+        inFlightDelta: replacementState.inFlightDelta,
+        quarantined: replacementState.quarantined,
         needsCatchup: false,
       };
     }

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -3486,7 +3486,7 @@ const channelSubscribeInputSchema: RelayJsonSchema = {
 const channelSubscribeFrameSchema: RelayJsonSchema = {
   title: 'ChannelsSubscribeFrameData',
   description:
-    'Versioned NDJSON frames. Discriminate on frame; event.payload is a ChannelEventV1 or channel-heartbeat-v1 payload.',
+    'Versioned NDJSON frames. Discriminate on frame; event.payload is a ChannelEventV1 or channel-heartbeat-v1 payload. On an explicit resume, channel-snapshot-v1.messages contains only seq greater than afterSeq; optional stateReplacements are non-delivery updates for already-acknowledged rows.',
   oneOf: [
     {
       title: 'ChannelsSubscribeOpenFrameV1',

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -129,6 +129,31 @@ describe('isChannelEventV1 validator matrix', () => {
     expect(isChannelEventV1(snapshot)).toBe(true);
     expect(
       isChannelEventV1({
+        ...snapshot,
+        mode: 'catchup',
+        stateReplacements: [{ message: message() }],
+      })
+    ).toBe(true);
+    expect(
+      isChannelEventV1({
+        ...snapshot,
+        stateReplacements: [{ message: message() }],
+      })
+    ).toBe(false);
+    expect(
+      isChannelEventV1({
+        ...snapshot,
+        mode: 'catchup',
+        stateReplacements: [
+          {
+            message: message({ status: 'complete' }),
+            inFlight: { messageId: 'chm:1', deltaIndex: 0 },
+          },
+        ],
+      })
+    ).toBe(false);
+    expect(
+      isChannelEventV1({
         type: 'channel-run-lifecycle-v1',
         channelId: CHANNEL,
         timestamp: 't',
@@ -551,6 +576,59 @@ describe('applyChannelEventV1 reducer', () => {
     state = applyChannelEventV1(state, catchup);
     expect(state.messages.map((m) => m.seq)).toEqual([1, 2, 3]);
     expect(state.lastSeq).toBe(3);
+  });
+
+  it('applies catch-up state replacements in place without creating rows or advancing the cursor', () => {
+    const streaming = message({
+      id: 'chm:streaming' as ChannelMessageId,
+      seq: 4,
+      status: 'streaming',
+      body: { text: 'partial', format: 'markdown' },
+    });
+    let state = applyChannelEventV1(initialChannelReducerState(CHANNEL), {
+      type: 'channel-snapshot-v1',
+      channelId: CHANNEL,
+      timestamp: 't',
+      mode: 'full',
+      messages: [streaming],
+      members: [],
+      latestSeq: 4,
+      inFlight: [{ messageId: streaming.id, deltaIndex: 2 }],
+      truncated: false,
+    });
+
+    const completed = message({
+      id: streaming.id,
+      seq: 4,
+      status: 'complete',
+      body: { text: 'complete answer', format: 'markdown' },
+    });
+    state = applyChannelEventV1(state, {
+      type: 'channel-snapshot-v1',
+      channelId: CHANNEL,
+      timestamp: 't',
+      mode: 'catchup',
+      messages: [],
+      stateReplacements: [
+        { message: completed },
+        {
+          message: message({
+            id: 'chm:unknown-replacement' as ChannelMessageId,
+            seq: 2,
+          }),
+        },
+      ],
+      members: [],
+      latestSeq: 4,
+      inFlight: [],
+      truncated: false,
+    });
+
+    expect(state.messages).toHaveLength(1);
+    expect(state.byId[streaming.id]).toEqual(completed);
+    expect(state.lastSeq).toBe(4);
+    expect(state.inFlightDelta[streaming.id]).toBeUndefined();
+    expect(state.needsCatchup).toBe(false);
   });
 
   it('preserves omitted run projections but clears an explicit empty projection', () => {

--- a/test/channel-hub.test.ts
+++ b/test/channel-hub.test.ts
@@ -543,6 +543,65 @@ describe('channel-hub snapshot correctness', () => {
     expect(state.quarantined[streaming.id]).toBeUndefined();
   });
 
+  it('dedupes a pending coalesced delta against a catch-up state replacement cursor', () => {
+    vi.useFakeTimers();
+    const s = store();
+    const hub = hubWith(s, { coalesceMs: 50 });
+    const streaming = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { runtimeId: 'runtime' },
+    });
+    hub.beginStreamBroadcast(streaming);
+
+    // Establish the row/cursor the reconnecting reducer already holds.
+    const first = fakeSocket();
+    hub.handleConnection(first, { channelId: 'topic:c', sinceSeq: null });
+    let state = initialChannelReducerState('topic:c');
+    for (const event of first.sent) state = applyChannelEventV1(state, event);
+    first.emit('close');
+
+    // idx 0 flushes while disconnected. The next text is still pending when
+    // reconnect registration flushes it, creating the exact queue/snapshot race.
+    hub.pushDelta(streaming.id, 'Hello ');
+    vi.advanceTimersByTime(50);
+    hub.pushDelta(streaming.id, 'world');
+
+    const resumed = fakeSocket();
+    hub.handleConnection(resumed, { channelId: 'topic:c', sinceSeq: streaming.seq });
+    const snapshot = resumed.sent[0];
+    if (snapshot?.type !== 'channel-snapshot-v1') {
+      throw new Error('expected catch-up snapshot');
+    }
+    expect(snapshot.messages).toEqual([]);
+    expect(snapshot.stateReplacements).toMatchObject([
+      {
+        message: { id: streaming.id, body: { text: 'Hello world' } },
+        inFlight: { messageId: streaming.id, deltaIndex: 1 },
+      },
+    ]);
+    expect(
+      resumed.sent.filter((event) => event.type === 'channel-message-delta-v1')
+    ).toEqual([]);
+
+    for (const event of resumed.sent) state = applyChannelEventV1(state, event);
+
+    // A later coalesced delta is still delivered exactly once.
+    hub.pushDelta(streaming.id, '!');
+    vi.advanceTimersByTime(50);
+    const laterDeltas = resumed.sent.filter(
+      (event) => event.type === 'channel-message-delta-v1'
+    );
+    expect(laterDeltas).toMatchObject([
+      { messageId: streaming.id, deltaIndex: 2, delta: { text: '!' } },
+    ]);
+    for (const event of laterDeltas) state = applyChannelEventV1(state, event);
+
+    expect(state.byId[streaming.id]?.body.text).toBe('Hello world!');
+    expect(state.quarantined[streaming.id]).toBeUndefined();
+    expect(state.needsCatchup).toBe(false);
+  });
+
   it('heals a stream that finalized while the client was disconnected on reconnect', () => {
     const s = store();
     const hub = hubWith(s);
@@ -636,7 +695,7 @@ describe('channel-hub snapshot correctness', () => {
     expect(state.needsCatchup).toBe(false);
   });
 
-  it('trims resync rows nearest the cursor while emitting them in ascending sequence order', () => {
+  it('trims resync replacements nearest the cursor without replaying them as messages', () => {
     const s = store();
     for (let index = 0; index < 4; index++) {
       s.appendComplete({
@@ -663,7 +722,10 @@ describe('channel-hub snapshot correctness', () => {
       throw new Error('expected snapshot');
 
     expect(snap.truncated).toBe(true);
-    expect(snap.messages.map((message) => message.seq)).toEqual([3, 4]);
+    expect(snap.messages).toEqual([]);
+    expect(
+      snap.stateReplacements?.map((replacement) => replacement.message.seq)
+    ).toEqual([3, 4]);
     expect(snap.latestSeq).toBe(4);
   });
 
@@ -745,7 +807,7 @@ describe('channel-hub snapshot correctness', () => {
     ).toBeLessThanOrEqual(snapshotMaxBytes);
   });
 
-  it('keeps an under-budget resync plus fresh catch-up complete and ascending', () => {
+  it('keeps fresh catch-up rows exclusive while carrying under-budget replacements separately', () => {
     const s = store();
     for (let index = 0; index < 2; index++) {
       s.appendComplete({
@@ -772,7 +834,10 @@ describe('channel-hub snapshot correctness', () => {
     expect(snap.mode).toBe('catchup');
     expect(snap.truncated).toBe(false);
     expect(snap.latestSeq).toBe(fresh.seq);
-    expect(snap.messages.map((message) => message.seq)).toEqual([1, 2, 3, 4]);
+    expect(snap.messages.map((message) => message.seq)).toEqual([3, 4]);
+    expect(
+      snap.stateReplacements?.map((replacement) => replacement.message.seq)
+    ).toEqual([1, 2]);
   });
 
   it('forces a full snapshot (client reset) when the cursor is ahead of the server head', () => {

--- a/test/channel-subscription-routes.test.ts
+++ b/test/channel-subscription-routes.test.ts
@@ -1,16 +1,28 @@
 import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import express from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { attachAuthenticatedCliGatewayActorCredential } from '../server/cli-gateway-actor-auth.js';
+import { createChannelHub } from '../server/channel-hub.js';
+import { createChannelMessageStore } from '../server/channel-message-store.js';
 import { createChannelSubscriptionRouter } from '../server/channel-subscription-router.js';
 import type { ChannelEventSink, ChannelHub } from '../server/channel-hub.js';
-import type { ChannelMessage } from '../shared/channel-chat-protocol.js';
+import {
+  applyChannelEventV1,
+  initialChannelReducerState,
+  type ChannelEventV1,
+  type ChannelMessage,
+} from '../shared/channel-chat-protocol.js';
 import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
 
 const servers: http.Server[] = [];
+const cleanup: Array<() => void> = [];
 afterEach(() => {
   for (const server of servers.splice(0)) server.close();
+  while (cleanup.length > 0) cleanup.pop()?.();
 });
 
 async function listen(input: {
@@ -21,6 +33,7 @@ async function listen(input: {
   heartbeatMs?: number;
   drainTimeoutMs?: number;
   writeResponse?: (res: express.Response, data: string) => boolean;
+  hub?: ChannelHub;
 }): Promise<number> {
   const app = express();
   app.use((req, _res, next) => {
@@ -32,13 +45,18 @@ async function listen(input: {
     } as ScopedActorCredentialRecord);
     next();
   });
-  const hub = {
-    channelExists: (id: string) => id === 'topic:a' || id === 'topic:b',
-    subscribe: (sink: ChannelEventSink, value: { afterSeq: number | null }) => {
-      input.subscribe?.(sink, value.afterSeq);
-      return () => input.onUnsubscribe?.();
-    },
-  } as unknown as ChannelHub;
+  const hub =
+    input.hub ??
+    ({
+      channelExists: (id: string) => id === 'topic:a' || id === 'topic:b',
+      subscribe: (
+        sink: ChannelEventSink,
+        value: { afterSeq: number | null }
+      ) => {
+        input.subscribe?.(sink, value.afterSeq);
+        return () => input.onUnsubscribe?.();
+      },
+    } as unknown as ChannelHub);
   app.use(
     createChannelSubscriptionRouter({
       hub,
@@ -60,6 +78,31 @@ async function listen(input: {
   const address = server.address();
   if (!address || typeof address === 'string') throw new Error('missing port');
   return address.port;
+}
+
+function createNdjsonReader(response: Response): () => Promise<unknown> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('missing NDJSON response body');
+  const decoder = new TextDecoder();
+  let buffered = '';
+  return async () => {
+    while (true) {
+      const newline = buffered.indexOf('\n');
+      if (newline !== -1) {
+        const line = buffered.slice(0, newline);
+        buffered = buffered.slice(newline + 1);
+        if (line) return JSON.parse(line) as unknown;
+        continue;
+      }
+      const { done, value } = await reader.read();
+      if (done) throw new Error('NDJSON stream ended before the next frame');
+      buffered += decoder.decode(value, { stream: true });
+    }
+  };
+}
+
+function pause(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe('channel subscription route', () => {
@@ -198,6 +241,20 @@ describe('channel subscription route', () => {
               body: { text: 'answer', format: 'markdown' },
             },
           ] as ChannelMessage[],
+          stateReplacements: [
+            {
+              message: {
+                id: 'chm:stale-at-cursor',
+                seq: 3,
+                kind: 'message',
+                status: 'complete',
+                sender: { kind: 'agent', id: 'agent:one' },
+                threadId: null,
+                parentMessageId: null,
+                body: { text: 'stale answer', format: 'markdown' },
+              },
+            },
+          ],
           runs: [
             {
               id: 'chrun:included',
@@ -220,14 +277,14 @@ describe('channel subscription route', () => {
       },
     });
     const response = await fetch(
-      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?status=complete&terminalOnly=true`,
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=4&status=complete&terminalOnly=true&principalOnly=true`,
       { headers: { 'x-relay-cli-gateway': 'v1' } }
     );
     const frames = (await response.text())
       .trim()
       .split('\n')
       .map((line) => JSON.parse(line));
-    expect(frames.map((frame) => frame.durableSeq)).toEqual([0, 9, 9]);
+    expect(frames.map((frame) => frame.durableSeq)).toEqual([4, 9, 9]);
     expect(frames[1].payload).toMatchObject({
       type: 'channel-snapshot-v1',
       messages: [{ id: 'chm:matched' }],
@@ -236,6 +293,17 @@ describe('channel subscription route', () => {
       inFlight: [],
       truncated: false,
     });
+    expect(frames[1].payload.stateReplacements).toEqual([
+      {
+        message: expect.objectContaining({ id: 'chm:stale-at-cursor', seq: 3 }),
+      },
+    ]);
+    expect(
+      frames[1].payload.messages.map((message: ChannelMessage) => message.id)
+    ).toEqual(['chm:matched']);
+    expect(frames[1].payload.messages.every((message) => message.seq > 4)).toBe(
+      true
+    );
   });
 
   it('treats explicit false booleans as the exact unfiltered stream', async () => {
@@ -554,6 +622,214 @@ describe('channel subscription route', () => {
       .split('\n')
       .map((line) => JSON.parse(line));
     expect(frames.map((frame) => frame.durableSeq)).toEqual([4, 6, 6]);
+  });
+
+  it('keeps at-cursor refreshes in the replacement lane through an explicit HTTP catch-up', async () => {
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: (sink) => {
+        // The hub intentionally includes seq 3 to replace a row which changed
+        // in place while the client was away. It is not durable progress after
+        // the explicit cursor 4, so HTTP subscribers must not see it again.
+        sink.send({
+          type: 'channel-snapshot-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-11T00:00:00.000Z',
+          mode: 'catchup',
+          messages: [{ id: 'chm:fresh', seq: 5 } as ChannelMessage],
+          stateReplacements: [
+            {
+              message: { id: 'chm:resync', seq: 3 } as ChannelMessage,
+              inFlight: { messageId: 'chm:resync', deltaIndex: 1 },
+            },
+          ],
+          members: [],
+          latestSeq: 5,
+          inFlight: [{ messageId: 'chm:fresh', deltaIndex: 2 }],
+          truncated: false,
+        });
+        sink.close({ code: 'transport-closed' });
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=4`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+
+    expect(frames.map((frame) => frame.durableSeq)).toEqual([4, 5, 5]);
+    expect(frames[1]?.payload).toMatchObject({
+      type: 'channel-snapshot-v1',
+      mode: 'catchup',
+      messages: [{ seq: 5 }],
+      latestSeq: 5,
+      inFlight: [{ messageId: 'chm:fresh', deltaIndex: 2 }],
+    });
+    expect(frames[1]?.payload.messages).toHaveLength(1);
+    expect(frames[1]?.payload.stateReplacements).toEqual([
+      {
+        message: { id: 'chm:resync', seq: 3 },
+        inFlight: { messageId: 'chm:resync', deltaIndex: 1 },
+      },
+    ]);
+  });
+
+  it('reconstructs an agent stream exactly across a real hub and HTTP resume handoff', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-subscribe-resume-')
+    );
+    const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+    const hub = createChannelHub({
+      store,
+      channelExists: (id) => id === 'topic:a',
+      coalesceMs: 5,
+    });
+    cleanup.push(() => hub.close());
+    cleanup.push(() => store.close());
+    cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+    const streaming = store.beginStream({
+      channelId: 'topic:a',
+      sender: { kind: 'agent', id: 'agent:claude', providerId: 'claude' },
+      source: { runtimeId: 'resume-test' },
+    });
+    hub.beginStreamBroadcast(streaming);
+    const port = await listen({ channelIds: ['topic:a'], hub });
+    const headers = { 'x-relay-cli-gateway': 'v1' };
+
+    const firstAbort = new AbortController();
+    const firstResponse = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=0`,
+      { headers, signal: firstAbort.signal }
+    );
+    const firstFrame = createNdjsonReader(firstResponse);
+    await firstFrame(); // open
+    const initial = (await firstFrame()) as {
+      payload: ChannelEventV1;
+      durableSeq: number;
+    };
+    expect(initial.payload.type).toBe('channel-snapshot-v1');
+    if (initial.payload.type !== 'channel-snapshot-v1')
+      throw new Error('expected initial snapshot');
+    expect(initial.payload.messages.map((message) => message.seq)).toEqual([
+      streaming.seq,
+    ]);
+    let state = applyChannelEventV1(
+      initialChannelReducerState('topic:a'),
+      initial.payload
+    );
+    expect(state.lastSeq).toBe(streaming.seq);
+    firstAbort.abort();
+    await pause(0);
+
+    // This flush happened while the first HTTP subscriber was disconnected.
+    hub.pushDelta(streaming.id, 'hello ');
+    await pause(15);
+
+    const resumedAbort = new AbortController();
+    const resumedResponse = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=${state.lastSeq}`,
+      { headers, signal: resumedAbort.signal }
+    );
+    const resumedFrame = createNdjsonReader(resumedResponse);
+    await resumedFrame(); // open
+    const replacementFrame = (await resumedFrame()) as {
+      payload: ChannelEventV1;
+      durableSeq: number;
+    };
+    expect(replacementFrame.payload.type).toBe('channel-snapshot-v1');
+    if (replacementFrame.payload.type !== 'channel-snapshot-v1')
+      throw new Error('expected catch-up snapshot');
+    expect(replacementFrame.payload.messages).toEqual([]);
+    expect(replacementFrame.payload.stateReplacements).toEqual([
+      {
+        message: expect.objectContaining({
+          id: streaming.id,
+          seq: streaming.seq,
+          body: expect.objectContaining({ text: 'hello ' }),
+        }),
+        inFlight: { messageId: streaming.id, deltaIndex: 0 },
+      },
+    ]);
+    state = applyChannelEventV1(state, replacementFrame.payload);
+    expect(state.lastSeq).toBe(streaming.seq);
+    expect(state.byId[streaming.id]?.body.text).toBe('hello ');
+
+    hub.pushDelta(streaming.id, 'world');
+    await pause(15);
+    const final = store.finalizeStream(streaming.id, {
+      text: 'hello world',
+      status: 'complete',
+    });
+    if (!final) throw new Error('expected final stream row');
+    hub.completeStreamBroadcast(final);
+
+    const deltaFrame = (await resumedFrame()) as { payload: ChannelEventV1 };
+    const completedFrame = (await resumedFrame()) as {
+      payload: ChannelEventV1;
+    };
+    expect(deltaFrame.payload).toMatchObject({
+      type: 'channel-message-delta-v1',
+      messageId: streaming.id,
+      deltaIndex: 1,
+      delta: { text: 'world' },
+    });
+    expect(completedFrame.payload).toMatchObject({
+      type: 'channel-message-completed-v1',
+      message: { id: streaming.id, body: { text: 'hello world' } },
+    });
+    state = applyChannelEventV1(state, deltaFrame.payload);
+    state = applyChannelEventV1(state, completedFrame.payload);
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]?.body.text).toBe('hello world');
+    expect(state.lastSeq).toBe(streaming.seq);
+    expect(state.needsCatchup).toBe(false);
+    resumedAbort.abort();
+  });
+
+  it('keeps full snapshots when the cursor is omitted or requires a reset', async () => {
+    const subscribe = (sink: ChannelEventSink) => {
+      sink.send({
+        type: 'channel-snapshot-v1',
+        channelId: 'topic:a',
+        timestamp: '2026-08-11T00:00:00.000Z',
+        mode: 'full',
+        messages: [{ seq: 3 } as ChannelMessage],
+        members: [],
+        latestSeq: 3,
+        inFlight: [],
+        truncated: false,
+      });
+      sink.close({ code: 'transport-closed' });
+    };
+    const [omittedPort, resetPort] = await Promise.all([
+      listen({ channelIds: ['topic:a'], subscribe }),
+      listen({ channelIds: ['topic:a'], subscribe }),
+    ]);
+    const headers = { 'x-relay-cli-gateway': 'v1' };
+    const [omitted, reset] = await Promise.all(
+      [
+        `http://127.0.0.1:${omittedPort}/channels/topic%3Aa/subscribe`,
+        `http://127.0.0.1:${resetPort}/channels/topic%3Aa/subscribe?afterSeq=4`,
+      ].map(async (url) => {
+        const response = await fetch(url, { headers });
+        return (await response.text())
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line));
+      })
+    );
+
+    for (const frames of [omitted, reset]) {
+      expect(frames[1]?.payload).toMatchObject({
+        type: 'channel-snapshot-v1',
+        mode: 'full',
+        messages: [{ seq: 3 }],
+      });
+    }
   });
 
   it('flushes a large accepted snapshot after res.write signals backpressure', async () => {


### PR DESCRIPTION
Closes #1398

## Summary

- Keep explicit-resume `snapshot.messages` exclusive to durable rows with `seq > afterSeq`.
- Carry stale in-place stream refreshes in optional, backward-compatible `stateReplacements`, including their stream cursor when applicable.
- Preserve browser/hub full and omitted-cursor snapshot behavior; replacements update existing timeline state only and never advance the durable cursor.
- Seed reconnect handoff dedupe from replacement cursors to prevent a coalesced delta from being replayed or quarantined.

## Validation

- Focused: 95 tests across subscription routes, hub, protocol, and CLI subscribe.
- Full: 6,614 tests across 480 files.
- `npm run check`, `npm run build`, and `git diff --check` passed.

The focused reconnect race covers an offline flush represented by a replacement, followed by one live delta and completion, reconstructing the body exactly once.