### PR TITLE
chore(adapters): quirk-vs-choreography guardrails + shared reconnect helper

### DIFF
--- a/.chalk/skills/adapter-review/SKILL.md
+++ b/.chalk/skills/adapter-review/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: adapter-review
+description: >
+  Review a PR diff that touches server/protocol-adapters/** for generality
+  classification: reject copied choreography, reject generalized quirks, and
+  check the "Adapter generality:" PR-body line is truthful. Use when reviewing
+  or preparing an adapter change, when the user says "review this adapter PR",
+  "adapter review", or when a diff adds/edits a ProtocolAdapterV2 adapter.
+---
+
+# Adapter review
+
+Review step for any PR touching `server/protocol-adapters/**`. About half of
+that directory is choreography repeated across adapters with known drift, so
+the reviewer's job is to check the author's QUIRK-vs-CHOREOGRAPHY call, not
+just the code.
+
+Background: `.chalk/skills/add-provider/SKILL.md` § Editing existing adapters.
+
+## Checklist
+
+1. **Copied choreography.** Does the diff add logic that already exists in a
+   sibling adapter? Grep the other adapters for the concern. If it is the third
+   copy of the same shape, reject: route it through
+   `server/protocol-adapters/adapter-utils.ts` and have the callers use it.
+2. **Generalized quirk.** Does the diff lift harness-specific behavior into
+   shared code? Event vocabularies, protocol handshakes, resume-id names, and
+   permission-mode flags stay adapter-local. Reject shared helpers that carry a
+   provider name or a provider-shaped branch.
+3. **The `Adapter generality:` line.** A PR-body line must start with it and it
+   must be true. CI checks presence — and accepts an
+   `adapter-generality-reviewed` label instead — so accuracy is yours: a line
+   claiming "quirk" over a diff that duplicates a sibling's lifecycle is a
+   reject, and a label with no classification behind it is worse.
+4. **Honest capabilities.** Resume, queue, approvals, questions, images, and
+   env-refresh flags in `server/protocol-adapters/index.ts` must still match
+   what the adapter actually does. A capability toggled to make a test pass is
+   a defect.
+5. **Stable-id and never-drop invariants.** Native ids stay stable across the
+   run; deterministic fallbacks only where no native id exists. No path may
+   swallow a native event without emitting a patch or a logged reason.
+6. **Scatter sites.** If the diff adds or renames a provider, confirm the sites
+   outside the adapters directory moved with it: the resume-id ladder in
+   `server/channel-agent-runtime.ts` and the launch contracts plus capability
+   sets in `server/protocol-adapters/index.ts`.
+
+## Verdicts
+
+- Correct classification, shared code untouched → approve.
+- Copy N+1 of an existing shape → request shared-utils routing.
+- Quirk pushed into shared code → request it stays local, with the reason in
+  the PR body.
+- Missing or false `Adapter generality:` line → request the honest one before
+  reading further.
+
+Do not ask for a broad extraction pass. Mass extraction of repeated
+choreography is sequenced behind an adapter conformance suite; a review is not
+the place to start it.

--- a/.chalk/skills/add-provider/SKILL.md
+++ b/.chalk/skills/add-provider/SKILL.md
@@ -41,6 +41,38 @@ provider to Relay's channel-first product.
 - Provider session ids are opaque resume state.
 - Never attribute visible messages to a transient runtime id.
 
+## Editing existing adapters
+
+Roughly half of `server/protocol-adapters/` is choreography repeated across
+adapters, so any edit to shared-looking logic is a classification decision
+before it is a code change.
+
+1. Grep the sibling adapters for the same concern before you change it.
+2. Classify the change:
+   - **QUIRK** — harness-specific: event vocabulary, protocol handshake,
+     resume-id name, permission-mode flag. Stays adapter-local. Never copy it
+     into another harness, and say why it is local in the PR.
+   - **CHOREOGRAPHY** — the same shape in three or more adapters: lifecycle
+     ordering, patch emission, id fallbacks, env sanitizing. Extend the shared
+     utils layer (`server/protocol-adapters/adapter-utils.ts`) instead of
+     writing copy N+1.
+3. When the shared shape almost fits, add a hook, not a fork. `reconnect()`
+   matches in claude/codex-native/hermes/opencode apart from the not-connected
+   wording, which the shared helper takes as a parameter; pi-agent and
+   prime-agent fold `providerSessionId` into config first — that is a
+   config-transform hook, not a reason to duplicate.
+4. Renaming or adding a provider also touches sites outside this directory: the
+   resume-id ladder in `server/channel-agent-runtime.ts` and the launch
+   contracts plus capability sets in `server/protocol-adapters/index.ts`.
+5. Every PR touching `server/protocol-adapters/**` starts a PR-body line with
+   `Adapter generality:` stating the classification and its reason. CI requires
+   the line (or the `adapter-generality-reviewed` label); the `adapter-review`
+   skill checks that it is true.
+
+Mass extraction of the repeated choreography is sequenced behind an adapter
+conformance suite. Until that lands, extend shared utils only for the concern
+you are already touching.
+
 ## Verification
 
 ```bash

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ Refs #
 ## Checklist
 
 - [ ] `CHANGELOG.md` `[Unreleased]` entry added — or decline by starting a line of this body with "No user-visible change" (CI checks it on `server/`, `frontend/`, `shared/` diffs; the `no-user-visible-change` label works too)
+- [ ] Adapter change classified — start a PR-body line with `Adapter generality: <quirk|choreography> — <reason>` (required when the diff touches `server/protocol-adapters/`; CI checks it; the `adapter-generality-reviewed` label works too)
 - [ ] Docs updated — name which (`AGENTS.md` / `docs/*.md` / `DESIGN.md`) — or "none needed" stated here
 - [ ] Tests added/updated, with the decisive command under Verification
 - [ ] New HTTP route → added to `AUTH_ROUTE_LANE_INVENTORY` (`server/auth.ts`) and `test/auth.test.ts`

--- a/.github/workflows/adapter-generality.yml
+++ b/.github/workflows/adapter-generality.yml
@@ -1,0 +1,58 @@
+name: Adapter generality
+
+# Backpressure for the adapter-generality rule in AGENTS.md and the PR template:
+# a PR that touches server/protocol-adapters/ must say which kind of change it
+# is. A harness-local quirk (event vocabulary, handshake, resume-id name,
+# permission-mode flag) stays in its own adapter and is never copied to a
+# sibling; shared choreography belongs in the shared utils layer instead of a
+# hand-duplicated third copy. The label is the escape hatch for PRs whose
+# classification was reviewed somewhere else.
+#
+# The paths filter means no check run exists on PRs outside this directory, so
+# this workflow cannot be a required status check as written -- a required but
+# never-created check leaves every other PR pending. To require it, drop the
+# paths filter and scope in-script the way changelog.yml does: checkout, then
+# `git merge-base` + `git diff --name-only`, and exit 0 when out of scope.
+
+on:
+  pull_request:
+    branches: [nightly, master]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    paths:
+      - 'server/protocol-adapters/**'
+
+permissions:
+  contents: read
+
+jobs:
+  classification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a quirk-or-choreography classification
+        env:
+          # Untrusted PR text stays in env vars; it is never interpolated into
+          # the script body.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          case ",${PR_LABELS}," in
+            *,adapter-generality-reviewed,*)
+              echo "Labelled adapter-generality-reviewed; body declaration not required."
+              exit 0
+              ;;
+          esac
+
+          # The declaration must lead its own line. A substring match would let
+          # any PR that merely quotes the rule -- this workflow's own PR, or any
+          # doc change describing it -- silently satisfy itself.
+          if printf '%s\n' "${PR_BODY:-}" \
+            | sed -E 's/^[[:space:]]*([-*+>][[:space:]]*)*(\[[ xX]\][[:space:]]*)?//; s/^[*_`]+//' \
+            | grep -qiE '^adapter generality:'; then
+            echo "PR body classifies the adapter change."
+            exit 0
+          fi
+
+          echo "::error::This PR touches server/protocol-adapters/ but never classifies the change. State whether it is a harness-local quirk (stays in its adapter, never copied to sibling adapters) or shared choreography (goes through the shared utils layer, not a per-adapter copy) by starting a line of the PR body with 'Adapter generality:' (see the /adapter-review skill), or apply the adapter-generality-reviewed label."
+          exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
       "bin": {
         "relay-ide": "dist/bin/relay-ide.js",
         "relay-ide-browser": "dist/scripts/agent-browser-cli.js",
+        "relay-mcp": "dist/bin/relay-mcp.js",
         "relayctl": "dist/bin/relayctl.js"
       },
       "devDependencies": {

--- a/server/protocol-adapters/AGENTS.md
+++ b/server/protocol-adapters/AGENTS.md
@@ -1,0 +1,59 @@
+# server/protocol-adapters
+
+One `ProtocolAdapterV2` implementation per provider, plus its registration in
+`index.ts` (`v2Adapters` factory and `CHANNEL_ADAPTER_LAUNCH_CONTRACTS`).
+Nothing here owns conversation identity, history, or routing.
+
+> Map, not manual. Keep under 60 lines. `CLAUDE.md` symlinks to this file.
+
+## Quirk vs choreography
+
+About half of this directory is choreography repeated across adapters, with
+known drift. Every edit to one adapter is therefore a classification, and you
+must audit the sibling adapters for the same concern before landing it:
+
+- **QUIRK** — harness-specific: event vocabularies, protocol handshakes,
+  resume-id names, permission-mode flags, availability probes. Stays
+  adapter-local and is **never** copied to a sibling harness for symmetry.
+- **CHOREOGRAPHY** — provider-agnostic sequencing: turn lifecycle, patch
+  emission order, teardown, env sanitizing. Goes through the shared utils layer
+  (`adapter-utils.ts`, `../utils.ts`), never a third hand-written copy.
+
+Default posture is quirk containment. Propagating a fix into a sibling needs
+proof of the same underlying behavior, not the same-looking code. `reconnect()`
+matches across claude, codex-native, hermes, and opencode apart from the
+not-connected wording the shared helper parameterizes; pi-agent and prime-agent
+fold `providerSessionId` into config — a config-transform hook, not a copy.
+
+## Fidelity invariants
+
+- Native event to `AgentPatchV2` mapping is deterministic: same in, same patch.
+- Native ids (turn, item, session) stay stable across a turn and across resume.
+- Never drop. An unmapped native event is a logged gap, not silence.
+- Capability flags are honest. A flag whose patch cannot render stays `false` —
+  see the `telemetry: false` note on `hermes` in `index.ts`.
+
+## Scatter sites a new or renamed provider must also touch
+
+- `server/channel-agent-runtime.ts` `providerResumeId` — the resume-state ladder
+  maps `providerId` to a resume key. **Missing it fails silently**: the provider
+  connects, then loses resume with no error.
+- `index.ts` — launch contract (`command` / `gateway` / `embedded`) and, for
+  bridged adapters, the hand-transcribed capability set.
+- `server/utils.ts` `cleanEnv` plus `index.ts` `sanitizeChannelAdapterProcessEnv`
+  own env stripping. Provider-specific keys go in the contract's
+  `processEnvDenylist`, never at spawn sites.
+
+## Sequencing
+
+No mass choreography extraction until an adapter conformance suite exists —
+without it a shared rewrite silently reshapes five harnesses at once. Small
+helpers proven identical may move into `adapter-utils.ts` with tests now.
+
+## PR rule
+
+Every PR touching this directory states its classification in the body on a line
+starting with `Adapter generality:`, or takes the `adapter-generality-reviewed`
+label. CI checks for the line; reviewers validate the claim, not its presence.
+Tests live in `test/server/protocol-adapters/`. See `docs/provider-guide.md`,
+`/add-provider`, `/adapter-review`.

--- a/server/protocol-adapters/CLAUDE.md
+++ b/server/protocol-adapters/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/server/protocol-adapters/adapter-utils.ts
+++ b/server/protocol-adapters/adapter-utils.ts
@@ -1,19 +1,52 @@
-/** Shared helpers for protocol adapters — extracts common field accessors. */
+/**
+ * Shared choreography for protocol adapters.
+ *
+ * Classification rule for anything you change in an adapter:
+ * - QUIRK (event vocabulary, protocol handshake, resume-id name, permission
+ *   flags) stays adapter-local and is never copied to a sibling adapter.
+ * - CHOREOGRAPHY (the same dance in every adapter) lives here and is never
+ *   hand-duplicated into a third adapter.
+ *
+ * This module is the seed of that layer. Broad extraction is sequenced behind
+ * an adapter conformance suite; add here only what is already identical.
+ */
 
-export function strField(
-  data: Record<string, unknown> | undefined,
-  key: string,
-  fallback = ''
-): string {
-  return String(data?.[key] ?? fallback);
+import type { AdapterConfig } from '../protocol-adapter-v2.js';
+
+export interface ReconnectWithStoredConfigOptions {
+  /** Config captured by the last successful connect; null before one. */
+  config: AdapterConfig | null | undefined;
+  /** Tear down the live transport (adapters vary in how much they reset). */
+  disconnect: () => void | Promise<void>;
+  /** Re-establish the transport with the resolved config. */
+  connect: (config: AdapterConfig) => void | Promise<void>;
+  /**
+   * Quirk hook for adapters that resume by folding a provider session id into
+   * the config (pi-agent, prime-agent). Runs before `disconnect` so it reads
+   * pre-teardown adapter state, matching the hand-written order it replaces.
+   */
+  transformConfig?: (config: AdapterConfig) => AdapterConfig;
+  /** Per-adapter wording; adapters disagree and the text is observable. */
+  notConnectedMessage?: string;
 }
 
-export function objField(
-  data: Record<string, unknown> | undefined,
-  key: string
-): Record<string, unknown> | undefined {
-  const val = data?.[key];
-  return typeof val === 'object' && val !== null
-    ? (val as Record<string, unknown>)
-    : undefined;
+/**
+ * Reconnect = re-run connect with the stored config after a full teardown.
+ * Identical in every real adapter apart from the config transform and the
+ * not-connected message, both parameterized here.
+ */
+export async function reconnectWithStoredConfig(
+  options: ReconnectWithStoredConfigOptions
+): Promise<void> {
+  const { config } = options;
+  if (!config) {
+    throw new Error(
+      options.notConnectedMessage ?? 'Cannot reconnect before connect'
+    );
+  }
+  const nextConfig = options.transformConfig
+    ? options.transformConfig(config)
+    : config;
+  await options.disconnect();
+  await options.connect(nextConfig);
 }

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -1,4 +1,5 @@
 import { CLAUDE_CHANNEL_COMMAND } from './launch-commands.js';
+import { reconnectWithStoredConfig } from './adapter-utils.js';
 import * as fs from 'node:fs';
 import { spawn as nodeSpawn } from 'node:child_process';
 import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
@@ -866,10 +867,11 @@ export class ClaudeProtocolAdapter
   }
 
   async reconnect(): Promise<void> {
-    if (!this.config) throw new Error('Cannot reconnect before connect');
-    const config = this.config;
-    await this.disconnect();
-    await this.connect(config);
+    await reconnectWithStoredConfig({
+      config: this.config,
+      disconnect: () => this.disconnect(),
+      connect: (config) => this.connect(config),
+    });
   }
 
   /**

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -1,3 +1,4 @@
+import { reconnectWithStoredConfig } from './adapter-utils.js';
 import {
   AgentSteerRejectedError,
   BaseProtocolAdapterV2,
@@ -708,10 +709,11 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   async reconnect(): Promise<void> {
-    if (!this.config) throw new Error('Cannot reconnect before connect');
-    const config = this.config;
-    await this.disconnect();
-    await this.connect(config);
+    await reconnectWithStoredConfig({
+      config: this.config,
+      disconnect: () => this.disconnect(),
+      connect: (config) => this.connect(config),
+    });
   }
 
   // ── Message sending ───────────────────────────────────────────────────────

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -1,3 +1,4 @@
+import { reconnectWithStoredConfig } from './adapter-utils.js';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -811,11 +812,12 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
   }
 
   async reconnect(): Promise<void> {
-    if (!this._config)
-      throw new Error('Cannot reconnect before initial connect');
-    const config = this._config;
-    await this.disconnect();
-    await this.connect(config);
+    await reconnectWithStoredConfig({
+      config: this._config,
+      notConnectedMessage: 'Cannot reconnect before initial connect',
+      disconnect: () => this.disconnect(),
+      connect: (config) => this.connect(config),
+    });
   }
 
   // ── User Actions ──────────────────────────────────────────────────────────

--- a/server/protocol-adapters/opencode-adapter.ts
+++ b/server/protocol-adapters/opencode-adapter.ts
@@ -1,4 +1,5 @@
 import { OPENCODE_CHANNEL_COMMAND } from './launch-commands.js';
+import { reconnectWithStoredConfig } from './adapter-utils.js';
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import crypto from 'node:crypto';
@@ -195,11 +196,12 @@ export class OpenCodeProtocolAdapter extends BaseProtocolAdapter {
   }
 
   async reconnect(): Promise<void> {
-    if (!this._config)
-      throw new Error('Cannot reconnect before initial connect');
-    const config = this._config;
-    await this.disconnect();
-    await this.connect(config);
+    await reconnectWithStoredConfig({
+      config: this._config,
+      notConnectedMessage: 'Cannot reconnect before initial connect',
+      disconnect: () => this.disconnect(),
+      connect: (config) => this.connect(config),
+    });
   }
 
   /**

--- a/server/protocol-adapters/pi-agent-adapter.ts
+++ b/server/protocol-adapters/pi-agent-adapter.ts
@@ -1,4 +1,5 @@
 import { PI_AGENT_CHANNEL_COMMAND } from './launch-commands.js';
+import { reconnectWithStoredConfig } from './adapter-utils.js';
 import * as fs from 'node:fs';
 import { spawn as nodeSpawn } from 'node:child_process';
 import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
@@ -261,17 +262,21 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   async reconnect(): Promise<void> {
-    if (!this.config) throw new Error('Cannot reconnect before connect');
-    const config = {
-      ...this.config,
-      ...(this.providerSessionId
-        ? { resumeSessionId: this.providerSessionId }
-        : {}),
-    };
-    this.resetForTransportSwitch('Pi transport reconnected');
-    this._status = 'disconnected';
-    await this.teardownClient();
-    await this.connect(config);
+    await reconnectWithStoredConfig({
+      config: this.config,
+      transformConfig: (config) => ({
+        ...config,
+        ...(this.providerSessionId
+          ? { resumeSessionId: this.providerSessionId }
+          : {}),
+      }),
+      disconnect: async () => {
+        this.resetForTransportSwitch('Pi transport reconnected');
+        this._status = 'disconnected';
+        await this.teardownClient();
+      },
+      connect: (config) => this.connect(config),
+    });
   }
 
   async resumeSession(sessionId: string): Promise<void> {

--- a/server/protocol-adapters/prime-agent-adapter.ts
+++ b/server/protocol-adapters/prime-agent-adapter.ts
@@ -1,4 +1,5 @@
 import { PRIME_AGENT_CHANNEL_COMMAND } from './launch-commands.js';
+import { reconnectWithStoredConfig } from './adapter-utils.js';
 import * as fs from 'node:fs';
 import { spawn as nodeSpawn } from 'node:child_process';
 import {
@@ -289,17 +290,21 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   async reconnect(): Promise<void> {
-    if (!this.config) throw new Error('Cannot reconnect before connect');
-    const config = {
-      ...this.config,
-      ...(this.providerSessionId
-        ? { resumeSessionId: this.providerSessionId }
-        : {}),
-    };
-    this.resetForTransportSwitch('Prime Agent transport reconnected');
-    this._status = 'disconnected';
-    await this.teardownClient();
-    await this.connect(config);
+    await reconnectWithStoredConfig({
+      config: this.config,
+      transformConfig: (config) => ({
+        ...config,
+        ...(this.providerSessionId
+          ? { resumeSessionId: this.providerSessionId }
+          : {}),
+      }),
+      disconnect: async () => {
+        this.resetForTransportSwitch('Prime Agent transport reconnected');
+        this._status = 'disconnected';
+        await this.teardownClient();
+      },
+      connect: (config) => this.connect(config),
+    });
   }
 
   async resumeSession(sessionId: string): Promise<void> {

--- a/test/server/protocol-adapters/adapter-utils.test.ts
+++ b/test/server/protocol-adapters/adapter-utils.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import { reconnectWithStoredConfig } from '../../../server/protocol-adapters/adapter-utils.js';
+import { ClaudeProtocolAdapter } from '../../../server/protocol-adapters/claude-adapter.js';
+import { CodexNativeProtocolAdapter } from '../../../server/protocol-adapters/codex-native-adapter.js';
+import { HermesProtocolAdapter } from '../../../server/protocol-adapters/hermes-adapter.js';
+import { OpenCodeProtocolAdapter } from '../../../server/protocol-adapters/opencode-adapter.js';
+import { PiAgentProtocolAdapter } from '../../../server/protocol-adapters/pi-agent-adapter.js';
+import { PrimeAgentProtocolAdapter } from '../../../server/protocol-adapters/prime-agent-adapter.js';
+import type { AdapterConfig } from '../../../server/protocol-adapter-v2.js';
+
+const storedConfig: AdapterConfig = {
+  cwd: '/tmp',
+  port: 1,
+  sessionId: 'relay-session',
+  hookToken: 'hook-token',
+  configDir: '/tmp',
+};
+
+describe('reconnectWithStoredConfig', () => {
+  it('tears down and reconnects with the stored config', async () => {
+    const order: string[] = [];
+    const connect = vi.fn(async () => {
+      order.push('connect');
+    });
+
+    await reconnectWithStoredConfig({
+      config: storedConfig,
+      disconnect: async () => {
+        order.push('disconnect');
+      },
+      connect,
+    });
+
+    expect(order).toEqual(['disconnect', 'connect']);
+    expect(connect).toHaveBeenCalledWith(storedConfig);
+  });
+
+  it('throws the default message when no config was stored', async () => {
+    const disconnect = vi.fn();
+    const connect = vi.fn();
+
+    await expect(
+      reconnectWithStoredConfig({ config: null, disconnect, connect })
+    ).rejects.toThrow('Cannot reconnect before connect');
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('throws the adapter-supplied message when one is given', async () => {
+    await expect(
+      reconnectWithStoredConfig({
+        config: undefined,
+        notConnectedMessage: 'Cannot reconnect before initial connect',
+        disconnect: vi.fn(),
+        connect: vi.fn(),
+      })
+    ).rejects.toThrow('Cannot reconnect before initial connect');
+  });
+
+  // pi-agent/prime-agent fold the provider session id into the config, and they
+  // read it *before* teardown clears adapter state — so the hook must run first.
+  it('applies the config transform before disconnect runs', async () => {
+    const order: string[] = [];
+    const connect = vi.fn(async () => {
+      order.push('connect');
+    });
+
+    await reconnectWithStoredConfig({
+      config: storedConfig,
+      transformConfig: (config) => {
+        order.push('transform');
+        return { ...config, resumeSessionId: 'provider-session' };
+      },
+      disconnect: async () => {
+        order.push('disconnect');
+      },
+      connect,
+    });
+
+    expect(order).toEqual(['transform', 'disconnect', 'connect']);
+    expect(connect).toHaveBeenCalledWith({
+      ...storedConfig,
+      resumeSessionId: 'provider-session',
+    });
+  });
+
+  it('leaves the stored config untouched when transforming', async () => {
+    const config = { ...storedConfig };
+
+    await reconnectWithStoredConfig({
+      config,
+      transformConfig: (stored) => ({
+        ...stored,
+        resumeSessionId: 'provider-session',
+      }),
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+    });
+
+    expect(config).toEqual(storedConfig);
+  });
+
+  it('propagates a connect failure to the caller', async () => {
+    await expect(
+      reconnectWithStoredConfig({
+        config: storedConfig,
+        disconnect: vi.fn(),
+        connect: async () => {
+          throw new Error('transport refused');
+        },
+      })
+    ).rejects.toThrow('transport refused');
+  });
+});
+
+// The shared helper replaced six hand-written reconnect() bodies whose
+// not-connected wording already disagreed. The wording is observable, so pin
+// each adapter's exact string against the real adapter, not the helper.
+describe('adapter reconnect-before-connect messages are unchanged', () => {
+  const cases: Array<[string, { reconnect(): Promise<void> }, string]> = [
+    ['claude', new ClaudeProtocolAdapter(), 'Cannot reconnect before connect'],
+    [
+      'codex-native',
+      new CodexNativeProtocolAdapter(),
+      'Cannot reconnect before connect',
+    ],
+    [
+      'hermes',
+      new HermesProtocolAdapter(),
+      'Cannot reconnect before initial connect',
+    ],
+    [
+      'opencode',
+      new OpenCodeProtocolAdapter(),
+      'Cannot reconnect before initial connect',
+    ],
+    [
+      'pi-agent',
+      new PiAgentProtocolAdapter(),
+      'Cannot reconnect before connect',
+    ],
+    [
+      'prime-agent',
+      new PrimeAgentProtocolAdapter(),
+      'Cannot reconnect before connect',
+    ],
+  ];
+
+  for (const [name, adapter, message] of cases) {
+    it(`${name} throws "${message}"`, async () => {
+      await expect(adapter.reconnect()).rejects.toThrow(message);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Slice 0 of the harness-integration-surface ladder (omnigent comparison study, 2026-08-19).

- **`server/protocol-adapters/AGENTS.md`** (+ `CLAUDE.md` symlink): nested agent contract — every adapter edit is classified as harness-local **quirk** (never copied to sibling adapters) or shared **choreography** (routed through `adapter-utils`, never hand-duplicated). Lists the silent scatter sites (resume ladder in `channel-agent-runtime.ts`, capability transcription in `index.ts`) and the sequencing rule: mass extraction waits for the adapter conformance suite.
- **Skills** (`.chalk/`, projected by chalkbag): `add-provider` gains an "Editing existing adapters" audit section; new `adapter-review` skill gives reviewers the generality checklist for adapter diffs.
- **CI gate** `.github/workflows/adapter-generality.yml` (mirrors the changelog gate): PRs touching `server/protocol-adapters/**` must carry an `Adapter generality:` body line or the `adapter-generality-reviewed` label. PR template updated; template wording deliberately does not satisfy the gate's own regex.
- **Shared utils seed**: `reconnectWithStoredConfig()` replaces six near-identical `reconnect()` bodies. The two genuine quirks are parameterized: per-adapter not-connected error wording, and pi/prime's providerSessionId→resumeSessionId merge via a `transformConfig` hook that runs before teardown (order is load-bearing). Dead `strField`/`objField` exports deleted. New unit test pins error strings and transform ordering.

No user-visible change — contributor tooling, docs, CI, and a behavior-preserving internal refactor.

Adapter generality: choreography — the reconnect dance moves to the shared utils layer; per-adapter error wording and resume-config merges stay quirk-local by design.

## Verification

- `npm run check` exit 0
- `npm test -- test/server/protocol-adapters/ test/framework-availability.test.ts` — 10 files, 260 tests passed
- `CLAUDE.md` symlink resolves; workflow YAML parses
- Adversarial review pass: 1 P1 (gate no-op via template self-match) found and fixed, 5 lower findings applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)