### PR TITLE
feat(cli): add channel client and MCP facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ workflow.
 - Stream scoped channel replies through a durable, resumable
   `channels.subscribe` CLI gateway contract without per-message blocking waits
   (#1389)
+- Add a local stdio `relay-mcp` façade with a closed eight-command channel
+  allowlist, environment-only credentials, bounded subscriptions, and public
+  provider-diagnostic redaction (#1399)
 - Add bounded server-side semantic filters to durable channel subscriptions so
   agent consumers can wait for principal or terminal replies without receiving
   detail/tool traffic, while preserving safe resume cursors (#1390)

--- a/bin/relay-mcp.ts
+++ b/bin/relay-mcp.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/* eslint-disable no-console -- stdio MCP startup diagnostics belong on stderr. */
+
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+
+import { createRelayMcpServer } from '../shared/relay-mcp.js';
+
+// This executable is deliberately configuration-free: Relay URL and credentials
+// come only from RELAY_IDE_URL/PORT and RELAY_IDE_ACTOR_TOKEN or BROWSER_TOKEN.
+if (process.argv.length !== 2) {
+  console.error(
+    'relay-mcp accepts no command-line arguments; configure Relay through environment variables.'
+  );
+  process.exitCode = 64;
+} else {
+  try {
+    await createRelayMcpServer().connect(new StdioServerTransport());
+  } catch {
+    // Never stringify errors here: connection errors can include proxy URLs or
+    // upstream messages, neither of which belongs on an MCP stdio host log.
+    console.error('relay-mcp failed to start.');
+    process.exitCode = 1;
+  }
+}

--- a/bin/relay-mcp.ts
+++ b/bin/relay-mcp.ts
@@ -6,7 +6,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import { createRelayMcpServer } from '../shared/relay-mcp.js';
 
 // This executable is deliberately configuration-free: Relay URL and credentials
-// come only from RELAY_IDE_URL/PORT and RELAY_IDE_ACTOR_TOKEN or BROWSER_TOKEN.
+// come only from RELAY_IDE_URL/PORT and RELAY_IDE_ACTOR_TOKEN or RELAY_IDE_BROWSER_TOKEN.
 if (process.argv.length !== 2) {
   console.error(
     'relay-mcp accepts no command-line arguments; configure Relay through environment variables.'

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -128,6 +128,21 @@ The stable gateway exposes scoped list/get/history/thread-history/roster/post
 commands plus a durable `channels.subscribe` stream. Search and browser-only
 conveniences remain outside the gateway contract.
 
+### Local MCP channel facade (#1399)
+
+`relay-mcp` is an optional local stdio façade for hosts that speak MCP. It
+exposes only `channels.list`, `channels.get`, `channels.run.get`,
+`channels.history`, `channels.subscribe`, `channels.threads.history`,
+`channels.roster`, and `channels.post`; it does not inject unsolicited work
+into a Codex host and it cannot invoke shell, terminal, or provider-runtime
+commands. Configure the local Relay URL and credential only through process
+environment (`RELAY_IDE_URL`/`RELAY_IDE_PORT` and
+`RELAY_IDE_ACTOR_TOKEN` or `RELAY_IDE_BROWSER_TOKEN`), never MCP tool input.
+MCP subscribe calls must provide bounded `maxEvents` (≤100) and
+`idleTimeoutMs` (≤30,000); returned rows omit provider runtime, turn, and item
+identifiers while retaining Relay-owned run/target ids and server-derived
+sender metadata.
+
 `relay-ide v1 channels subscribe --channel-id <id> --after-seq <N> --json`
 emits one NDJSON envelope per versioned `open`, `event`, or `closed` frame.
 Every frame requires `schemaVersion: 1`, `channelId`, `sequence`, `occurredAt`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@modelcontextprotocol/server": "^2.0.0",
         "@tanstack/react-query": "^5.96.1",
         "@tanstack/react-virtual": "^3.13.24",
         "@xterm/addon-fit": "^0.11.0",
@@ -2071,6 +2072,31 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
@@ -8774,7 +8800,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -4,9 +4,17 @@
   "description": "Channel-first workspace for collaborating with AI coding agents from any device",
   "type": "module",
   "main": "dist/server/index.js",
+  "exports": {
+    ".": "./dist/server/index.js",
+    "./channel-client": {
+      "types": "./dist/shared/channel-client.d.ts",
+      "import": "./dist/shared/channel-client.js"
+    }
+  },
   "bin": {
     "relay-ide": "dist/bin/relay-ide.js",
     "relay-ide-browser": "dist/scripts/agent-browser-cli.js",
+    "relay-mcp": "dist/bin/relay-mcp.js",
     "relayctl": "dist/bin/relayctl.js"
   },
   "files": [
@@ -18,7 +26,7 @@
     "lint": "eslint .",
     "typecheck:test": "tsc --noEmit -p test/tsconfig.json",
     "check": "tsc --noEmit && tsc --noEmit -p frontend/tsconfig.json && npm run typecheck:test && npm run lint",
-    "build": "npm run clean && tsc && chmod +x dist/bin/relay-ide.js dist/bin/relayctl.js dist/scripts/agent-browser-cli.js && vite build --config frontend/vite.config.ts",
+    "build": "npm run clean && tsc && chmod +x dist/bin/relay-ide.js dist/bin/relay-mcp.js dist/bin/relayctl.js dist/scripts/agent-browser-cli.js && vite build --config frontend/vite.config.ts",
     "build:server": "tsc",
     "build:frontend": "vite build --config frontend/vite.config.ts",
     "dev": "npm run build:server && node dist/scripts/dev.js",
@@ -87,6 +95,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@tanstack/react-query": "^5.96.1",
     "@tanstack/react-virtual": "^3.13.24",
     "@xterm/addon-fit": "^0.11.0",

--- a/shared/channel-client.ts
+++ b/shared/channel-client.ts
@@ -172,7 +172,7 @@ export class RelayChannelSubscriptionOverflowError extends RelayChannelClientErr
   ) {
     super(413, {
       code: 'UPSTREAM_ERROR',
-      retryable: true,
+      retryable: false,
       message: `Relay subscription exceeded ${limit} limit`,
       details: { limit, maximum, observed },
     });
@@ -330,6 +330,7 @@ export const RELAY_CHANNEL_SUBSCRIPTION_MAX_LINE_BYTES = 1024 * 1024;
 export const RELAY_CHANNEL_SUBSCRIPTION_MAX_STREAM_BYTES = 8 * 1024 * 1024;
 export const RELAY_CHANNEL_SUBSCRIPTION_MAX_COLLECTED_OUTPUT_BYTES =
   8 * 1024 * 1024;
+const PRIVATE_REDACTION_MIN_CHARS = 8;
 
 function isPrivateProviderKey(key: string): boolean {
   const normalized = key.replace(/[-_]/g, '').toLowerCase();
@@ -358,6 +359,18 @@ function isPrivateValueKey(key: string): boolean {
 }
 
 /**
+ * A provider locator is normally an opaque, punctuation-safe identifier. Do
+ * not turn ubiquitous short words (for example `codex`, `0`, or `1`) into
+ * global redaction needles merely because an upstream put one under `source`.
+ */
+function isRedactablePrivateValue(value: string): boolean {
+  return (
+    value.length >= PRIVATE_REDACTION_MIN_CHARS &&
+    /^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(value)
+  );
+}
+
+/**
  * First pass: keep the strings named by private fields even when they are
  * echoed under an otherwise harmless key somewhere else in the same envelope.
  * This deliberately runs before field removal; a source object can contain a
@@ -369,7 +382,7 @@ function collectPrivateStringValues(
   inheritedPrivate = false
 ): void {
   if (typeof value === 'string') {
-    if (inheritedPrivate && value.length > 0) values.add(value);
+    if (inheritedPrivate && isRedactablePrivateValue(value)) values.add(value);
     return;
   }
   if (Array.isArray(value)) {
@@ -552,6 +565,33 @@ function jsonBytes(value: unknown): number {
   return new TextEncoder().encode(JSON.stringify(value)).byteLength;
 }
 
+function textBytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+/** Exact JSON byte length without repeatedly serializing retained frames. */
+function collectionOutputBytes(
+  frameBytes: number,
+  state: RelayChannelReducerState,
+  durableSeq: number,
+  stopReason: ChannelCollectedSubscription['stopReason']
+): number {
+  // Property order intentionally matches collectionOutput below. State is a
+  // generic reducer projection, so its exact current serialization remains the
+  // only safe cap authority; retained frames are incrementally accounted for.
+  return (
+    textBytes('{"frames":') +
+    frameBytes +
+    textBytes(',"state":') +
+    jsonBytes(state) +
+    textBytes(',"durableSeq":') +
+    jsonBytes(durableSeq) +
+    textBytes(',"stopReason":') +
+    jsonBytes(stopReason) +
+    1
+  );
+}
+
 function collectionOutput(
   frames: readonly ChannelSubscriptionFrame[],
   state: RelayChannelReducerState,
@@ -712,7 +752,7 @@ function isSubscriptionFrame(
 export function createRelayChannelClient(
   config: RelayChannelClientConfig = {}
 ): RelayChannelClient {
-  const env = config.env ?? process.env;
+  const env = config.env ?? (typeof process === 'undefined' ? {} : process.env);
   const baseUrl = trimBaseUrl(config.baseUrl ?? defaultBaseUrl(env));
   // A browser bearer is accepted by the ordinary HTTP auth lane.  Advertising
   // it as an actor credential would switch server-side scope semantics, so the
@@ -896,8 +936,18 @@ export function createRelayChannelClient(
         });
       }
       const parsed = frame;
-      if (parsed.frame === 'event' && isChannelEventV1(parsed.payload)) {
-        state = applyChannelEventV1(state, parsed.payload);
+      const publicPayload =
+        parsed.frame === 'event' && isChannelEventV1(parsed.payload)
+          ? projectChannelEvent(parsed.payload, token)
+          : undefined;
+      if (publicPayload) {
+        // State starts public and receives only the projected event. This keeps
+        // provider diagnostics out of reducer state and avoids reprojecting
+        // every retained row for each incoming delta.
+        state = applyChannelEventV1(
+          state,
+          publicPayload as unknown as ChannelEventV1
+        );
       }
       // durableSeq comes from the authoritative frame, never reducer state.
       durableSeq = Math.max(durableSeq, parsed.durableSeq);
@@ -907,13 +957,13 @@ export function createRelayChannelClient(
             ChannelSubscriptionFrame,
             'payload'
           >),
-          ...(parsed.payload && isChannelEventV1(parsed.payload)
-            ? { payload: projectChannelEvent(parsed.payload, token) }
+          ...(publicPayload
+            ? { payload: publicPayload }
             : parsed.payload
               ? { payload: parsed.payload }
               : {}),
         },
-        state: projectReducerState(state, token),
+        state: state as unknown as RelayChannelReducerState,
         durableSeq,
       };
     };
@@ -973,12 +1023,24 @@ export function createRelayChannelClient(
       'maxOutputBytes'
     );
     const controller = new AbortController();
-    const idleSignal =
-      idleTimeoutMs === undefined
-        ? undefined
-        : AbortSignal.timeout(idleTimeoutMs);
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleTimedOut = false;
+    const clearIdleTimer = () => {
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
+    };
+    const resetIdleTimer = () => {
+      clearIdleTimer();
+      if (idleTimeoutMs === undefined) return;
+      idleTimer = setTimeout(() => {
+        idleTimedOut = true;
+        controller.abort();
+      }, idleTimeoutMs);
+    };
     const combined = AbortSignal.any(
-      [signal, controller.signal, idleSignal].filter(
+      [signal, controller.signal].filter(
         (value): value is AbortSignal => value !== undefined
       )
     );
@@ -988,47 +1050,63 @@ export function createRelayChannelClient(
       projectReducerState(initialChannelReducerState(subscribeInput.channelId));
     let durableSeq = subscribeInput.afterSeq ?? 0;
     let events = 0;
+    let serializedFrameBytes = 2; // `[]`
     let stopReason: ChannelCollectedSubscription['stopReason'] =
       'stream-closed';
-    for await (const update of subscribe({
-      ...subscribeInput,
-      signal: combined,
-    })) {
-      const nextEvents = events + (update.frame.frame === 'event' ? 1 : 0);
-      const nextStopReason =
-        maxEvents !== undefined && nextEvents >= maxEvents
-          ? 'max-events'
-          : 'stream-closed';
-      // Count the exact object returned to a caller, not fragments of it. That
-      // includes braces, property names, commas, durableSeq, and stopReason.
-      const nextOutputBytes = jsonBytes(
-        collectionOutput(
-          [...frames, update.frame],
+    resetIdleTimer();
+    try {
+      for await (const update of subscribe({
+        ...subscribeInput,
+        signal: combined,
+      })) {
+        const nextEvents = events + (update.frame.frame === 'event' ? 1 : 0);
+        const nextStopReason =
+          maxEvents !== undefined && nextEvents >= maxEvents
+            ? 'max-events'
+            : 'stream-closed';
+        const nextSerializedFrameBytes =
+          serializedFrameBytes +
+          (frames.length === 0 ? 0 : 1) +
+          jsonBytes(update.frame);
+        // Count the exact object returned to a caller, including wrappers and
+        // durable state, without reserializing all previously retained frames.
+        const nextOutputBytes = collectionOutputBytes(
+          nextSerializedFrameBytes,
           update.state,
           update.durableSeq,
           nextStopReason
-        )
-      );
-      if (nextOutputBytes > maxOutputBytes) {
-        controller.abort();
-        throw new RelayChannelSubscriptionOverflowError(
-          'collected-output-bytes',
-          maxOutputBytes,
-          nextOutputBytes
         );
+        if (nextOutputBytes > maxOutputBytes) {
+          controller.abort();
+          throw new RelayChannelSubscriptionOverflowError(
+            'collected-output-bytes',
+            maxOutputBytes,
+            nextOutputBytes
+          );
+        }
+        frames.push(update.frame);
+        serializedFrameBytes = nextSerializedFrameBytes;
+        state = update.state;
+        durableSeq = update.durableSeq;
+        events = nextEvents;
+        if (maxEvents !== undefined && events >= maxEvents) {
+          // Max-events is a successful local terminal condition. Clear the
+          // timer before aborting so a simultaneous deadline cannot win.
+          stopReason = 'max-events';
+          clearIdleTimer();
+          controller.abort();
+          break;
+        }
+        // Only an accepted update extends the quiet-stream deadline.
+        resetIdleTimer();
       }
-      frames.push(update.frame);
-      state = update.state;
-      durableSeq = update.durableSeq;
-      events = nextEvents;
-      if (maxEvents !== undefined && events >= maxEvents) {
-        stopReason = 'max-events';
-        controller.abort();
-        break;
-      }
+    } finally {
+      clearIdleTimer();
     }
-    if (idleSignal?.aborted) stopReason = 'idle-timeout';
-    else if (signal?.aborted) stopReason = 'aborted';
+    if (stopReason !== 'max-events') {
+      if (idleTimedOut) stopReason = 'idle-timeout';
+      else if (signal?.aborted) stopReason = 'aborted';
+    }
     return collectionOutput(frames, state, durableSeq, stopReason);
   };
 

--- a/shared/channel-client.ts
+++ b/shared/channel-client.ts
@@ -1,0 +1,1095 @@
+/**
+ * Thin Node/TypeScript client for Relay's stable channel HTTP surface.
+ *
+ * Credentials are deliberately construction-only.  Per-call payloads contain
+ * only channel data, so callers cannot accidentally persist a token in a post,
+ * a replay fixture, or application logs.
+ */
+import {
+  applyChannelEventV1,
+  initialChannelReducerState,
+  isChannelEventV1,
+  type ChannelAsyncRun,
+  type ChannelAgentDetail,
+  type ChannelEventV1,
+  type ChannelMessage,
+  type ChannelMessageId,
+  type ChannelReducerState,
+  type ChannelSenderRef,
+  type ChannelSnapshotEventV1,
+  type ChannelSnapshotStateReplacementV1,
+  type ChannelSubscriptionFilter,
+} from './channel-chat-protocol.js';
+
+/**
+ * The HTTP client is a public boundary, not a provider debugging surface.
+ * Relay-owned run/target ids and sender identity remain useful to callers;
+ * backing-runtime, turn and provider-item correlation do not cross it.
+ */
+export type RelayChannelMessage = Omit<
+  ChannelMessage,
+  'sender' | 'source' | 'agentDetail' | 'meta'
+> & {
+  sender: Omit<ChannelSenderRef, 'runtimeId'>;
+  agentDetail?: Omit<ChannelAgentDetail, 'itemId'>;
+  meta?: Record<string, unknown>;
+};
+
+type ChannelMessageEvent = Extract<ChannelEventV1, { message: ChannelMessage }>;
+type RelayChannelMessageEvent = Omit<ChannelMessageEvent, 'message'> & {
+  message: RelayChannelMessage;
+};
+export type RelayChannelSnapshotStateReplacement = Omit<
+  ChannelSnapshotStateReplacementV1,
+  'message'
+> & { message: RelayChannelMessage };
+export type RelayChannelSnapshotEvent = Omit<
+  ChannelSnapshotEventV1,
+  'messages' | 'stateReplacements'
+> & {
+  messages: RelayChannelMessage[];
+  stateReplacements?: RelayChannelSnapshotStateReplacement[];
+};
+export type RelayChannelEvent =
+  | Exclude<ChannelEventV1, ChannelMessageEvent | ChannelSnapshotEventV1>
+  | RelayChannelMessageEvent
+  | RelayChannelSnapshotEvent;
+
+/** A reducer view whose message-bearing fields have passed the public boundary. */
+export type RelayChannelReducerState = Omit<
+  ChannelReducerState,
+  'messages' | 'byId'
+> & {
+  messages: RelayChannelMessage[];
+  byId: Record<string, RelayChannelMessage>;
+};
+
+export interface RelayChannelClientConfig {
+  /** Relay hub URL. Defaults to RELAY_IDE_URL or the local RELAY_IDE_PORT hub. */
+  baseUrl?: string;
+  /** Construction-only bearer credential. Defaults to actor then browser env credential. */
+  token?: string;
+  /** Construction-only headers, useful for an already-authenticated proxy. */
+  headers?: HeadersInit;
+  /** Injectable for tests or a custom Node fetch dispatcher. */
+  fetch?: typeof globalThis.fetch;
+  /** Injectable environment for embedded clients and tests. */
+  env?: Readonly<Record<string, string | undefined>>;
+}
+
+export interface RelayChannelClientErrorBody {
+  code?: RelayChannelClientErrorCode;
+  message?: string;
+  retryable?: boolean;
+  details?: Record<string, unknown>;
+}
+
+/** Codes are kept in the stable gateway vocabulary even for local guards. */
+export type RelayChannelClientErrorCode =
+  | 'UNAUTHORIZED'
+  | 'SERVER_UNAVAILABLE'
+  | 'INVALID_ARGUMENT'
+  | 'INVALID_JSON'
+  | 'UNSUPPORTED'
+  | 'NOT_FOUND'
+  | 'FORBIDDEN'
+  | 'SESSION_CONFLICT'
+  | 'CONFIRMATION_REQUIRED'
+  | 'NODE_OFFLINE'
+  | 'SESSION_EXPIRED'
+  | 'SESSION_REVOKED'
+  | 'SESSION_MISMATCH'
+  | 'SESSION_NON_RENEWABLE'
+  | 'CONTROL_STATE_STALE'
+  | 'INTERVENTION_ACK_REQUIRED'
+  | 'INTERVENTION_ACK_STALE'
+  | 'CONTROL_STATE_UNKNOWN'
+  | 'UPSTREAM_ERROR'
+  | 'INTERNAL';
+
+const RELAY_CHANNEL_CLIENT_ERROR_CODES = new Set<RelayChannelClientErrorCode>([
+  'UNAUTHORIZED',
+  'SERVER_UNAVAILABLE',
+  'INVALID_ARGUMENT',
+  'INVALID_JSON',
+  'UNSUPPORTED',
+  'NOT_FOUND',
+  'FORBIDDEN',
+  'SESSION_CONFLICT',
+  'CONFIRMATION_REQUIRED',
+  'NODE_OFFLINE',
+  'SESSION_EXPIRED',
+  'SESSION_REVOKED',
+  'SESSION_MISMATCH',
+  'SESSION_NON_RENEWABLE',
+  'CONTROL_STATE_STALE',
+  'INTERVENTION_ACK_REQUIRED',
+  'INTERVENTION_ACK_STALE',
+  'CONTROL_STATE_UNKNOWN',
+  'UPSTREAM_ERROR',
+  'INTERNAL',
+]);
+
+function gatewayErrorCode(value: unknown): RelayChannelClientErrorCode {
+  return typeof value === 'string' &&
+    RELAY_CHANNEL_CLIENT_ERROR_CODES.has(value as RelayChannelClientErrorCode)
+    ? (value as RelayChannelClientErrorCode)
+    : 'UPSTREAM_ERROR';
+}
+
+/** Error envelope projected without request headers or credential material. */
+export class RelayChannelClientError extends Error {
+  readonly status: number;
+  readonly code?: RelayChannelClientErrorCode;
+  readonly retryable?: boolean;
+  readonly details?: Record<string, unknown>;
+
+  constructor(status: number, body: RelayChannelClientErrorBody) {
+    super(body.message ?? `Relay channel request failed (${status})`);
+    this.name = 'RelayChannelClientError';
+    this.status = status;
+    if (body.code !== undefined) this.code = body.code;
+    if (body.retryable !== undefined) this.retryable = body.retryable;
+    if (body.details !== undefined) this.details = body.details;
+  }
+}
+
+export type RelayChannelSubscriptionLimit =
+  | 'line-bytes'
+  | 'stream-bytes'
+  | 'collected-output-bytes';
+
+/** A local, fail-closed bound stopped consuming an untrusted subscription. */
+export class RelayChannelSubscriptionOverflowError extends RelayChannelClientError {
+  readonly limit: RelayChannelSubscriptionLimit;
+  readonly maximum: number;
+  readonly observed: number;
+
+  constructor(
+    limit: RelayChannelSubscriptionLimit,
+    maximum: number,
+    observed: number
+  ) {
+    super(413, {
+      code: 'UPSTREAM_ERROR',
+      retryable: true,
+      message: `Relay subscription exceeded ${limit} limit`,
+      details: { limit, maximum, observed },
+    });
+    this.name = 'RelayChannelSubscriptionOverflowError';
+    this.limit = limit;
+    this.maximum = maximum;
+    this.observed = observed;
+  }
+}
+
+export interface ChannelSummary {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface ChannelRosterEntry {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface ChannelPage {
+  messages: RelayChannelMessage[];
+  hasMore?: boolean;
+  nextCursor?: { beforeSeq: number } | { afterSeq: number };
+}
+
+export interface ChannelPostInput {
+  channelId: string;
+  text: string;
+  format?: 'text' | 'markdown';
+  parentMessageId?: ChannelMessageId;
+  threadId?: ChannelMessageId | null;
+  clientMessageId?: string;
+}
+
+export interface ChannelPostResult {
+  message: RelayChannelMessage;
+  run?: ChannelAsyncRun;
+  [key: string]: unknown;
+}
+
+export interface ChannelSubscribeInput extends ChannelSubscriptionFilter {
+  channelId: string;
+  afterSeq?: number;
+  /** Prior reducer state when resuming; enables catchup state replacement. */
+  state?: RelayChannelReducerState;
+  signal?: AbortSignal;
+  /** Maximum bytes in one NDJSON line. Defaults to 1 MiB. */
+  maxLineBytes?: number;
+  /** Maximum bytes read from one subscription response. Defaults to 8 MiB. */
+  maxStreamBytes?: number;
+}
+
+export interface ChannelSubscriptionFrame {
+  schemaVersion: 1;
+  frame: 'open' | 'event' | 'closed';
+  channelId: string;
+  sequence: number;
+  occurredAt: string;
+  durableSeq: number;
+  payload?: RelayChannelEvent | { type: 'channel-heartbeat-v1' };
+  reason?: string;
+  retryable?: boolean;
+  latestSeq?: number;
+}
+
+export interface ChannelSubscriptionUpdate {
+  frame: ChannelSubscriptionFrame;
+  /** State after this frame's payload; snapshots apply stateReplacements here. */
+  state: RelayChannelReducerState;
+  /** Server-confirmed durable cursor; replacements never advance it. */
+  durableSeq: number;
+}
+
+export interface ChannelCollectInput extends ChannelSubscribeInput {
+  /** Stop after this many event frames, without counting open/closed frames. */
+  maxEvents?: number;
+  /** Stop a quiet stream locally. This is not sent to the server. */
+  idleTimeoutMs?: number;
+  /** Maximum serialized bytes retained by this collector. Defaults to 8 MiB. */
+  maxOutputBytes?: number;
+}
+
+export interface ChannelCollectedSubscription {
+  frames: ChannelSubscriptionFrame[];
+  state: RelayChannelReducerState;
+  durableSeq: number;
+  /** Why a finite local collection returned. */
+  stopReason: 'max-events' | 'idle-timeout' | 'stream-closed' | 'aborted';
+}
+
+export interface RelayChannelClient {
+  list(): Promise<{ channels: ChannelSummary[] }>;
+  get(input: { channelId: string }): Promise<{ channel: ChannelSummary }>;
+  run: {
+    get(input: {
+      channelId: string;
+      runId: string;
+      threadId?: string;
+    }): Promise<{ run: ChannelAsyncRun }>;
+  };
+  history(input: {
+    channelId: string;
+    limit?: number;
+    beforeSeq?: number;
+    afterSeq?: number;
+  }): Promise<ChannelPage>;
+  threads: {
+    history(input: {
+      channelId: string;
+      threadId: string;
+      limit?: number;
+      beforeSeq?: number;
+      afterSeq?: number;
+    }): Promise<ChannelPage>;
+  };
+  roster(input: {
+    channelId: string;
+  }): Promise<{ roster: ChannelRosterEntry[] }>;
+  post(input: ChannelPostInput): Promise<ChannelPostResult>;
+  subscribe(
+    input: ChannelSubscribeInput
+  ): AsyncGenerator<ChannelSubscriptionUpdate>;
+  collect(input: ChannelCollectInput): Promise<ChannelCollectedSubscription>;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+const PRIVATE_PROVIDER_KEYS = new Set([
+  'runtimeId',
+  'turnId',
+  'itemId',
+  'providerItemId',
+  'providerTurnId',
+  'providerRuntimeId',
+  'sessionId',
+  'source',
+  'sourceId',
+  'sourceRuntimeId',
+  'sourceTurnId',
+  'sourceItemId',
+]);
+const PRIVATE_PROVIDER_NORMALIZED_KEYS = new Set(
+  [...PRIVATE_PROVIDER_KEYS].map((key) =>
+    key.replace(/[-_]/g, '').toLowerCase()
+  )
+);
+const SENSITIVE_ERROR_KEY =
+  /(?:token|authorization|credential|secret|api[-_]?key|password)/i;
+export const RELAY_CHANNEL_SUBSCRIPTION_MAX_LINE_BYTES = 1024 * 1024;
+export const RELAY_CHANNEL_SUBSCRIPTION_MAX_STREAM_BYTES = 8 * 1024 * 1024;
+export const RELAY_CHANNEL_SUBSCRIPTION_MAX_COLLECTED_OUTPUT_BYTES =
+  8 * 1024 * 1024;
+
+function isPrivateProviderKey(key: string): boolean {
+  const normalized = key.replace(/[-_]/g, '').toLowerCase();
+  return (
+    PRIVATE_PROVIDER_NORMALIZED_KEYS.has(normalized) ||
+    /^(?:provider|source)?(?:runtime|turn|item|session)(?:id)?$/.test(
+      normalized
+    )
+  );
+}
+
+/** Public Relay correlations must not become redaction needles. */
+function isRetainedRelayKey(key: string): boolean {
+  const normalized = key.replace(/[-_]/g, '').toLowerCase();
+  return (
+    normalized === 'runid' ||
+    normalized === 'targetid' ||
+    normalized === 'sender' ||
+    normalized === 'senderid' ||
+    normalized === 'providerid'
+  );
+}
+
+function isPrivateValueKey(key: string): boolean {
+  return isPrivateProviderKey(key) || SENSITIVE_ERROR_KEY.test(key);
+}
+
+/**
+ * First pass: keep the strings named by private fields even when they are
+ * echoed under an otherwise harmless key somewhere else in the same envelope.
+ * This deliberately runs before field removal; a source object can contain a
+ * provider marker which a diagnostic string later repeats verbatim.
+ */
+function collectPrivateStringValues(
+  value: unknown,
+  values: Set<string>,
+  inheritedPrivate = false
+): void {
+  if (typeof value === 'string') {
+    if (inheritedPrivate && value.length > 0) values.add(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value)
+      collectPrivateStringValues(entry, values, inheritedPrivate);
+    return;
+  }
+  const object = record(value);
+  if (!object) return;
+  for (const [key, entry] of Object.entries(object)) {
+    const childPrivate = isRetainedRelayKey(key)
+      ? false
+      : inheritedPrivate || isPrivateValueKey(key);
+    collectPrivateStringValues(entry, values, childPrivate);
+  }
+}
+
+function redactPrivateStrings(
+  value: string,
+  needles: ReadonlySet<string>
+): string {
+  let result = value;
+  for (const needle of needles)
+    result = result.split(needle).join('[REDACTED]');
+  return result;
+}
+
+/** Remove provider correlations and secret-bearing keys from nested public data. */
+function projectPublicValue(value: unknown, configuredToken?: string): unknown {
+  const privateValues = new Set<string>();
+  if (configuredToken) privateValues.add(configuredToken);
+  collectPrivateStringValues(value, privateValues);
+  return projectPublicValueWithNeedles(value, privateValues);
+}
+
+function projectPublicValueWithNeedles(
+  value: unknown,
+  privateValues: ReadonlySet<string>
+): unknown {
+  if (typeof value === 'string')
+    return redactPrivateStrings(value, privateValues);
+  if (Array.isArray(value))
+    return value.map((entry) =>
+      projectPublicValueWithNeedles(entry, privateValues)
+    );
+  const object = record(value);
+  if (!object) return value;
+  return Object.fromEntries(
+    Object.entries(object)
+      .filter(([key]) => !isPrivateValueKey(key))
+      .map(([key, entry]) => [
+        key,
+        projectPublicValueWithNeedles(entry, privateValues),
+      ])
+  );
+}
+
+/** Project every message-bearing response at the client boundary. */
+export function projectRelayChannelMessage(
+  message: ChannelMessage,
+  configuredToken?: string
+): RelayChannelMessage {
+  return projectPublicValue(message, configuredToken) as RelayChannelMessage;
+}
+
+function projectChannelEvent(
+  event: ChannelEventV1,
+  configuredToken?: string
+): RelayChannelEvent {
+  // One pass over the complete event matters: a private source value on one
+  // snapshot row must also be redacted if another row echoes it under `detail`.
+  return projectPublicValue(event, configuredToken) as RelayChannelEvent;
+}
+
+function projectReducerState(
+  state: ChannelReducerState,
+  configuredToken?: string
+): RelayChannelReducerState {
+  return projectPublicValue(state, configuredToken) as RelayChannelReducerState;
+}
+
+function asInternalReducerState(
+  state: RelayChannelReducerState
+): ChannelReducerState {
+  // Reducer operations use stable row ids, sequence and stream cursors. The
+  // omitted provider metadata is deliberately irrelevant to those operations.
+  return state as unknown as ChannelReducerState;
+}
+
+function projectPage(
+  page: {
+    messages: ChannelMessage[];
+    hasMore?: boolean;
+    nextCursor?: ChannelPage['nextCursor'];
+  },
+  configuredToken?: string
+): ChannelPage {
+  return {
+    messages: page.messages.map((message) =>
+      projectRelayChannelMessage(message, configuredToken)
+    ),
+    ...(page.hasMore === undefined ? {} : { hasMore: page.hasMore }),
+    ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
+  };
+}
+
+function projectPostResult(
+  result: Omit<ChannelPostResult, 'message'> & { message: ChannelMessage },
+  configuredToken?: string
+): ChannelPostResult {
+  return projectPublicValue(
+    {
+      ...result,
+      message: projectRelayChannelMessage(result.message, configuredToken),
+    },
+    configuredToken
+  ) as ChannelPostResult;
+}
+
+function readErrorBody(
+  value: unknown,
+  configuredToken?: string
+): RelayChannelClientErrorBody {
+  const outer = record(value);
+  const candidate = record(outer?.['error']) ?? outer;
+  if (!candidate) return {};
+  const projectedCandidate =
+    record(projectPublicValue(candidate, configuredToken)) ?? {};
+  const details = record(projectedCandidate['details']);
+  return {
+    ...(typeof candidate['code'] === 'string'
+      ? { code: gatewayErrorCode(candidate['code']) }
+      : { code: 'UPSTREAM_ERROR' }),
+    ...(typeof projectedCandidate['message'] === 'string'
+      ? {
+          message: projectedCandidate['message'],
+        }
+      : {}),
+    ...(typeof projectedCandidate['retryable'] === 'boolean'
+      ? { retryable: projectedCandidate['retryable'] }
+      : {}),
+    ...(details
+      ? {
+          details,
+        }
+      : {}),
+  };
+}
+
+function publicTransportError(error: unknown, configuredToken?: string): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  return new Error(projectPublicValue(message, configuredToken) as string);
+}
+
+function trimBaseUrl(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function defaultBaseUrl(
+  env: Readonly<Record<string, string | undefined>>
+): string {
+  return trimBaseUrl(
+    env['RELAY_IDE_URL'] ??
+      `http://127.0.0.1:${env['RELAY_IDE_PORT'] ?? '3456'}`
+  );
+}
+
+function pathWithQuery(
+  pathname: string,
+  query: Record<string, unknown>
+): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== false) search.set(key, String(value));
+  }
+  return `${pathname}${search.size ? `?${search}` : ''}`;
+}
+
+function jsonBytes(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function collectionOutput(
+  frames: readonly ChannelSubscriptionFrame[],
+  state: RelayChannelReducerState,
+  durableSeq: number,
+  stopReason: ChannelCollectedSubscription['stopReason']
+): ChannelCollectedSubscription {
+  return { frames: [...frames], state, durableSeq, stopReason };
+}
+
+function boundedPositiveInteger(
+  value: number | undefined,
+  fallback: number,
+  name: string
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new RelayChannelClientError(400, {
+      code: 'INVALID_ARGUMENT',
+      message: `${name} must be a positive safe integer`,
+    });
+  }
+  return resolved;
+}
+
+function appendBytes(
+  left: Uint8Array<ArrayBufferLike>,
+  right: Uint8Array<ArrayBufferLike>
+): Uint8Array<ArrayBufferLike> {
+  if (left.byteLength === 0) return right;
+  if (right.byteLength === 0) return left;
+  const joined = new Uint8Array(left.byteLength + right.byteLength);
+  joined.set(left);
+  joined.set(right, left.byteLength);
+  return joined;
+}
+
+function isHeartbeat(
+  value: unknown
+): value is { type: 'channel-heartbeat-v1' } {
+  const payload = record(value);
+  return (
+    payload !== undefined &&
+    Object.keys(payload).length === 1 &&
+    payload['type'] === 'channel-heartbeat-v1'
+  );
+}
+
+type InternalSubscriptionFrame = Omit<ChannelSubscriptionFrame, 'payload'> & {
+  payload?: ChannelEventV1 | { type: 'channel-heartbeat-v1' };
+};
+
+const SUBSCRIPTION_FRAME_COMMON_KEYS = [
+  'schemaVersion',
+  'frame',
+  'channelId',
+  'sequence',
+  'occurredAt',
+  'durableSeq',
+] as const;
+
+function hasOnlySubscriptionFrameKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[]
+): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function hasValidSubscriptionFrameBase(
+  frame: Record<string, unknown>,
+  expectedChannelId: string
+): boolean {
+  return (
+    frame['schemaVersion'] === 1 &&
+    frame['channelId'] === expectedChannelId &&
+    typeof frame['sequence'] === 'number' &&
+    Number.isSafeInteger(frame['sequence']) &&
+    frame['sequence'] >= 0 &&
+    typeof frame['occurredAt'] === 'string' &&
+    typeof frame['durableSeq'] === 'number' &&
+    Number.isSafeInteger(frame['durableSeq']) &&
+    frame['durableSeq'] >= 0
+  );
+}
+
+function eventMatchesSubscriptionChannel(
+  event: ChannelEventV1,
+  channelId: string
+): boolean {
+  if (event.channelId !== channelId) return false;
+  switch (event.type) {
+    case 'channel-snapshot-v1':
+      return (
+        event.messages.every((message) => message.channelId === channelId) &&
+        event.stateReplacements?.every(
+          (replacement) => replacement.message.channelId === channelId
+        ) !== false &&
+        event.runs?.every((run) => run.channelId === channelId) !== false
+      );
+    case 'channel-message-created-v1':
+    case 'channel-message-updated-v1':
+    case 'channel-message-completed-v1':
+    case 'channel-message-edited-v1':
+    case 'channel-message-deleted-v1':
+      return event.message.channelId === channelId;
+    case 'channel-run-lifecycle-v1':
+      return event.run.channelId === channelId;
+    case 'channel-message-delta-v1':
+    case 'channel-resync-required-v1':
+      return true;
+  }
+}
+
+/** Validate the wire discriminants before reducing or spreading any frame. */
+function isSubscriptionFrame(
+  value: unknown,
+  expectedChannelId: string
+): value is InternalSubscriptionFrame {
+  const frame = record(value);
+  if (!frame || !hasValidSubscriptionFrameBase(frame, expectedChannelId))
+    return false;
+  if (frame['frame'] === 'open') {
+    return hasOnlySubscriptionFrameKeys(frame, SUBSCRIPTION_FRAME_COMMON_KEYS);
+  }
+  if (frame['frame'] === 'event') {
+    if (
+      !hasOnlySubscriptionFrameKeys(frame, [
+        ...SUBSCRIPTION_FRAME_COMMON_KEYS,
+        'payload',
+      ]) ||
+      !Object.hasOwn(frame, 'payload')
+    ) {
+      return false;
+    }
+    const payload = frame['payload'];
+    return (
+      isHeartbeat(payload) ||
+      (isChannelEventV1(payload) &&
+        eventMatchesSubscriptionChannel(payload, expectedChannelId))
+    );
+  }
+  if (frame['frame'] !== 'closed') return false;
+  return (
+    hasOnlySubscriptionFrameKeys(frame, [
+      ...SUBSCRIPTION_FRAME_COMMON_KEYS,
+      'reason',
+      'retryable',
+      'latestSeq',
+    ]) &&
+    typeof frame['reason'] === 'string' &&
+    typeof frame['retryable'] === 'boolean' &&
+    (frame['latestSeq'] === undefined ||
+      (typeof frame['latestSeq'] === 'number' &&
+        Number.isSafeInteger(frame['latestSeq']) &&
+        frame['latestSeq'] >= 0))
+  );
+}
+
+export function createRelayChannelClient(
+  config: RelayChannelClientConfig = {}
+): RelayChannelClient {
+  const env = config.env ?? process.env;
+  const baseUrl = trimBaseUrl(config.baseUrl ?? defaultBaseUrl(env));
+  // A browser bearer is accepted by the ordinary HTTP auth lane.  Advertising
+  // it as an actor credential would switch server-side scope semantics, so the
+  // actor marker is emitted only for a known actor credential/env lane.
+  const configuredToken = config.token;
+  const configuredActor = configuredToken?.startsWith('relay-sac-v1.')
+    ? configuredToken
+    : undefined;
+  const actorToken = configuredActor ?? env['RELAY_IDE_ACTOR_TOKEN'];
+  const browserToken = configuredActor
+    ? undefined
+    : (configuredToken ?? env['RELAY_IDE_BROWSER_TOKEN']);
+  const token = actorToken ?? browserToken;
+  const fetcher = config.fetch ?? globalThis.fetch;
+  const staticHeaders = new Headers(config.headers);
+
+  const headersFor = (command: string, write = false): Headers => {
+    const headers = new Headers(staticHeaders);
+    headers.set('accept', 'application/json');
+    headers.set('x-relay-cli-gateway', 'v1');
+    headers.set('x-relay-cli-command', command);
+    headers.set(
+      'x-relay-capabilities',
+      write ? 'context:write' : 'context:read'
+    );
+    if (token && !headers.has('authorization'))
+      headers.set('authorization', `Bearer ${token}`);
+    if (actorToken && !headers.has('x-relay-cli-actor-token'))
+      headers.set('x-relay-cli-actor-token', 'v1');
+    return headers;
+  };
+
+  const request = async <T>(
+    command: string,
+    pathname: string,
+    init: RequestInit = {},
+    write = false
+  ): Promise<T> => {
+    const headers = headersFor(command, write);
+    if (init.headers)
+      new Headers(init.headers).forEach((value, key) =>
+        headers.set(key, value)
+      );
+    let response: Response;
+    try {
+      response = await fetcher(`${baseUrl}${pathname}`, { ...init, headers });
+    } catch (error) {
+      throw publicTransportError(error, token);
+    }
+    let raw: string;
+    try {
+      raw = await response.text();
+    } catch (error) {
+      throw publicTransportError(error, token);
+    }
+    let parsed: unknown;
+    try {
+      parsed = raw ? JSON.parse(raw) : undefined;
+    } catch {
+      parsed = undefined;
+    }
+    if (!response.ok)
+      throw new RelayChannelClientError(
+        response.status,
+        readErrorBody(parsed, token)
+      );
+    // Every non-streaming success crosses the same fail-closed recursive
+    // boundary.  Do this before typed method projections so list/get/run/roster
+    // cannot accidentally become a provider-correlation escape hatch.
+    return projectPublicValue(parsed, token) as T;
+  };
+
+  const subscribe = async function* (
+    input: ChannelSubscribeInput
+  ): AsyncGenerator<ChannelSubscriptionUpdate> {
+    const {
+      channelId,
+      afterSeq,
+      state: initialState,
+      signal,
+      maxLineBytes: requestedMaxLineBytes,
+      maxStreamBytes: requestedMaxStreamBytes,
+      ...filter
+    } = input;
+    const maxLineBytes = boundedPositiveInteger(
+      requestedMaxLineBytes,
+      RELAY_CHANNEL_SUBSCRIPTION_MAX_LINE_BYTES,
+      'maxLineBytes'
+    );
+    const maxStreamBytes = boundedPositiveInteger(
+      requestedMaxStreamBytes,
+      RELAY_CHANNEL_SUBSCRIPTION_MAX_STREAM_BYTES,
+      'maxStreamBytes'
+    );
+    const pathname = pathWithQuery(
+      `/channels/${encodeURIComponent(channelId)}/subscribe`,
+      {
+        afterSeq,
+        ...filter,
+      }
+    );
+    const headers = headersFor('channels.subscribe');
+    headers.set('accept', 'application/x-ndjson');
+    const streamAbort = new AbortController();
+    const streamSignal = AbortSignal.any(
+      [signal, streamAbort.signal].filter(
+        (value): value is AbortSignal => value !== undefined
+      )
+    );
+    let response: Response;
+    try {
+      response = await fetcher(`${baseUrl}${pathname}`, {
+        headers,
+        signal: streamSignal,
+      });
+    } catch (error) {
+      if (signal?.aborted || streamAbort.signal.aborted) return;
+      throw publicTransportError(error, token);
+    }
+    if (!response.ok) {
+      let raw: string;
+      try {
+        raw = await response.text();
+      } catch (error) {
+        throw publicTransportError(error, token);
+      }
+      let parsed: unknown;
+      try {
+        parsed = raw ? JSON.parse(raw) : undefined;
+      } catch {
+        parsed = undefined;
+      }
+      throw new RelayChannelClientError(
+        response.status,
+        readErrorBody(parsed, token)
+      );
+    }
+    if (!response.body)
+      throw new RelayChannelClientError(502, {
+        code: 'UPSTREAM_ERROR',
+        retryable: true,
+        message: 'Relay subscription response had no body',
+      });
+
+    let state = initialState
+      ? asInternalReducerState(initialState)
+      : initialChannelReducerState(channelId);
+    let durableSeq = afterSeq ?? 0;
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let pendingLine: Uint8Array<ArrayBufferLike> = new Uint8Array();
+    let streamBytes = 0;
+    const overflow = (
+      limit: RelayChannelSubscriptionLimit,
+      maximum: number,
+      observed: number
+    ): never => {
+      streamAbort.abort();
+      throw new RelayChannelSubscriptionOverflowError(limit, maximum, observed);
+    };
+    const emit = (
+      lineBytes: Uint8Array
+    ): ChannelSubscriptionUpdate | undefined => {
+      const line = decoder.decode(lineBytes).trim();
+      if (!line) return undefined;
+      let frame: unknown;
+      try {
+        frame = JSON.parse(line);
+      } catch {
+        throw new RelayChannelClientError(502, {
+          code: 'UPSTREAM_ERROR',
+          retryable: true,
+          message: 'Relay subscription emitted invalid NDJSON',
+        });
+      }
+      if (!isSubscriptionFrame(frame, channelId)) {
+        throw new RelayChannelClientError(502, {
+          code: 'UPSTREAM_ERROR',
+          retryable: true,
+          message: 'Relay subscription emitted an invalid frame',
+        });
+      }
+      const parsed = frame;
+      if (parsed.frame === 'event' && isChannelEventV1(parsed.payload)) {
+        state = applyChannelEventV1(state, parsed.payload);
+      }
+      // durableSeq comes from the authoritative frame, never reducer state.
+      durableSeq = Math.max(durableSeq, parsed.durableSeq);
+      return {
+        frame: {
+          ...(projectPublicValue(parsed, token) as Omit<
+            ChannelSubscriptionFrame,
+            'payload'
+          >),
+          ...(parsed.payload && isChannelEventV1(parsed.payload)
+            ? { payload: projectChannelEvent(parsed.payload, token) }
+            : parsed.payload
+              ? { payload: parsed.payload }
+              : {}),
+        },
+        state: projectReducerState(state, token),
+        durableSeq,
+      };
+    };
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        streamBytes += value.byteLength;
+        if (streamBytes > maxStreamBytes)
+          overflow('stream-bytes', maxStreamBytes, streamBytes);
+        let start = 0;
+        for (let index = 0; index < value.byteLength; index += 1) {
+          if (value[index] !== 0x0a) continue;
+          const segment = value.subarray(start, index);
+          const lineBytes = pendingLine.byteLength + segment.byteLength;
+          if (lineBytes > maxLineBytes)
+            overflow('line-bytes', maxLineBytes, lineBytes);
+          pendingLine = appendBytes(pendingLine, segment);
+          const update = emit(pendingLine);
+          pendingLine = new Uint8Array();
+          if (update) yield update;
+          start = index + 1;
+        }
+        // The final segment has no newline and becomes the bounded carry-over.
+        pendingLine = appendBytes(pendingLine, value.subarray(start));
+        if (pendingLine.byteLength > maxLineBytes)
+          overflow('line-bytes', maxLineBytes, pendingLine.byteLength);
+      }
+      const update = emit(pendingLine);
+      if (update) yield update;
+    } catch (error) {
+      if (signal?.aborted) return;
+      if (error instanceof RelayChannelClientError) throw error;
+      throw publicTransportError(error, token);
+    } finally {
+      streamAbort.abort();
+      await reader.cancel().catch(() => undefined);
+      await reader.closed.catch(() => undefined);
+      reader.releaseLock();
+    }
+  };
+
+  const collect = async (
+    input: ChannelCollectInput
+  ): Promise<ChannelCollectedSubscription> => {
+    const {
+      maxEvents,
+      idleTimeoutMs,
+      maxOutputBytes: requestedMaxOutputBytes,
+      signal,
+      ...subscribeInput
+    } = input;
+    const maxOutputBytes = boundedPositiveInteger(
+      requestedMaxOutputBytes,
+      RELAY_CHANNEL_SUBSCRIPTION_MAX_COLLECTED_OUTPUT_BYTES,
+      'maxOutputBytes'
+    );
+    const controller = new AbortController();
+    const idleSignal =
+      idleTimeoutMs === undefined
+        ? undefined
+        : AbortSignal.timeout(idleTimeoutMs);
+    const combined = AbortSignal.any(
+      [signal, controller.signal, idleSignal].filter(
+        (value): value is AbortSignal => value !== undefined
+      )
+    );
+    const frames: ChannelSubscriptionFrame[] = [];
+    let state: RelayChannelReducerState =
+      subscribeInput.state ??
+      projectReducerState(initialChannelReducerState(subscribeInput.channelId));
+    let durableSeq = subscribeInput.afterSeq ?? 0;
+    let events = 0;
+    let stopReason: ChannelCollectedSubscription['stopReason'] =
+      'stream-closed';
+    for await (const update of subscribe({
+      ...subscribeInput,
+      signal: combined,
+    })) {
+      const nextEvents = events + (update.frame.frame === 'event' ? 1 : 0);
+      const nextStopReason =
+        maxEvents !== undefined && nextEvents >= maxEvents
+          ? 'max-events'
+          : 'stream-closed';
+      // Count the exact object returned to a caller, not fragments of it. That
+      // includes braces, property names, commas, durableSeq, and stopReason.
+      const nextOutputBytes = jsonBytes(
+        collectionOutput(
+          [...frames, update.frame],
+          update.state,
+          update.durableSeq,
+          nextStopReason
+        )
+      );
+      if (nextOutputBytes > maxOutputBytes) {
+        controller.abort();
+        throw new RelayChannelSubscriptionOverflowError(
+          'collected-output-bytes',
+          maxOutputBytes,
+          nextOutputBytes
+        );
+      }
+      frames.push(update.frame);
+      state = update.state;
+      durableSeq = update.durableSeq;
+      events = nextEvents;
+      if (maxEvents !== undefined && events >= maxEvents) {
+        stopReason = 'max-events';
+        controller.abort();
+        break;
+      }
+    }
+    if (idleSignal?.aborted) stopReason = 'idle-timeout';
+    else if (signal?.aborted) stopReason = 'aborted';
+    return collectionOutput(frames, state, durableSeq, stopReason);
+  };
+
+  return {
+    list: () => request('channels.list', '/channels'),
+    get: ({ channelId }) =>
+      request('channels.get', `/channels/${encodeURIComponent(channelId)}`),
+    run: {
+      get: ({ channelId, runId, threadId }) =>
+        request(
+          'channels.run.get',
+          pathWithQuery(
+            `/channels/${encodeURIComponent(channelId)}/runs/${encodeURIComponent(runId)}`,
+            { threadId }
+          )
+        ),
+    },
+    history: ({ channelId, limit, beforeSeq, afterSeq }) =>
+      request<{
+        messages: ChannelMessage[];
+        hasMore?: boolean;
+        nextCursor?: ChannelPage['nextCursor'];
+      }>(
+        'channels.history',
+        pathWithQuery(`/channels/${encodeURIComponent(channelId)}/messages`, {
+          limit,
+          beforeSeq,
+          afterSeq,
+        })
+      ).then(projectPage),
+    threads: {
+      history: ({ channelId, threadId, limit, beforeSeq, afterSeq }) =>
+        request<{
+          messages: ChannelMessage[];
+          hasMore?: boolean;
+          nextCursor?: ChannelPage['nextCursor'];
+        }>(
+          'channels.threads.history',
+          pathWithQuery(
+            `/channels/${encodeURIComponent(channelId)}/threads/${encodeURIComponent(threadId)}`,
+            { limit, beforeSeq, afterSeq }
+          )
+        ).then(projectPage),
+    },
+    roster: ({ channelId }) =>
+      request(
+        'channels.roster',
+        `/channels/${encodeURIComponent(channelId)}/roster`
+      ),
+    post: ({ channelId, ...body }) =>
+      request<Omit<ChannelPostResult, 'message'> & { message: ChannelMessage }>(
+        'channels.post',
+        `/channels/${encodeURIComponent(channelId)}/messages`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+        true
+      ).then(projectPostResult),
+    subscribe,
+    collect,
+  };
+}

--- a/shared/relay-mcp.ts
+++ b/shared/relay-mcp.ts
@@ -1,0 +1,675 @@
+/**
+ * Local, stdio-only MCP facade for the deliberately small channel-client API.
+ *
+ * This is not a generic Relay gateway bridge. The command tuple is closed so a
+ * desktop MCP host cannot turn an ambient Relay credential into shell, PTY, or
+ * provider-runtime access. Credentials are read only by createRelayChannelClient
+ * from process configuration; no MCP tool accepts connection settings or tokens.
+ */
+import {
+  fromJsonSchema,
+  McpServer,
+  type JsonSchemaType,
+} from '@modelcontextprotocol/server';
+
+import {
+  RELAY_CLI_GATEWAY_CONTRACT,
+  RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+  RELAY_CLI_GATEWAY_MAJOR,
+  type RelayCliGatewayCommand,
+  type RelayCliGatewayCommandSpec,
+  type RelayCliGatewayError,
+  type RelayJsonSchema,
+} from './cli-gateway-contract.js';
+import {
+  createRelayChannelClient,
+  RelayChannelClientError,
+  type RelayChannelClient,
+} from './channel-client.js';
+import { RELAY_COMMAND_MANIFEST } from './relay-command-manifest.js';
+
+/** The complete and intentionally non-extensible Relay MCP command set. */
+export const RELAY_MCP_CHANNEL_COMMANDS = [
+  'channels.list',
+  'channels.get',
+  'channels.run.get',
+  'channels.history',
+  'channels.subscribe',
+  'channels.threads.history',
+  'channels.roster',
+  'channels.post',
+] as const satisfies readonly RelayCliGatewayCommand[];
+
+export const RELAY_MCP_SUBSCRIBE_MAX_EVENTS = 100;
+export const RELAY_MCP_SUBSCRIBE_MAX_IDLE_TIMEOUT_MS = 30_000;
+
+type RelayMcpChannelCommand = (typeof RELAY_MCP_CHANNEL_COMMANDS)[number];
+type JsonRecord = Record<string, unknown>;
+
+// Keep this denylist aligned with the channel-client projection. The MCP
+// facade repeats it deliberately: injected/test clients and future client
+// regressions must not turn the facade into a provider-correlation escape.
+const PRIVATE_PROVIDER_KEYS = new Set([
+  'runtimeId',
+  'turnId',
+  'itemId',
+  'providerItemId',
+  'providerTurnId',
+  'providerRuntimeId',
+  'sessionId',
+  'source',
+  'sourceId',
+  'sourceRuntimeId',
+  'sourceTurnId',
+  'sourceItemId',
+]);
+const PRIVATE_PROVIDER_NORMALIZED_KEYS = new Set(
+  [...PRIVATE_PROVIDER_KEYS].map((key) => key.toLowerCase())
+);
+const SENSITIVE_ERROR_KEY =
+  /(?:token|authorization|credential|secret|api[-_]?key|password)/i;
+
+export interface RelayMcpToolDefinition {
+  command: RelayMcpChannelCommand;
+  name: string;
+  description: string;
+  inputSchema: RelayJsonSchema;
+  outputSchema: RelayJsonSchema;
+}
+
+export interface RelayMcpOkEnvelope {
+  ok: true;
+  contract: typeof RELAY_CLI_GATEWAY_MAJOR;
+  contractVersion: typeof RELAY_CLI_GATEWAY_CONTRACT_VERSION;
+  command: RelayMcpChannelCommand;
+  data: JsonRecord;
+}
+
+export interface RelayMcpErrorEnvelope {
+  ok: false;
+  contract: typeof RELAY_CLI_GATEWAY_MAJOR;
+  contractVersion: typeof RELAY_CLI_GATEWAY_CONTRACT_VERSION;
+  command: RelayMcpChannelCommand;
+  error: RelayCliGatewayError;
+}
+
+export type RelayMcpEnvelope = RelayMcpOkEnvelope | RelayMcpErrorEnvelope;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPrivateProviderKey(key: string): boolean {
+  const normalized = key.replace(/[-_]/g, '').toLowerCase();
+  return (
+    PRIVATE_PROVIDER_NORMALIZED_KEYS.has(normalized) ||
+    /^(?:provider|source)?(?:runtime|turn|item|session)(?:id)?$/.test(
+      normalized
+    )
+  );
+}
+
+function toolName(command: RelayMcpChannelCommand): string {
+  return `relay_${command.replaceAll('.', '_')}`;
+}
+
+function commandSpec(
+  command: RelayMcpChannelCommand
+): RelayCliGatewayCommandSpec {
+  const spec = RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.find(
+    (candidate) => candidate.name === command
+  );
+  const manifestEntry = RELAY_COMMAND_MANIFEST.commands.find(
+    (candidate) => candidate.name === command
+  );
+  if (
+    !spec ||
+    !manifestEntry ||
+    manifestEntry.inputSchema !== spec.inputSchema ||
+    manifestEntry.outputSchema !== spec.outputSchema
+  ) {
+    throw new Error(`Relay MCP command manifest drift for ${command}`);
+  }
+  return spec;
+}
+
+function copySchema(schema: RelayJsonSchema): RelayJsonSchema {
+  return structuredClone(schema);
+}
+
+/**
+ * The gateway allows long-lived subscriptions for native clients. MCP calls
+ * must always name both bounds so an agent cannot accidentally hold stdio open.
+ */
+function boundedSubscribeInputSchema(schema: RelayJsonSchema): RelayJsonSchema {
+  const result = copySchema(schema);
+  const properties = result.properties ?? {};
+  properties['maxEvents'] = {
+    ...(properties['maxEvents'] ?? {}),
+    minimum: 1,
+    maximum: RELAY_MCP_SUBSCRIBE_MAX_EVENTS,
+    description: `Required MCP bound; at most ${RELAY_MCP_SUBSCRIBE_MAX_EVENTS} event frames.`,
+  };
+  properties['idleTimeoutMs'] = {
+    ...(properties['idleTimeoutMs'] ?? {}),
+    minimum: 1,
+    maximum: RELAY_MCP_SUBSCRIBE_MAX_IDLE_TIMEOUT_MS,
+    description: `Required MCP quiet-stream deadline; at most ${RELAY_MCP_SUBSCRIBE_MAX_IDLE_TIMEOUT_MS} ms.`,
+  };
+  result.properties = properties;
+  result.required = [
+    ...new Set([...(result.required ?? []), 'maxEvents', 'idleTimeoutMs']),
+  ];
+  return result;
+}
+
+/**
+ * Preserve the gateway envelope shape but state that returned values are the
+ * public channel projection. The source schema remains mechanically sourced
+ * from the stable contract, while the runtime sanitizer below removes every
+ * provider-runtime locator before it reaches the MCP transport.
+ */
+function publicOutputSchema(spec: RelayCliGatewayCommandSpec): RelayJsonSchema {
+  const schema = copySchema(spec.outputSchema);
+  return {
+    title: `${schema.title ?? spec.name}McpEnvelope`,
+    description: `${schema.description ?? spec.summary} MCP returns a typed Relay success or error envelope after public-channel projection; provider runtimeId, turnId, and itemId are never returned.`,
+    oneOf: [schema, copySchema(RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema)],
+  };
+}
+
+/**
+ * MCP is request/response, so its subscribe tool does not expose the gateway's
+ * unbounded single-frame result. It returns the client's finite collection
+ * instead. Keep the frame validator mechanically derived from the canonical
+ * gateway schema so event variants cannot drift between the two surfaces.
+ */
+function boundedSubscribeOutputSchema(
+  spec: RelayCliGatewayCommandSpec
+): RelayJsonSchema {
+  const successSchema = copySchema(spec.outputSchema);
+  const canonicalFrameSchema = successSchema.properties?.['data'];
+  if (!canonicalFrameSchema)
+    throw new Error('channels.subscribe is missing its canonical frame schema');
+
+  successSchema.title = 'ChannelsSubscribeCollectionOutput';
+  successSchema.description =
+    'A finite public-channel collection. frames use the canonical channels.subscribe frame schema and are bounded by the required MCP maxEvents input.';
+  successSchema.properties = {
+    ...successSchema.properties,
+    data: {
+      title: 'ChannelsSubscribeCollectionData',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        frames: {
+          type: 'array',
+          items: copySchema(canonicalFrameSchema),
+          description: `At most ${RELAY_MCP_SUBSCRIBE_MAX_EVENTS} event frames, plus any open or closed boundary frames.`,
+        },
+        // The client intentionally returns its reduced public state along with
+        // frames, so an MCP host can resume from durableSeq without replaying
+        // non-delivery state replacements as user-visible messages.
+        state: { type: 'object', additionalProperties: true },
+        durableSeq: { type: 'integer', minimum: 0 },
+        stopReason: { type: 'string' },
+      },
+      required: ['frames', 'state', 'durableSeq', 'stopReason'],
+    },
+  };
+  return {
+    title: `${successSchema.title}McpEnvelope`,
+    description:
+      'MCP returns the bounded public channel collection or a typed Relay error. Provider runtimeId, turnId, and itemId are never returned.',
+    oneOf: [
+      successSchema,
+      copySchema(RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema),
+    ],
+  };
+}
+
+export function relayMcpToolDefinitions(): readonly RelayMcpToolDefinition[] {
+  return RELAY_MCP_CHANNEL_COMMANDS.map((command) => {
+    const spec = commandSpec(command);
+    return {
+      command,
+      name: toolName(command),
+      description: `${spec.summary} Local stdio only; Relay credentials come exclusively from the process environment.`,
+      inputSchema:
+        command === 'channels.subscribe'
+          ? boundedSubscribeInputSchema(spec.inputSchema)
+          : copySchema(spec.inputSchema),
+      outputSchema:
+        command === 'channels.subscribe'
+          ? boundedSubscribeOutputSchema(spec)
+          : publicOutputSchema(spec),
+    };
+  });
+}
+
+function invalid(
+  command: RelayMcpChannelCommand,
+  message: string
+): RelayMcpErrorEnvelope {
+  return {
+    ok: false,
+    contract: RELAY_CLI_GATEWAY_MAJOR,
+    contractVersion: RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+    command,
+    error: { code: 'INVALID_ARGUMENT', message, retryable: false },
+  };
+}
+
+function requireString(input: JsonRecord, key: string): string | undefined {
+  const value = input[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function optionalString(input: JsonRecord, key: string): string | undefined {
+  const value = input[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function optionalInteger(input: JsonRecord, key: string): number | undefined {
+  const value = input[key];
+  return typeof value === 'number' && Number.isInteger(value)
+    ? value
+    : undefined;
+}
+
+function assertOnlySchemaKeys(
+  command: RelayMcpChannelCommand,
+  input: JsonRecord,
+  schema: RelayJsonSchema
+): RelayMcpErrorEnvelope | undefined {
+  if (schema.additionalProperties !== false) return undefined;
+  const allowed = new Set(Object.keys(schema.properties ?? {}));
+  const unexpected = Object.keys(input).find((key) => !allowed.has(key));
+  return unexpected
+    ? invalid(command, `${unexpected} is not a supported input`)
+    : undefined;
+}
+
+function privateProviderValues(value: unknown, values: Set<string>): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => privateProviderValues(entry, values));
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    if (
+      isPrivateProviderKey(key) &&
+      typeof nested === 'string' &&
+      nested.length > 0
+    ) {
+      values.add(nested);
+    }
+    privateProviderValues(nested, values);
+  }
+}
+
+function redactProviderValues(
+  value: string,
+  values: ReadonlySet<string>
+): string {
+  let result = value;
+  for (const privateValue of [...values].sort(
+    (left, right) => right.length - left.length
+  )) {
+    result = result.replaceAll(privateValue, '[redacted]');
+  }
+  return result;
+}
+
+function publicValue(
+  value: unknown,
+  privateValues: ReadonlySet<string> = new Set()
+): unknown {
+  if (typeof value === 'string')
+    return redactProviderValues(value, privateValues);
+  if (Array.isArray(value))
+    return value.map((entry) => publicValue(entry, privateValues));
+  if (!isRecord(value)) return value;
+  const result: JsonRecord = {};
+  for (const [key, nested] of Object.entries(value)) {
+    // These fields name provider-private runtime entities. Omit them at every
+    // depth, including unknown server error details and future event variants.
+    if (isPrivateProviderKey(key) || SENSITIVE_ERROR_KEY.test(key)) continue;
+    const projected = publicValue(nested, privateValues);
+    if (
+      key === 'agentDetail' &&
+      isRecord(projected) &&
+      Object.keys(projected).length === 0
+    )
+      continue;
+    result[key] = projected;
+  }
+  return result;
+}
+
+function publicData(value: unknown): JsonRecord {
+  const privateValues = new Set<string>();
+  privateProviderValues(value, privateValues);
+  const projected = publicValue(value, privateValues);
+  return isRecord(projected) ? projected : { value: projected };
+}
+
+/**
+ * A client can receive an untrusted error body from a remote Relay endpoint.
+ * Never pass an unknown string through to MCP's canonical error schema: that
+ * would make an otherwise typed facade fail output validation and discard the
+ * useful error envelope. Unknown upstream spellings are safely categorized.
+ */
+function canonicalErrorCode(value: unknown): RelayCliGatewayError['code'] {
+  const canonicalCodes =
+    RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema.properties?.['error']
+      ?.properties?.['code']?.enum ?? [];
+  return typeof value === 'string' &&
+    canonicalCodes.includes(value as RelayCliGatewayError['code'])
+    ? (value as RelayCliGatewayError['code'])
+    : 'UPSTREAM_ERROR';
+}
+
+function publicError(error: unknown): RelayCliGatewayError {
+  if (error instanceof RelayChannelClientError) {
+    const privateValues = new Set<string>();
+    privateProviderValues(error.details, privateValues);
+    return {
+      code: canonicalErrorCode(error.code),
+      message: redactProviderValues(error.message, privateValues),
+      retryable: error.retryable ?? true,
+      ...(error.details ? { details: publicData(error.details) } : {}),
+    };
+  }
+  return {
+    code: 'UPSTREAM_ERROR',
+    message: 'Relay channel request failed',
+    retryable: true,
+  };
+}
+
+function errorEnvelope(
+  command: RelayMcpChannelCommand,
+  error: unknown
+): RelayMcpErrorEnvelope {
+  return {
+    ok: false,
+    contract: RELAY_CLI_GATEWAY_MAJOR,
+    contractVersion: RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+    command,
+    error: publicError(error),
+  };
+}
+
+function success(
+  command: RelayMcpChannelCommand,
+  data: unknown
+): RelayMcpOkEnvelope {
+  return {
+    ok: true,
+    contract: RELAY_CLI_GATEWAY_MAJOR,
+    contractVersion: RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+    command,
+    data: publicData(data),
+  };
+}
+
+function boundedSubscribeInput(input: JsonRecord):
+  | {
+      channelId: string;
+      maxEvents: number;
+      idleTimeoutMs: number;
+      afterSeq?: number;
+      filter?: JsonRecord;
+    }
+  | RelayMcpErrorEnvelope {
+  const channelId = requireString(input, 'channelId');
+  const maxEvents = optionalInteger(input, 'maxEvents');
+  const idleTimeoutMs = optionalInteger(input, 'idleTimeoutMs');
+  if (!channelId)
+    return invalid(
+      'channels.subscribe',
+      'channelId must be a non-empty string'
+    );
+  if (
+    maxEvents === undefined ||
+    maxEvents < 1 ||
+    maxEvents > RELAY_MCP_SUBSCRIBE_MAX_EVENTS
+  )
+    return invalid(
+      'channels.subscribe',
+      `maxEvents must be an integer from 1 to ${RELAY_MCP_SUBSCRIBE_MAX_EVENTS}`
+    );
+  if (
+    idleTimeoutMs === undefined ||
+    idleTimeoutMs < 1 ||
+    idleTimeoutMs > RELAY_MCP_SUBSCRIBE_MAX_IDLE_TIMEOUT_MS
+  )
+    return invalid(
+      'channels.subscribe',
+      `idleTimeoutMs must be an integer from 1 to ${RELAY_MCP_SUBSCRIBE_MAX_IDLE_TIMEOUT_MS}`
+    );
+  const afterSeq = optionalInteger(input, 'afterSeq');
+  if (
+    input['afterSeq'] !== undefined &&
+    (afterSeq === undefined || afterSeq < 0)
+  )
+    return invalid(
+      'channels.subscribe',
+      'afterSeq must be a non-negative integer'
+    );
+  const filter = input['filter'];
+  if (filter !== undefined && !isRecord(filter))
+    return invalid('channels.subscribe', 'filter must be an object');
+  return {
+    channelId,
+    maxEvents,
+    idleTimeoutMs,
+    ...(afterSeq === undefined ? {} : { afterSeq }),
+    ...(filter === undefined ? {} : { filter }),
+  };
+}
+
+type RelayMcpReadCommand = Exclude<
+  RelayMcpChannelCommand,
+  'channels.post' | 'channels.subscribe'
+>;
+
+function pageInput(
+  command: RelayMcpReadCommand,
+  input: JsonRecord
+):
+  | { channelId: string; limit?: number; beforeSeq?: number; afterSeq?: number }
+  | RelayMcpErrorEnvelope {
+  const channelId = requireString(input, 'channelId');
+  if (!channelId)
+    return invalid(command, 'channelId must be a non-empty string');
+  const limit = optionalInteger(input, 'limit');
+  const beforeSeq = optionalInteger(input, 'beforeSeq');
+  const afterSeq = optionalInteger(input, 'afterSeq');
+  if (beforeSeq !== undefined && afterSeq !== undefined)
+    return invalid(command, 'beforeSeq and afterSeq cannot both be set');
+  return {
+    channelId,
+    ...(limit === undefined ? {} : { limit }),
+    ...(beforeSeq === undefined ? {} : { beforeSeq }),
+    ...(afterSeq === undefined ? {} : { afterSeq }),
+  };
+}
+
+async function executeReadTool(
+  command: RelayMcpReadCommand,
+  input: JsonRecord,
+  client: RelayChannelClient
+): Promise<RelayMcpEnvelope> {
+  switch (command) {
+    case 'channels.list':
+      return success(command, await client.list());
+    case 'channels.get': {
+      const channelId = requireString(input, 'channelId');
+      return channelId
+        ? success(command, await client.get({ channelId }))
+        : invalid(command, 'channelId must be a non-empty string');
+    }
+    case 'channels.run.get': {
+      const channelId = requireString(input, 'channelId');
+      const runId = requireString(input, 'runId');
+      if (!channelId || !runId)
+        return invalid(
+          command,
+          'channelId and runId must be non-empty strings'
+        );
+      const threadId = optionalString(input, 'threadId');
+      return success(
+        command,
+        await client.run.get({
+          channelId,
+          runId,
+          ...(threadId === undefined ? {} : { threadId }),
+        })
+      );
+    }
+    case 'channels.history': {
+      const page = pageInput(command, input);
+      return 'ok' in page ? page : success(command, await client.history(page));
+    }
+    case 'channels.threads.history': {
+      const page = pageInput(command, input);
+      const threadId = requireString(input, 'threadId');
+      if ('ok' in page) return page;
+      if (!threadId)
+        return invalid(
+          command,
+          'channelId and threadId must be non-empty strings'
+        );
+      return success(
+        command,
+        await client.threads.history({ ...page, threadId })
+      );
+    }
+    case 'channels.roster': {
+      const channelId = requireString(input, 'channelId');
+      return channelId
+        ? success(command, await client.roster({ channelId }))
+        : invalid(command, 'channelId must be a non-empty string');
+    }
+  }
+}
+
+async function executePostTool(
+  input: JsonRecord,
+  client: RelayChannelClient
+): Promise<RelayMcpEnvelope> {
+  const command = 'channels.post' as const;
+  const channelId = requireString(input, 'channelId');
+  const text = requireString(input, 'text');
+  if (!channelId || !text)
+    return invalid(command, 'channelId and text must be non-empty strings');
+  const format = input['format'];
+  if (format !== undefined && format !== 'text' && format !== 'markdown')
+    return invalid(command, 'format must be text or markdown');
+  const parentMessageId = optionalString(input, 'parentMessageId');
+  const threadId = input['threadId'];
+  if (
+    threadId !== undefined &&
+    threadId !== null &&
+    typeof threadId !== 'string'
+  )
+    return invalid(command, 'threadId must be a string or null');
+  const clientMessageId = optionalString(input, 'clientMessageId');
+  return success(
+    command,
+    await client.post({
+      channelId,
+      text,
+      ...(format === undefined ? {} : { format }),
+      ...(parentMessageId === undefined
+        ? {}
+        : { parentMessageId: parentMessageId as `chm:${string}` }),
+      ...(threadId === undefined
+        ? {}
+        : { threadId: threadId as `chm:${string}` | null }),
+      ...(clientMessageId === undefined ? {} : { clientMessageId }),
+    })
+  );
+}
+
+async function executeSubscribeTool(
+  input: JsonRecord,
+  client: RelayChannelClient
+): Promise<RelayMcpEnvelope> {
+  const bounded = boundedSubscribeInput(input);
+  if ('ok' in bounded) return bounded;
+  return success(
+    'channels.subscribe',
+    await client.collect({
+      channelId: bounded.channelId,
+      maxEvents: bounded.maxEvents,
+      idleTimeoutMs: bounded.idleTimeoutMs,
+      ...(bounded.afterSeq === undefined ? {} : { afterSeq: bounded.afterSeq }),
+      ...(bounded.filter ?? {}),
+    })
+  );
+}
+
+/** Execute one of the eight allowed commands; never accepts credentials/configuration. */
+export async function executeRelayMcpTool(
+  command: RelayMcpChannelCommand,
+  input: unknown,
+  client: RelayChannelClient = createRelayChannelClient()
+): Promise<RelayMcpEnvelope> {
+  const definition = relayMcpToolDefinitions().find(
+    (entry) => entry.command === command
+  );
+  if (!definition || !isRecord(input))
+    return invalid(command, 'tool input must be an object');
+  const unexpected = assertOnlySchemaKeys(
+    command,
+    input,
+    definition.inputSchema
+  );
+  if (unexpected) return unexpected;
+  try {
+    if (command === 'channels.post')
+      return await executePostTool(input, client);
+    if (command === 'channels.subscribe')
+      return await executeSubscribeTool(input, client);
+    return await executeReadTool(command, input, client);
+  } catch (error) {
+    return errorEnvelope(command, error);
+  }
+}
+
+/** Create the local stdio server. Callers intentionally cannot add Relay tools. */
+export function createRelayMcpServer(
+  client: RelayChannelClient = createRelayChannelClient()
+): McpServer {
+  const server = new McpServer({ name: 'relay-mcp', version: '0.1.1' });
+  for (const definition of relayMcpToolDefinitions()) {
+    server.registerTool(
+      definition.name,
+      {
+        description: definition.description,
+        inputSchema: fromJsonSchema(
+          definition.inputSchema as unknown as JsonSchemaType
+        ),
+        outputSchema: fromJsonSchema(
+          definition.outputSchema as unknown as JsonSchemaType
+        ),
+      },
+      async (input) => {
+        const envelope = await executeRelayMcpTool(
+          definition.command,
+          input,
+          client
+        );
+        return {
+          content: [{ type: 'text', text: JSON.stringify(envelope) }],
+          structuredContent: envelope,
+          ...(envelope.ok ? {} : { isError: true }),
+        };
+      }
+    );
+  }
+  return server;
+}

--- a/shared/relay-mcp.ts
+++ b/shared/relay-mcp.ts
@@ -24,8 +24,13 @@ import {
 import {
   createRelayChannelClient,
   RelayChannelClientError,
+  RelayChannelSubscriptionOverflowError,
   type RelayChannelClient,
 } from './channel-client.js';
+import {
+  isChannelSubscriptionFilter,
+  type ChannelSubscriptionFilter,
+} from './channel-chat-protocol.js';
 import { RELAY_COMMAND_MANIFEST } from './relay-command-manifest.js';
 
 /** The complete and intentionally non-extensible Relay MCP command set. */
@@ -68,6 +73,7 @@ const PRIVATE_PROVIDER_NORMALIZED_KEYS = new Set(
 );
 const SENSITIVE_ERROR_KEY =
   /(?:token|authorization|credential|secret|api[-_]?key|password)/i;
+const PRIVATE_REDACTION_MIN_CHARS = 8;
 
 export interface RelayMcpToolDefinition {
   command: RelayMcpChannelCommand;
@@ -228,7 +234,7 @@ function boundedSubscribeOutputSchema(
   };
 }
 
-export function relayMcpToolDefinitions(): readonly RelayMcpToolDefinition[] {
+function buildRelayMcpToolDefinitions(): readonly RelayMcpToolDefinition[] {
   return RELAY_MCP_CHANNEL_COMMANDS.map((command) => {
     const spec = commandSpec(command);
     return {
@@ -245,6 +251,14 @@ export function relayMcpToolDefinitions(): readonly RelayMcpToolDefinition[] {
           : publicOutputSchema(spec),
     };
   });
+}
+
+// The contract and manifest are process-static. Build once so each tool call
+// cannot allocate/clone eight schemas on its hot path.
+const RELAY_MCP_TOOL_DEFINITIONS = buildRelayMcpToolDefinitions();
+
+export function relayMcpToolDefinitions(): readonly RelayMcpToolDefinition[] {
+  return RELAY_MCP_TOOL_DEFINITIONS;
 }
 
 function invalid(
@@ -300,7 +314,8 @@ function privateProviderValues(value: unknown, values: Set<string>): void {
     if (
       isPrivateProviderKey(key) &&
       typeof nested === 'string' &&
-      nested.length > 0
+      nested.length >= PRIVATE_REDACTION_MIN_CHARS &&
+      /^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(nested)
     ) {
       values.add(nested);
     }
@@ -371,13 +386,25 @@ function canonicalErrorCode(value: unknown): RelayCliGatewayError['code'] {
 }
 
 function publicError(error: unknown): RelayCliGatewayError {
+  if (error instanceof RelayChannelSubscriptionOverflowError) {
+    return {
+      code: 'UPSTREAM_ERROR',
+      message: 'Relay subscription exceeded a local safety limit',
+      retryable: false,
+      details: publicData({
+        limit: error.limit,
+        maximum: error.maximum,
+        observed: error.observed,
+      }),
+    };
+  }
   if (error instanceof RelayChannelClientError) {
     const privateValues = new Set<string>();
     privateProviderValues(error.details, privateValues);
     return {
       code: canonicalErrorCode(error.code),
       message: redactProviderValues(error.message, privateValues),
-      retryable: error.retryable ?? true,
+      retryable: error.retryable ?? error.status >= 500,
       ...(error.details ? { details: publicData(error.details) } : {}),
     };
   }
@@ -420,7 +447,7 @@ function boundedSubscribeInput(input: JsonRecord):
       maxEvents: number;
       idleTimeoutMs: number;
       afterSeq?: number;
-      filter?: JsonRecord;
+      filter?: ChannelSubscriptionFilter;
     }
   | RelayMcpErrorEnvelope {
   const channelId = requireString(input, 'channelId');
@@ -459,8 +486,11 @@ function boundedSubscribeInput(input: JsonRecord):
       'afterSeq must be a non-negative integer'
     );
   const filter = input['filter'];
-  if (filter !== undefined && !isRecord(filter))
-    return invalid('channels.subscribe', 'filter must be an object');
+  if (filter !== undefined && !isChannelSubscriptionFilter(filter))
+    return invalid(
+      'channels.subscribe',
+      'filter must be a valid channel subscription predicate object'
+    );
   return {
     channelId,
     maxEvents,
@@ -603,11 +633,14 @@ async function executeSubscribeTool(
   return success(
     'channels.subscribe',
     await client.collect({
+      // Forward only shared, validated predicate fields. Authoritative MCP
+      // bounds and route identity are assigned afterwards, so a nested object
+      // can never shadow them through object spread order.
+      ...(bounded.filter ?? {}),
       channelId: bounded.channelId,
       maxEvents: bounded.maxEvents,
       idleTimeoutMs: bounded.idleTimeoutMs,
       ...(bounded.afterSeq === undefined ? {} : { afterSeq: bounded.afterSeq }),
-      ...(bounded.filter ?? {}),
     })
   );
 }
@@ -621,8 +654,10 @@ export async function executeRelayMcpTool(
   const definition = relayMcpToolDefinitions().find(
     (entry) => entry.command === command
   );
-  if (!definition || !isRecord(input))
-    return invalid(command, 'tool input must be an object');
+  // Do not reflect an unsupported command supplied through an unsafe cast into
+  // the public envelope or MCP logs. The advertised tuple remains closed.
+  if (!definition) return invalid('channels.list', 'tool is not supported');
+  if (!isRecord(input)) return invalid(command, 'tool input must be an object');
   const unexpected = assertOnlySchemaKeys(
     command,
     input,

--- a/test/channel-client.test.ts
+++ b/test/channel-client.test.ts
@@ -1,0 +1,762 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createRelayChannelClient,
+  RelayChannelClientError,
+  RelayChannelSubscriptionOverflowError,
+} from '../shared/channel-client.js';
+
+const enc = new TextEncoder();
+function message(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    id: 'chm:one',
+    channelId: 'topic:one',
+    seq: 1,
+    kind: 'message',
+    status: 'streaming',
+    sender: { kind: 'agent', id: 'agent:one' },
+    body: { text: 'Hello', format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-08-12T00:00:00.000Z',
+    updatedAt: '2026-08-12T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const PRIVATE_PROVIDER_VALUES = [
+  'runtime-private',
+  'turn-private',
+  'item-private',
+  'sender-runtime-private',
+  'meta-runtime-private',
+  'provider-item-private',
+  'provider-runtime-private',
+  'source-runtime-private',
+  'source-turn-private',
+  'source-session-private',
+];
+const PRIVATE_PROVIDER_KEYS = [
+  'runtimeId',
+  'turnId',
+  'itemId',
+  'providerRuntimeId',
+  'providerTurnId',
+  'sessionId',
+  'provider_item_id',
+  'provider_turn_id',
+  'source',
+  'source_runtime_id',
+  'sourceSessionId',
+];
+
+function providerMessage(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return message({
+    sender: {
+      kind: 'agent',
+      id: 'agent:one',
+      providerId: 'codex',
+      runtimeId: 'sender-runtime-private',
+    },
+    source: {
+      runtimeId: 'runtime-private',
+      turnId: 'turn-private',
+      itemId: 'item-private',
+    },
+    agentDetail: {
+      itemId: 'item-private',
+      card: { kind: 'message', title: 'Agent detail', status: 'completed' },
+    },
+    meta: {
+      runtimeId: 'meta-runtime-private',
+      nested: {
+        providerTurnId: 'turn-private',
+        provider_item_id: 'provider-item-private',
+        providerRuntimeId: 'provider-runtime-private',
+        provider_turn_id: 'turn-private',
+        source: {
+          source_runtime_id: 'source-runtime-private',
+          sourceTurnId: 'source-turn-private',
+          sourceSessionId: 'source-session-private',
+        },
+        safe: 'kept but echoed runtime-private and source-session-private',
+      },
+    },
+    ...overrides,
+  });
+}
+
+function expectNoProviderDiagnostics(value: unknown): void {
+  const serialized = JSON.stringify(value);
+  for (const key of PRIVATE_PROVIDER_KEYS) {
+    expect(serialized).not.toContain(`"${key}"`);
+  }
+  for (const marker of PRIVATE_PROVIDER_VALUES) {
+    expect(serialized).not.toContain(marker);
+  }
+}
+
+function ndjson(lines: unknown[], signal?: AbortSignal): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines)
+        controller.enqueue(enc.encode(`${JSON.stringify(line)}\n`));
+      controller.close();
+    },
+    cancel() {
+      // The client is allowed to end a bounded collector early.
+    },
+  });
+  void signal;
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'application/x-ndjson' },
+  });
+}
+
+describe('relay-ide/channel-client', () => {
+  it('maps the stable command methods with construction-only credentials', async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test/',
+      token: 'secret-never-in-input',
+      fetch: async (url, init) => {
+        requests.push({ url: String(url), init });
+        const pathname = new URL(String(url)).pathname;
+        if (pathname.includes('/threads/') || pathname.endsWith('/messages')) {
+          if (init?.method === 'POST')
+            return Response.json({ message: message() });
+          return Response.json({ messages: [] });
+        }
+        return Response.json({ channels: [] });
+      },
+    });
+
+    await client.list();
+    await client.get({ channelId: 'topic:one' });
+    await client.run.get({ channelId: 'topic:one', runId: 'chrun:one' });
+    await client.history({ channelId: 'topic:one', afterSeq: 4 });
+    await client.threads.history({
+      channelId: 'topic:one',
+      threadId: 'chm:one',
+    });
+    await client.roster({ channelId: 'topic:one' });
+    await client.post({ channelId: 'topic:one', text: 'hi' });
+
+    expect(requests.map(({ url }) => url)).toEqual([
+      'http://relay.test/channels',
+      'http://relay.test/channels/topic%3Aone',
+      'http://relay.test/channels/topic%3Aone/runs/chrun%3Aone',
+      'http://relay.test/channels/topic%3Aone/messages?afterSeq=4',
+      'http://relay.test/channels/topic%3Aone/threads/chm%3Aone',
+      'http://relay.test/channels/topic%3Aone/roster',
+      'http://relay.test/channels/topic%3Aone/messages',
+    ]);
+    const post = requests.at(-1)?.init;
+    expect(post?.method).toBe('POST');
+    expect(post?.body).toBe('{"text":"hi"}');
+    const headers = new Headers(requests[0]?.init?.headers);
+    expect(headers.get('authorization')).toBe('Bearer secret-never-in-input');
+    expect(headers.get('x-relay-cli-actor-token')).toBeNull();
+    expect(JSON.stringify(requests)).not.toContain('secret-never-in-input');
+  });
+
+  it('keeps concurrent run lookups isolated and preserves sibling denial envelopes', async () => {
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async (url) => {
+        const value = String(url);
+        if (value.endsWith('chrun%3Adenied')) {
+          return Response.json(
+            {
+              error: {
+                code: 'FORBIDDEN',
+                message: 'channel scope denied',
+                retryable: false,
+              },
+            },
+            { status: 403 }
+          );
+        }
+        return Response.json({
+          run: {
+            id: value.endsWith('chrun%3Aone') ? 'chrun:one' : 'chrun:two',
+          },
+        });
+      },
+    });
+    const [one, two] = await Promise.all([
+      client.run.get({ channelId: 'topic:one', runId: 'chrun:one' }),
+      client.run.get({ channelId: 'topic:two', runId: 'chrun:two' }),
+    ]);
+    expect(one.run.id).toBe('chrun:one');
+    expect(two.run.id).toBe('chrun:two');
+    await expect(
+      client.run.get({ channelId: 'topic:one', runId: 'chrun:denied' })
+    ).rejects.toMatchObject<Partial<RelayChannelClientError>>({
+      status: 403,
+      code: 'FORBIDDEN',
+      retryable: false,
+    });
+  });
+
+  it('projects recursive provider aliases from every non-streaming success path while retaining Relay ids', async () => {
+    const privateFields = {
+      providerRuntimeId: 'provider-runtime-private',
+      nested: {
+        provider_item_id: 'provider-item-private',
+        source: { source_runtime_id: 'source-runtime-private' },
+      },
+    };
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async (url) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname.endsWith('/roster'))
+          return Response.json({
+            roster: [{ id: 'agent:one', ...privateFields }],
+          });
+        if (pathname.includes('/runs/'))
+          return Response.json({
+            run: {
+              id: 'chrun:one',
+              targetId: 'target:one',
+              ...privateFields,
+            },
+          });
+        if (pathname === '/channels/topic%3Aone')
+          return Response.json({
+            channel: { id: 'topic:one', ...privateFields },
+          });
+        return Response.json({
+          channels: [{ id: 'topic:one', ...privateFields }],
+        });
+      },
+    });
+
+    const [listed, channel, run, roster] = await Promise.all([
+      client.list(),
+      client.get({ channelId: 'topic:one' }),
+      client.run.get({ channelId: 'topic:one', runId: 'chrun:one' }),
+      client.roster({ channelId: 'topic:one' }),
+    ]);
+    expectNoProviderDiagnostics({ listed, channel, run, roster });
+    expect(listed.channels[0]?.id).toBe('topic:one');
+    expect(channel.channel.id).toBe('topic:one');
+    expect(run.run).toMatchObject({ id: 'chrun:one', targetId: 'target:one' });
+    expect(roster.roster[0]?.id).toBe('agent:one');
+  });
+
+  it('resumes without duplicate durable rows and applies state replacement before a later delta', async () => {
+    const requests: string[] = [];
+    const initial = message();
+    const replacement = message({
+      body: { text: 'Hello world', format: 'text' },
+    });
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async (url, init) => {
+        requests.push(String(url));
+        const afterSeq = new URL(String(url)).searchParams.get('afterSeq');
+        if (afterSeq === null) {
+          return ndjson(
+            [
+              {
+                schemaVersion: 1,
+                frame: 'open',
+                channelId: 'topic:one',
+                sequence: 0,
+                occurredAt: '2026-08-12T00:00:00.000Z',
+                durableSeq: 0,
+              },
+              {
+                schemaVersion: 1,
+                frame: 'event',
+                channelId: 'topic:one',
+                sequence: 1,
+                occurredAt: '2026-08-12T00:00:01.000Z',
+                durableSeq: 1,
+                payload: {
+                  type: 'channel-snapshot-v1',
+                  channelId: 'topic:one',
+                  timestamp: '2026-08-12T00:00:01.000Z',
+                  mode: 'full',
+                  messages: [initial],
+                  members: [],
+                  latestSeq: 1,
+                  inFlight: [{ messageId: 'chm:one', deltaIndex: -1 }],
+                  truncated: false,
+                },
+              },
+            ],
+            init?.signal ?? undefined
+          );
+        }
+        return ndjson(
+          [
+            {
+              schemaVersion: 1,
+              frame: 'event',
+              channelId: 'topic:one',
+              sequence: 2,
+              occurredAt: '2026-08-12T00:00:02.000Z',
+              durableSeq: 1,
+              payload: {
+                type: 'channel-snapshot-v1',
+                channelId: 'topic:one',
+                timestamp: '2026-08-12T00:00:02.000Z',
+                mode: 'catchup',
+                messages: [],
+                stateReplacements: [
+                  {
+                    message: replacement,
+                    inFlight: { messageId: 'chm:one', deltaIndex: 1 },
+                  },
+                ],
+                members: [],
+                latestSeq: 1,
+                inFlight: [],
+                truncated: false,
+              },
+            },
+            {
+              schemaVersion: 1,
+              frame: 'event',
+              channelId: 'topic:one',
+              sequence: 3,
+              occurredAt: '2026-08-12T00:00:03.000Z',
+              durableSeq: 1,
+              payload: {
+                type: 'channel-message-delta-v1',
+                channelId: 'topic:one',
+                timestamp: '2026-08-12T00:00:03.000Z',
+                messageId: 'chm:one',
+                deltaIndex: 2,
+                delta: { text: '!' },
+              },
+            },
+          ],
+          init?.signal ?? undefined
+        );
+      },
+    });
+    const first = await client.collect({
+      channelId: 'topic:one',
+      maxEvents: 1,
+    });
+    expect(first.durableSeq).toBe(1);
+    const resumed = await client.collect({
+      channelId: 'topic:one',
+      afterSeq: first.durableSeq,
+      state: first.state,
+      maxEvents: 2,
+    });
+    expect(requests).toEqual([
+      'http://relay.test/channels/topic%3Aone/subscribe',
+      'http://relay.test/channels/topic%3Aone/subscribe?afterSeq=1',
+    ]);
+    expect(resumed.state.messages).toHaveLength(1);
+    expect(resumed.state.messages[0]?.body.text).toBe('Hello world!');
+    expect(resumed.state.lastSeq).toBe(1);
+    expect(resumed.durableSeq).toBe(1);
+  });
+
+  it('projects provider diagnostics out of history, post results, snapshot replacements, state, and errors', async () => {
+    const token = 'relay-sac-v1.private-token';
+    const sensitive = providerMessage();
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      token,
+      fetch: async (url, init) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname.endsWith('/denied')) {
+          return Response.json(
+            {
+              error: {
+                code: 'FORBIDDEN',
+                message: `credential ${token} rejected`,
+                details: {
+                  token,
+                  authorization: `Bearer ${token}`,
+                  runtimeId: 'runtime-private',
+                  nested: { providerTurnId: 'turn-private', echoed: token },
+                },
+              },
+            },
+            { status: 403 }
+          );
+        }
+        if (pathname.endsWith('/subscribe')) {
+          return ndjson([
+            {
+              schemaVersion: 1,
+              frame: 'event',
+              channelId: 'topic:one',
+              sequence: 1,
+              occurredAt: '2026-08-12T00:00:01.000Z',
+              durableSeq: 1,
+              payload: {
+                type: 'channel-snapshot-v1',
+                channelId: 'topic:one',
+                timestamp: '2026-08-12T00:00:01.000Z',
+                mode: 'full',
+                messages: [sensitive],
+                runs: [
+                  {
+                    id: 'chrun:one',
+                    channelId: 'topic:one',
+                    threadId: null,
+                    requestMessageId: 'chm:one',
+                    requesterId: 'human:one',
+                    state: 'working',
+                    targets: [
+                      {
+                        targetId: 'agent-profile:codex:one',
+                        state: 'working',
+                        updatedAt: '2026-08-12T00:00:01.000Z',
+                        providerRuntimeId: 'provider-runtime-private',
+                      },
+                    ],
+                    createdAt: '2026-08-12T00:00:01.000Z',
+                    updatedAt: '2026-08-12T00:00:01.000Z',
+                    source: { source_runtime_id: 'source-runtime-private' },
+                  },
+                ],
+                members: [],
+                latestSeq: 1,
+                inFlight: [],
+                truncated: false,
+              },
+            },
+            {
+              schemaVersion: 1,
+              frame: 'event',
+              channelId: 'topic:one',
+              sequence: 2,
+              occurredAt: '2026-08-12T00:00:02.000Z',
+              durableSeq: 1,
+              payload: {
+                type: 'channel-snapshot-v1',
+                channelId: 'topic:one',
+                timestamp: '2026-08-12T00:00:02.000Z',
+                mode: 'catchup',
+                messages: [],
+                stateReplacements: [{ message: sensitive }],
+                members: [],
+                latestSeq: 1,
+                inFlight: [],
+                truncated: false,
+              },
+            },
+          ]);
+        }
+        if (pathname.endsWith('/messages') && init?.method === 'POST') {
+          return Response.json({ message: sensitive });
+        }
+        return Response.json({ messages: [sensitive] });
+      },
+    });
+
+    const history = await client.history({ channelId: 'topic:one' });
+    const posted = await client.post({ channelId: 'topic:one', text: 'hi' });
+    const subscribed = await client.collect({
+      channelId: 'topic:one',
+      maxEvents: 2,
+    });
+    expectNoProviderDiagnostics(history);
+    expectNoProviderDiagnostics(posted);
+    expectNoProviderDiagnostics(subscribed);
+    const replacement = subscribed.frames[1]?.payload;
+    expect(replacement).toMatchObject({
+      type: 'channel-snapshot-v1',
+      messages: [],
+      stateReplacements: [{ message: { id: 'chm:one' } }],
+    });
+    expect(subscribed.state.messages[0]?.sender).toMatchObject({
+      id: 'agent:one',
+    });
+    expect(subscribed.state.runs['chrun:one']).toMatchObject({
+      id: 'chrun:one',
+      targets: [{ targetId: 'agent-profile:codex:one' }],
+    });
+
+    let thrown: unknown;
+    try {
+      await client.run.get({ channelId: 'topic:one', runId: 'denied' });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(RelayChannelClientError);
+    expectNoProviderDiagnostics(thrown);
+    expect(String(thrown)).not.toContain(token);
+    expect(JSON.stringify(thrown)).not.toContain('"token"');
+    expect(JSON.stringify(thrown)).not.toContain(token);
+  });
+
+  it('stops a bounded collector after maxEvents even when the upstream stream ignores abort', async () => {
+    const events = [1, 2, 3].map((sequence) => ({
+      schemaVersion: 1,
+      frame: 'event',
+      channelId: 'topic:one',
+      sequence,
+      occurredAt: `2026-08-12T00:00:0${sequence}.000Z`,
+      durableSeq: sequence,
+      payload: {
+        type: 'channel-message-created-v1',
+        channelId: 'topic:one',
+        timestamp: `2026-08-12T00:00:0${sequence}.000Z`,
+        message: message({
+          id: `chm:${sequence}`,
+          seq: sequence,
+          status: 'complete',
+        }),
+      },
+    }));
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async () => ndjson(events),
+    });
+
+    const collected = await client.collect({
+      channelId: 'topic:one',
+      maxEvents: 2,
+      idleTimeoutMs: 1_000,
+    });
+
+    expect(collected.frames).toHaveLength(2);
+    expect(collected.frames.map((frame) => frame.sequence)).toEqual([1, 2]);
+    expect(collected.durableSeq).toBe(2);
+  });
+
+  it('rejects malformed frames before projection or reducer application', async () => {
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async () =>
+        ndjson([
+          {
+            schemaVersion: 1,
+            frame: 'event',
+            channelId: 'topic:one',
+            sequence: 1,
+            occurredAt: '2026-08-12T00:00:01.000Z',
+            durableSeq: 1,
+            payload: {
+              type: 'channel-message-created-v1',
+              channelId: 'topic:two',
+            },
+          },
+        ]),
+    });
+
+    await expect(
+      client.collect({ channelId: 'topic:one', maxEvents: 1 })
+    ).rejects.toMatchObject<Partial<RelayChannelClientError>>({
+      code: 'UPSTREAM_ERROR',
+      status: 502,
+    });
+  });
+
+  it('fails closed on per-discriminant extras, missing closed fields, and nested channel mismatches', async () => {
+    const validCreated = {
+      type: 'channel-message-created-v1',
+      channelId: 'topic:one',
+      timestamp: '2026-08-12T00:00:01.000Z',
+      message: message(),
+    };
+    const invalidFrames = [
+      {
+        schemaVersion: 1,
+        frame: 'open',
+        channelId: 'topic:one',
+        sequence: 0,
+        occurredAt: '2026-08-12T00:00:00.000Z',
+        durableSeq: 0,
+        injected: true,
+      },
+      {
+        schemaVersion: 1,
+        frame: 'event',
+        channelId: 'topic:one',
+        sequence: 1,
+        occurredAt: '2026-08-12T00:00:01.000Z',
+        durableSeq: 1,
+        payload: validCreated,
+        injected: true,
+      },
+      {
+        schemaVersion: 1,
+        frame: 'closed',
+        channelId: 'topic:one',
+        sequence: 2,
+        occurredAt: '2026-08-12T00:00:02.000Z',
+        durableSeq: 1,
+        reason: 'transport-closed',
+      },
+      {
+        schemaVersion: 1,
+        frame: 'event',
+        channelId: 'topic:one',
+        sequence: 3,
+        occurredAt: '2026-08-12T00:00:03.000Z',
+        durableSeq: 1,
+        payload: {
+          ...validCreated,
+          message: message({ channelId: 'topic:two' }),
+        },
+      },
+    ];
+
+    for (const frame of invalidFrames) {
+      const client = createRelayChannelClient({
+        baseUrl: 'http://relay.test',
+        fetch: async () => ndjson([frame]),
+      });
+      await expect(
+        client.collect({ channelId: 'topic:one', maxEvents: 1 })
+      ).rejects.toMatchObject<Partial<RelayChannelClientError>>({
+        code: 'UPSTREAM_ERROR',
+        status: 502,
+        retryable: true,
+      });
+    }
+  });
+
+  it('bounds no-newline lines, aggregate stream bytes, and retained collector output independently', async () => {
+    let lineCanceled = false;
+    const noNewline = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode('x'.repeat(64)));
+      },
+      cancel() {
+        lineCanceled = true;
+      },
+    });
+    const lineClient = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async () => new Response(noNewline),
+    });
+    await expect(
+      lineClient.collect({
+        channelId: 'topic:one',
+        maxLineBytes: 16,
+        maxStreamBytes: 128,
+      })
+    ).rejects.toMatchObject<Partial<RelayChannelSubscriptionOverflowError>>({
+      limit: 'line-bytes',
+      maximum: 16,
+      observed: 64,
+    });
+    expect(lineCanceled).toBe(true);
+
+    let aggregateCanceled = false;
+    const aggregate = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode('12345678'));
+        controller.enqueue(enc.encode('abcdefgh'));
+      },
+      cancel() {
+        aggregateCanceled = true;
+      },
+    });
+    const aggregateClient = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async () => new Response(aggregate),
+    });
+    await expect(
+      aggregateClient.collect({
+        channelId: 'topic:one',
+        maxLineBytes: 32,
+        maxStreamBytes: 12,
+      })
+    ).rejects.toMatchObject<Partial<RelayChannelSubscriptionOverflowError>>({
+      limit: 'stream-bytes',
+      maximum: 12,
+      observed: 16,
+    });
+    expect(aggregateCanceled).toBe(true);
+
+    const outputClient = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async () =>
+        ndjson([
+          {
+            schemaVersion: 1,
+            frame: 'event',
+            channelId: 'topic:one',
+            sequence: 1,
+            occurredAt: '2026-08-12T00:00:01.000Z',
+            durableSeq: 1,
+            payload: {
+              type: 'channel-message-created-v1',
+              channelId: 'topic:one',
+              timestamp: '2026-08-12T00:00:01.000Z',
+              message: message(),
+            },
+          },
+        ]),
+    });
+    await expect(
+      outputClient.collect({
+        channelId: 'topic:one',
+        maxOutputBytes: 1,
+      })
+    ).rejects.toMatchObject<Partial<RelayChannelSubscriptionOverflowError>>({
+      limit: 'collected-output-bytes',
+      maximum: 1,
+    });
+  });
+
+  it('accounts for the complete returned collection JSON at the exact output boundary', async () => {
+    const frames = [
+      {
+        schemaVersion: 1,
+        frame: 'event',
+        channelId: 'topic:one',
+        sequence: 1,
+        occurredAt: '2026-08-12T00:00:01.000Z',
+        durableSeq: 1,
+        payload: {
+          type: 'channel-message-created-v1',
+          channelId: 'topic:one',
+          timestamp: '2026-08-12T00:00:01.000Z',
+          message: message(),
+        },
+      },
+    ];
+    const createClient = () =>
+      createRelayChannelClient({
+        baseUrl: 'http://relay.test',
+        fetch: async () => ndjson(frames),
+      });
+    const baseline = await createClient().collect({
+      channelId: 'topic:one',
+      maxEvents: 1,
+    });
+    expect(baseline.stopReason).toBe('max-events');
+    const exactBytes = enc.encode(JSON.stringify(baseline)).byteLength;
+    await expect(
+      createClient().collect({
+        channelId: 'topic:one',
+        maxEvents: 1,
+        maxOutputBytes: exactBytes,
+      })
+    ).resolves.toEqual(baseline);
+    await expect(
+      createClient().collect({
+        channelId: 'topic:one',
+        maxEvents: 1,
+        maxOutputBytes: exactBytes - 1,
+      })
+    ).rejects.toMatchObject<Partial<RelayChannelSubscriptionOverflowError>>({
+      limit: 'collected-output-bytes',
+      maximum: exactBytes - 1,
+      observed: exactBytes,
+      code: 'UPSTREAM_ERROR',
+    });
+  });
+});

--- a/test/channel-client.test.ts
+++ b/test/channel-client.test.ts
@@ -163,6 +163,10 @@ describe('relay-ide/channel-client', () => {
     const headers = new Headers(requests[0]?.init?.headers);
     expect(headers.get('authorization')).toBe('Bearer secret-never-in-input');
     expect(headers.get('x-relay-cli-actor-token')).toBeNull();
+    for (const { url, init } of requests) {
+      expect(url).not.toContain('secret-never-in-input');
+      expect(String(init?.body ?? '')).not.toContain('secret-never-in-input');
+    }
     expect(JSON.stringify(requests)).not.toContain('secret-never-in-input');
   });
 
@@ -525,12 +529,92 @@ describe('relay-ide/channel-client', () => {
     const collected = await client.collect({
       channelId: 'topic:one',
       maxEvents: 2,
-      idleTimeoutMs: 1_000,
+      // Immediate upstream frames and the quiet deadline start in the same
+      // turn; max-events must win rather than report an idle timeout.
+      idleTimeoutMs: 1,
     });
 
     expect(collected.frames).toHaveLength(2);
     expect(collected.frames.map((frame) => frame.sequence)).toEqual([1, 2]);
     expect(collected.durableSeq).toBe(2);
+    expect(collected.stopReason).toBe('max-events');
+  });
+
+  it('uses a restartable quiet deadline while continuous accepted frames arrive', async () => {
+    let cancelled = false;
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async (_url, init) => {
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            let sequence = 0;
+            const emit = () => {
+              sequence += 1;
+              controller.enqueue(
+                enc.encode(
+                  `${JSON.stringify({
+                    schemaVersion: 1,
+                    frame: 'event',
+                    channelId: 'topic:one',
+                    sequence,
+                    occurredAt: `2026-08-12T00:00:0${sequence}.000Z`,
+                    durableSeq: sequence,
+                    payload: {
+                      type: 'channel-message-created-v1',
+                      channelId: 'topic:one',
+                      timestamp: `2026-08-12T00:00:0${sequence}.000Z`,
+                      message: message({
+                        id: `chm:${sequence}`,
+                        seq: sequence,
+                      }),
+                    },
+                  })}\n`
+                )
+              );
+              if (sequence < 3) setTimeout(emit, 10);
+            };
+            emit();
+            init?.signal?.addEventListener('abort', () => {
+              cancelled = true;
+              controller.close();
+            });
+          },
+        });
+        return new Response(stream);
+      },
+    });
+
+    const collected = await client.collect({
+      channelId: 'topic:one',
+      maxEvents: 3,
+      idleTimeoutMs: 18,
+    });
+    expect(collected.stopReason).toBe('max-events');
+    expect(collected.frames).toHaveLength(3);
+    expect(cancelled).toBe(true);
+  });
+
+  it('times out a quiet stream and clears its local abort timer', async () => {
+    let cancelled = false;
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async (_url, init) =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              init?.signal?.addEventListener('abort', () => {
+                cancelled = true;
+                controller.close();
+              });
+            },
+          })
+        ),
+    });
+
+    await expect(
+      client.collect({ channelId: 'topic:one', idleTimeoutMs: 10 })
+    ).resolves.toMatchObject({ stopReason: 'idle-timeout', frames: [] });
+    expect(cancelled).toBe(true);
   });
 
   it('rejects malformed frames before projection or reducer application', async () => {
@@ -757,6 +841,25 @@ describe('relay-ide/channel-client', () => {
       maximum: exactBytes - 1,
       observed: exactBytes,
       code: 'UPSTREAM_ERROR',
+    });
+  });
+
+  it('does not turn short common provider values into global redaction needles', async () => {
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async () =>
+        Response.json({
+          messages: [
+            providerMessage({
+              source: { runtimeId: '0', itemId: 'codex' },
+              meta: { diagnostic: 'codex 0 1 remains useful public prose' },
+            }),
+          ],
+        }),
+    });
+    const result = await client.history({ channelId: 'topic:one' });
+    expect(result.messages[0]?.meta).toEqual({
+      diagnostic: 'codex 0 1 remains useful public prose',
     });
   });
 });

--- a/test/relay-mcp.test.ts
+++ b/test/relay-mcp.test.ts
@@ -6,6 +6,7 @@ import { RELAY_CLI_GATEWAY_CONTRACT } from '../shared/cli-gateway-contract.js';
 import {
   createRelayChannelClient,
   RelayChannelClientError,
+  RelayChannelSubscriptionOverflowError,
   type RelayChannelClient,
 } from '../shared/channel-client.js';
 import {
@@ -140,9 +141,15 @@ async function openMcp(client: RelayChannelClient): Promise<{
     number,
     {
       resolve: (response: JsonRpcResponse) => void;
+      reject: (reason: Error) => void;
     }
   >();
   let nextId = 1;
+  const rejectPending = () => {
+    const error = new Error('MCP test transport closed before response');
+    for (const request of pending.values()) request.reject(error);
+    pending.clear();
+  };
   clientTransport.onmessage = (message) => {
     if (!isJsonRpcResponse(message)) return;
     const request = pending.get(message.id);
@@ -150,13 +157,15 @@ async function openMcp(client: RelayChannelClient): Promise<{
     pending.delete(message.id);
     request.resolve(message);
   };
+  clientTransport.onclose = rejectPending;
+  serverTransport.onclose = rejectPending;
   const request = async (
     method: string,
     params?: Record<string, unknown>
   ): Promise<JsonRpcResponse> => {
     const id = nextId++;
-    const response = new Promise<JsonRpcResponse>((resolve) => {
-      pending.set(id, { resolve });
+    const response = new Promise<JsonRpcResponse>((resolve, reject) => {
+      pending.set(id, { resolve, reject });
     });
     try {
       await clientTransport.send({
@@ -189,7 +198,10 @@ async function openMcp(client: RelayChannelClient): Promise<{
   });
   return {
     request,
-    close: () => clientTransport.close(),
+    close: async () => {
+      rejectPending();
+      await Promise.all([clientTransport.close(), serverTransport.close()]);
+    },
   };
 }
 
@@ -250,9 +262,10 @@ describe('relay-mcp', () => {
     );
     expect(forbidden).toMatchObject({
       ok: false,
-      command: 'sessions.input',
+      command: 'channels.list',
       error: { code: 'INVALID_ARGUMENT' },
     });
+    expect(JSON.stringify(forbidden)).not.toContain('sessions.input');
   });
 
   it('requires bounded subscribe count and time before opening a stream', async () => {
@@ -329,6 +342,98 @@ describe('relay-mcp', () => {
         (spec) => spec.name === 'channels.subscribe'
       )?.outputSchema.properties?.['data']
     );
+  });
+
+  it('forwards only validated subscribe predicates before authoritative bounds and identity', async () => {
+    let received: Record<string, unknown> | undefined;
+    const client = fakeClient({
+      collect: async (input) => {
+        received = input as unknown as Record<string, unknown>;
+        return {
+          frames: [],
+          state: {} as never,
+          durableSeq: 7,
+          stopReason: 'max-events',
+        };
+      },
+    });
+    const malformed = await executeRelayMcpTool(
+      'channels.subscribe',
+      {
+        channelId: 'topic:one',
+        maxEvents: 2,
+        idleTimeoutMs: 100,
+        filter: { runId: 'chrun:one', channelId: 'topic:other' },
+      },
+      client
+    );
+    expect(malformed).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT' },
+    });
+    expect(received).toBeUndefined();
+
+    await expect(
+      executeRelayMcpTool(
+        'channels.subscribe',
+        {
+          channelId: 'topic:one',
+          afterSeq: 4,
+          maxEvents: 2,
+          idleTimeoutMs: 100,
+          filter: { runId: 'chrun:one', terminalOnly: true },
+        },
+        client
+      )
+    ).resolves.toMatchObject({ ok: true });
+    expect(received).toEqual({
+      runId: 'chrun:one',
+      terminalOnly: true,
+      channelId: 'topic:one',
+      afterSeq: 4,
+      maxEvents: 2,
+      idleTimeoutMs: 100,
+    });
+  });
+
+  it('maps local overflow before generic client errors and derives generic retryability', async () => {
+    const overflow = await executeRelayMcpTool(
+      'channels.subscribe',
+      { channelId: 'topic:one', maxEvents: 1, idleTimeoutMs: 100 },
+      fakeClient({
+        collect: async () => {
+          throw new RelayChannelSubscriptionOverflowError('line-bytes', 8, 9);
+        },
+      })
+    );
+    expect(overflow).toMatchObject({
+      ok: false,
+      error: {
+        code: 'UPSTREAM_ERROR',
+        retryable: false,
+        details: { limit: 'line-bytes', maximum: 8, observed: 9 },
+      },
+    });
+    const client4xx = await executeRelayMcpTool(
+      'channels.get',
+      { channelId: 'topic:one' },
+      fakeClient({
+        get: async () => {
+          throw new RelayChannelClientError(404, { code: 'NOT_FOUND' });
+        },
+      })
+    );
+    const client5xx = await executeRelayMcpTool(
+      'channels.get',
+      { channelId: 'topic:one' },
+      fakeClient({
+        get: async () => {
+          throw new RelayChannelClientError(502, { code: 'UPSTREAM_ERROR' });
+        },
+      })
+    );
+    expect(client4xx).toMatchObject({ error: { retryable: false } });
+    expect(client5xx).toMatchObject({ error: { retryable: true } });
   });
 
   it('registers valid bounded collection schemas and results through MCP tools/list and tools/call', async () => {

--- a/test/relay-mcp.test.ts
+++ b/test/relay-mcp.test.ts
@@ -1,0 +1,667 @@
+import { describe, expect, it } from 'vitest';
+
+import { InMemoryTransport } from '@modelcontextprotocol/server';
+
+import { RELAY_CLI_GATEWAY_CONTRACT } from '../shared/cli-gateway-contract.js';
+import {
+  createRelayChannelClient,
+  RelayChannelClientError,
+  type RelayChannelClient,
+} from '../shared/channel-client.js';
+import {
+  createRelayMcpServer,
+  executeRelayMcpTool,
+  RELAY_MCP_CHANNEL_COMMANDS,
+  RELAY_MCP_SUBSCRIBE_MAX_EVENTS,
+  RELAY_MCP_SUBSCRIBE_MAX_IDLE_TIMEOUT_MS,
+  relayMcpToolDefinitions,
+} from '../shared/relay-mcp.js';
+
+const PRIVATE_VALUES = [
+  'runtime-private',
+  'turn-private',
+  'item-private',
+  'detail-private',
+  'provider-runtime-private',
+  'provider-item-private',
+  'source-runtime-private',
+] as const;
+
+const encoder = new TextEncoder();
+
+function ndjson(lines: unknown[]): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines)
+        controller.enqueue(encoder.encode(`${JSON.stringify(line)}\n`));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'application/x-ndjson' },
+  });
+}
+
+const privateMessage = {
+  schemaVersion: 1,
+  id: 'chm:one',
+  channelId: 'topic:one',
+  seq: 1,
+  kind: 'message',
+  status: 'complete',
+  sender: { kind: 'agent', id: 'agent:relay' },
+  body: { text: 'safe body', format: 'text' },
+  threadId: null,
+  parentMessageId: null,
+  createdAt: '2026-08-12T00:00:00.000Z',
+  updatedAt: '2026-08-12T00:00:00.000Z',
+  source: {
+    runtimeId: PRIVATE_VALUES[0],
+    turnId: PRIVATE_VALUES[1],
+    itemId: PRIVATE_VALUES[2],
+  },
+  agentDetail: { itemId: PRIVATE_VALUES[3], card: { title: 'public card' } },
+  providerRuntimeId: PRIVATE_VALUES[4],
+  nested: {
+    provider_item_id: PRIVATE_VALUES[5],
+    source_runtime_id: PRIVATE_VALUES[6],
+    api_key: 'must-never-leak',
+  },
+};
+
+function fakeClient(
+  overrides: Partial<RelayChannelClient> = {}
+): RelayChannelClient {
+  return {
+    list: async () => ({ channels: [] }),
+    get: async () => ({ channel: {} }),
+    run: { get: async () => ({ run: { id: 'chrun:one' } }) },
+    history: async () => ({ messages: [privateMessage] }),
+    threads: { history: async () => ({ messages: [privateMessage] }) },
+    roster: async () => ({ roster: [] }),
+    post: async () => ({ message: privateMessage as never }),
+    subscribe: async function* () {} as RelayChannelClient['subscribe'],
+    collect: async () => ({
+      durableSeq: 1,
+      stopReason: 'stream-closed',
+      frames: [
+        {
+          schemaVersion: 1,
+          frame: 'event',
+          channelId: 'topic:one',
+          sequence: 1,
+          occurredAt: '2026-08-12T00:00:00.000Z',
+          durableSeq: 1,
+          payload: {
+            type: 'channel-snapshot-v1',
+            stateReplacements: [{ message: privateMessage }],
+          },
+        },
+      ],
+      state: {
+        channelId: 'topic:one',
+        messages: [privateMessage],
+        byId: { 'chm:one': privateMessage },
+      },
+    }),
+    ...overrides,
+  } as unknown as RelayChannelClient;
+}
+
+type JsonRpcResponse = {
+  id: number;
+  result?: Record<string, unknown>;
+  error?: Record<string, unknown>;
+};
+
+function isJsonRpcResponse(value: unknown): value is JsonRpcResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof value.id === 'number' &&
+    ('result' in value || 'error' in value)
+  );
+}
+
+/** Exercise the actual registered MCP handlers, not only the facade helper. */
+async function openMcp(client: RelayChannelClient): Promise<{
+  request: (
+    method: string,
+    params?: Record<string, unknown>
+  ) => Promise<JsonRpcResponse>;
+  close: () => Promise<void>;
+}> {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const server = createRelayMcpServer(client);
+  const pending = new Map<
+    number,
+    {
+      resolve: (response: JsonRpcResponse) => void;
+    }
+  >();
+  let nextId = 1;
+  clientTransport.onmessage = (message) => {
+    if (!isJsonRpcResponse(message)) return;
+    const request = pending.get(message.id);
+    if (!request) return;
+    pending.delete(message.id);
+    request.resolve(message);
+  };
+  const request = async (
+    method: string,
+    params?: Record<string, unknown>
+  ): Promise<JsonRpcResponse> => {
+    const id = nextId++;
+    const response = new Promise<JsonRpcResponse>((resolve) => {
+      pending.set(id, { resolve });
+    });
+    try {
+      await clientTransport.send({
+        jsonrpc: '2.0',
+        id,
+        method,
+        ...(params === undefined ? {} : { params }),
+      });
+    } catch (error) {
+      pending.delete(id);
+      throw error;
+    }
+    return response;
+  };
+
+  await server.connect(serverTransport);
+  await clientTransport.start();
+  const initialized = await request('initialize', {
+    protocolVersion: '2025-11-25',
+    capabilities: {},
+    clientInfo: { name: 'relay-mcp-test', version: '0.0.0' },
+  });
+  if (initialized.error)
+    throw new Error(
+      `MCP initialize failed: ${JSON.stringify(initialized.error)}`
+    );
+  await clientTransport.send({
+    jsonrpc: '2.0',
+    method: 'notifications/initialized',
+  });
+  return {
+    request,
+    close: () => clientTransport.close(),
+  };
+}
+
+describe('relay-mcp', () => {
+  it('derives the closed eight-tool set from the gateway contract and command manifest', () => {
+    const tools = relayMcpToolDefinitions();
+    expect(tools.map((tool) => tool.command)).toEqual(
+      RELAY_MCP_CHANNEL_COMMANDS
+    );
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'relay_channels_list',
+      'relay_channels_get',
+      'relay_channels_run_get',
+      'relay_channels_history',
+      'relay_channels_subscribe',
+      'relay_channels_threads_history',
+      'relay_channels_roster',
+      'relay_channels_post',
+    ]);
+    for (const tool of tools) {
+      const spec = RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.find(
+        (entry) => entry.name === tool.command
+      );
+      expect(spec).toBeDefined();
+      expect(tool.outputSchema.oneOf?.[0]?.title).toBe(
+        tool.command === 'channels.subscribe'
+          ? 'ChannelsSubscribeCollectionOutput'
+          : spec?.outputSchema.title
+      );
+      if (tool.command !== 'channels.subscribe') {
+        expect(tool.inputSchema).toEqual(spec?.inputSchema);
+      }
+    }
+  });
+
+  it('fails closed for commands and tool inputs outside the allowlist', async () => {
+    expect(RELAY_MCP_CHANNEL_COMMANDS).not.toContain('sessions.input');
+    expect(RELAY_MCP_CHANNEL_COMMANDS).not.toContain('files.read');
+    const result = await executeRelayMcpTool(
+      'channels.get',
+      { channelId: 'topic:one', token: 'never-accepted' },
+      fakeClient()
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      command: 'channels.get',
+      error: { code: 'INVALID_ARGUMENT' },
+    });
+    expect(JSON.stringify(result)).not.toContain('never-accepted');
+    const forbidden = await executeRelayMcpTool(
+      'sessions.input' as never,
+      { id: 'session:one', data: 'never-run' },
+      fakeClient({
+        list: async () => {
+          throw new Error('unexpected client call');
+        },
+      })
+    );
+    expect(forbidden).toMatchObject({
+      ok: false,
+      command: 'sessions.input',
+      error: { code: 'INVALID_ARGUMENT' },
+    });
+  });
+
+  it('requires bounded subscribe count and time before opening a stream', async () => {
+    let calls = 0;
+    const client = fakeClient({
+      collect: async (input) => {
+        calls += 1;
+        expect(input.maxEvents).toBe(2);
+        expect(input.idleTimeoutMs).toBe(500);
+        return {
+          frames: [],
+          state: {} as never,
+          durableSeq: 0,
+          stopReason: 'stream-closed',
+        };
+      },
+    });
+    const missing = await executeRelayMcpTool(
+      'channels.subscribe',
+      { channelId: 'topic:one' },
+      client
+    );
+    const unbounded = await executeRelayMcpTool(
+      'channels.subscribe',
+      {
+        channelId: 'topic:one',
+        maxEvents: RELAY_MCP_SUBSCRIBE_MAX_EVENTS + 1,
+        idleTimeoutMs: 500,
+      },
+      client
+    );
+    const timeout = await executeRelayMcpTool(
+      'channels.subscribe',
+      {
+        channelId: 'topic:one',
+        maxEvents: 2,
+        idleTimeoutMs: RELAY_MCP_SUBSCRIBE_MAX_IDLE_TIMEOUT_MS + 1,
+      },
+      client
+    );
+    const accepted = await executeRelayMcpTool(
+      'channels.subscribe',
+      { channelId: 'topic:one', maxEvents: 2, idleTimeoutMs: 500 },
+      client
+    );
+    expect(missing).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT' },
+    });
+    expect(unbounded).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT' },
+    });
+    expect(timeout).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT' },
+    });
+    expect(accepted).toMatchObject({ ok: true, command: 'channels.subscribe' });
+    expect(calls).toBe(1);
+    const subscribe = relayMcpToolDefinitions().find(
+      (tool) => tool.command === 'channels.subscribe'
+    );
+    expect(subscribe?.inputSchema.required).toEqual(
+      expect.arrayContaining(['channelId', 'maxEvents', 'idleTimeoutMs'])
+    );
+    const collection = subscribe?.outputSchema.oneOf?.[0]?.properties?.['data'];
+    expect(collection).toMatchObject({
+      title: 'ChannelsSubscribeCollectionData',
+      type: 'object',
+      required: ['frames', 'state', 'durableSeq', 'stopReason'],
+    });
+    expect(collection?.properties?.['frames']?.items).toEqual(
+      RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.find(
+        (spec) => spec.name === 'channels.subscribe'
+      )?.outputSchema.properties?.['data']
+    );
+  });
+
+  it('registers valid bounded collection schemas and results through MCP tools/list and tools/call', async () => {
+    let collections = 0;
+    const mcp = await openMcp(
+      fakeClient({
+        collect: async ({ maxEvents, idleTimeoutMs }) => {
+          collections += 1;
+          expect(maxEvents).toBe(2);
+          expect(idleTimeoutMs).toBe(250);
+          return {
+            frames: [],
+            state: { channelId: 'topic:one' } as never,
+            durableSeq: 4,
+            stopReason: 'max-events',
+          };
+        },
+      })
+    );
+    try {
+      const listed = await mcp.request('tools/list');
+      expect(listed.error).toBeUndefined();
+      const tools = listed.result?.['tools'] as
+        | Array<Record<string, unknown>>
+        | undefined;
+      const subscribe = tools?.find(
+        (tool) => tool['name'] === 'relay_channels_subscribe'
+      );
+      expect(tools).toHaveLength(8);
+      expect(subscribe).toMatchObject({
+        inputSchema: {
+          required: expect.arrayContaining([
+            'channelId',
+            'maxEvents',
+            'idleTimeoutMs',
+          ]),
+        },
+      });
+
+      const accepted = await mcp.request('tools/call', {
+        name: 'relay_channels_subscribe',
+        arguments: {
+          channelId: 'topic:one',
+          maxEvents: 2,
+          idleTimeoutMs: 250,
+        },
+      });
+      expect(accepted.error).toBeUndefined();
+      expect(accepted.result).toMatchObject({
+        structuredContent: {
+          ok: true,
+          command: 'channels.subscribe',
+          data: {
+            frames: [],
+            state: { channelId: 'topic:one' },
+            durableSeq: 4,
+            stopReason: 'max-events',
+          },
+        },
+      });
+
+      const overBound = await mcp.request('tools/call', {
+        name: 'relay_channels_subscribe',
+        arguments: {
+          channelId: 'topic:one',
+          maxEvents: RELAY_MCP_SUBSCRIBE_MAX_EVENTS + 1,
+          idleTimeoutMs: 250,
+        },
+      });
+      expect(overBound.error).toBeUndefined();
+      expect(overBound.result).toMatchObject({ isError: true });
+      expect(collections).toBe(1);
+    } finally {
+      await mcp.close();
+    }
+  });
+
+  it('keeps the actual client-to-MCP post projection public while retaining Relay correlation ids', async () => {
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async () =>
+        Response.json({
+          message: {
+            ...privateMessage,
+            // A real upstream can echo a provider locator inside otherwise
+            // public diagnostic prose. The client must discover the private
+            // leaf before dropping its keyed source and the MCP facade must
+            // never reintroduce that value.
+            meta: { diagnostic: `upstream echoed ${PRIVATE_VALUES[0]}` },
+          },
+          run: {
+            id: 'chrun:public',
+            channelId: 'topic:one',
+            threadId: null,
+            requestMessageId: 'chm:one',
+            requesterId: 'human:operator',
+            state: 'submitted',
+            targets: [
+              {
+                targetId: 'target:public',
+                state: 'queued',
+                updatedAt: '2026-08-12T00:00:00.000Z',
+              },
+            ],
+            createdAt: '2026-08-12T00:00:00.000Z',
+            updatedAt: '2026-08-12T00:00:00.000Z',
+            runtimeId: PRIVATE_VALUES[0],
+            providerTurnId: PRIVATE_VALUES[1],
+          },
+        }),
+    });
+    const mcp = await openMcp(client);
+    try {
+      const response = await mcp.request('tools/call', {
+        name: 'relay_channels_post',
+        arguments: { channelId: 'topic:one', text: 'hello' },
+      });
+      expect(response.error).toBeUndefined();
+      const structured = response.result?.['structuredContent'];
+      expect(structured, JSON.stringify(response)).toBeDefined();
+      const serialized = JSON.stringify(structured);
+      for (const privateValue of PRIVATE_VALUES)
+        expect(serialized).not.toContain(privateValue);
+      expect(serialized).not.toMatch(
+        /"(?:source|runtimeId|turnId|itemId|providerRuntimeId|providerTurnId|provider_item_id|source_runtime_id)"/
+      );
+      expect(structured).toMatchObject({
+        ok: true,
+        command: 'channels.post',
+        data: {
+          message: { sender: { id: 'agent:relay' } },
+          run: {
+            id: 'chrun:public',
+            targets: [{ targetId: 'target:public' }],
+          },
+        },
+      });
+    } finally {
+      await mcp.close();
+    }
+  });
+
+  it('turns malformed upstream subscription frames into canonical UPSTREAM_ERROR MCP output', async () => {
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      fetch: async () =>
+        ndjson([
+          {
+            schemaVersion: 1,
+            frame: 'event',
+            channelId: 'topic:one',
+            sequence: 1,
+            occurredAt: '2026-08-12T00:00:01.000Z',
+            durableSeq: 1,
+            payload: {
+              type: 'channel-message-created-v1',
+              channelId: 'topic:other',
+            },
+          },
+        ]),
+    });
+    const mcp = await openMcp(client);
+    try {
+      const response = await mcp.request('tools/call', {
+        name: 'relay_channels_subscribe',
+        arguments: {
+          channelId: 'topic:one',
+          maxEvents: 1,
+          idleTimeoutMs: 100,
+        },
+      });
+      expect(response.error).toBeUndefined();
+      expect(response.result).toMatchObject({
+        isError: true,
+        structuredContent: {
+          ok: false,
+          command: 'channels.subscribe',
+          error: { code: 'UPSTREAM_ERROR', retryable: true },
+        },
+      });
+      expect(response.result?.['content']).toEqual([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('"code":"UPSTREAM_ERROR"'),
+        }),
+      ]);
+    } finally {
+      await mcp.close();
+    }
+  });
+
+  it('preserves exact sibling scope failures and concurrent Relay post/run correlation', async () => {
+    const posts: Array<{ channelId: string; clientMessageId?: string }> = [];
+    const client = fakeClient({
+      get: async ({ channelId }) => {
+        if (channelId === 'topic:forbidden')
+          throw new RelayChannelClientError(403, {
+            code: 'FORBIDDEN',
+            message: 'not scoped to sibling channel',
+            retryable: false,
+          });
+        return { channel: { id: channelId } } as never;
+      },
+      post: async ({ channelId, clientMessageId }) => {
+        posts.push({ channelId, clientMessageId });
+        return {
+          message: { channelId, clientMessageId },
+          run: {
+            id: `chrun:${clientMessageId}`,
+            channelId,
+            targets: [{ targetId: `target:${clientMessageId}` }],
+          },
+        } as never;
+      },
+      run: {
+        get: async ({ channelId, runId }) =>
+          ({ run: { id: runId, channelId } }) as never,
+      },
+    });
+    const [first, second] = await Promise.all([
+      executeRelayMcpTool(
+        'channels.post',
+        {
+          channelId: 'topic:one',
+          text: 'first',
+          clientMessageId: 'request-one',
+        },
+        client
+      ),
+      executeRelayMcpTool(
+        'channels.post',
+        {
+          channelId: 'topic:two',
+          text: 'second',
+          clientMessageId: 'request-two',
+        },
+        client
+      ),
+    ]);
+    expect(posts).toEqual([
+      { channelId: 'topic:one', clientMessageId: 'request-one' },
+      { channelId: 'topic:two', clientMessageId: 'request-two' },
+    ]);
+    expect(first).toMatchObject({
+      ok: true,
+      data: {
+        run: {
+          id: 'chrun:request-one',
+          targets: [{ targetId: 'target:request-one' }],
+        },
+      },
+    });
+    expect(second).toMatchObject({
+      ok: true,
+      data: {
+        run: {
+          id: 'chrun:request-two',
+          targets: [{ targetId: 'target:request-two' }],
+        },
+      },
+    });
+    await expect(
+      executeRelayMcpTool(
+        'channels.get',
+        { channelId: 'topic:forbidden' },
+        client
+      )
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'FORBIDDEN' },
+    });
+  });
+
+  it('projects provider diagnostics out of history, streamed replacements, and typed errors', async () => {
+    const history = await executeRelayMcpTool(
+      'channels.history',
+      { channelId: 'topic:one' },
+      fakeClient()
+    );
+    const subscribe = await executeRelayMcpTool(
+      'channels.subscribe',
+      { channelId: 'topic:one', maxEvents: 1, idleTimeoutMs: 100 },
+      fakeClient()
+    );
+    const error = await executeRelayMcpTool(
+      'channels.history',
+      { channelId: 'topic:one' },
+      fakeClient({
+        history: async () => {
+          throw new RelayChannelClientError(502, {
+            code: 'UPSTREAM_ERROR',
+            message: `upstream ${PRIVATE_VALUES[0]} failed`,
+            retryable: true,
+            details: {
+              source: {
+                runtimeId: PRIVATE_VALUES[0],
+                turnId: PRIVATE_VALUES[1],
+              },
+            },
+          });
+        },
+      })
+    );
+
+    for (const envelope of [history, subscribe, error]) {
+      const serialized = JSON.stringify(envelope);
+      expect(serialized).not.toMatch(
+        /"(?:source|runtimeId|turnId|itemId|providerRuntimeId|provider_item_id|source_runtime_id|api_key)"/
+      );
+      for (const privateValue of PRIVATE_VALUES)
+        expect(serialized).not.toContain(privateValue);
+      expect(serialized).not.toContain('must-never-leak');
+      expect(serialized).not.toContain('RELAY_IDE_ACTOR_TOKEN');
+    }
+    expect(history).toMatchObject({
+      ok: true,
+      data: { messages: [{ sender: { id: 'agent:relay' } }] },
+    });
+    expect(subscribe).toMatchObject({
+      ok: true,
+      data: {
+        frames: [
+          {
+            payload: {
+              stateReplacements: [{ message: { body: { text: 'safe body' } } }],
+            },
+          },
+        ],
+      },
+    });
+    expect(error).toMatchObject({
+      ok: false,
+      error: { code: 'UPSTREAM_ERROR', message: 'upstream [redacted] failed' },
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,16 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
+    "declaration": true,
     "skipLibCheck": true,
     "outDir": "dist/",
     "rootDir": "."
   },
-  "include": ["server/**/*.ts", "bin/**/*.ts", "scripts/**/*.ts", "shared/**/*.ts"],
+  "include": [
+    "server/**/*.ts",
+    "bin/**/*.ts",
+    "scripts/**/*.ts",
+    "shared/**/*.ts"
+  ],
   "exclude": ["public/", "frontend/", "test/", "node_modules/", "dist/"]
 }


### PR DESCRIPTION
## Summary

- publish the typed `relay-ide/channel-client` ESM subpath with declarations for stable channel reads, posts, run status, resumable NDJSON subscriptions, and bounded collection
- add local stdio `relay-mcp`, restricted mechanically to the eight supported channel commands and using the official MCP server SDK
- keep the host boundary local and channel-only: environment/process credentials, no shell or terminal tools, provider-correlation redaction, scoped auth, cancellation, strict frames, and byte/event/time bounds

## Contract and safety

- subscription state replacements remain reducer state rather than new message delivery; durable cursor semantics are preserved
- responses retain Relay-owned run/target IDs and server-derived sender metadata while removing provider runtime, turn, item, source, and echoed sensitive values
- `channels.subscribe` MCP output is a bounded `{ frames, state, durableSeq, stopReason }` collection with canonical frame schema; malformed upstream frames become typed `UPSTREAM_ERROR`

## Validation

- focused: 58 tests
- full suite: 6,632 tests
- `npm run check`, `npm run build`, `npm pack` installed JS/TypeScript consumer smoke, Prettier, and `git diff --check`
- adversarial fixes cover recursive privacy projection, closed frame validation, exact collection byte accounting, official MCP tools/list + tools/call validation, sibling scope denial, and concurrent run correlation

Closes #1399


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional local `relay-mcp` command-line gateway using stdio transport.
  * Added channel operations for listing, retrieving, posting, running, history, threads, rosters, and subscriptions.
  * Added a public TypeScript client for Relay channel APIs.
  * Added bounded subscriptions, resumable updates, cancellation, and output limits.
  * Added redaction of sensitive credentials and provider-specific diagnostics.

* **Documentation**
  * Documented setup, supported operations, configuration, security restrictions, and subscription limits.

* **Tests**
  * Added comprehensive coverage for client operations, subscriptions, validation, redaction, errors, and MCP integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->