### PR TITLE
test(adapters): fixture-driven conformance suite over all registered v2 adapters

### DIFF
--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -7,14 +7,11 @@
  * (`isAgentPatchV2` throws on an invalid emit) and, for the happy path, reduced
  * through `applyAgentPatchV2` to assert reducer legality.
  */
-import { describe, expect, it, vi } from 'vitest';
-import { PassThrough } from 'node:stream';
-import { EventEmitter } from 'node:events';
+import { describe, expect, it } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { ChildProcess } from 'node:child_process';
 import {
   ClaudeProtocolAdapter,
   ClaudeProcessRegistry,
@@ -23,6 +20,7 @@ import type { AdapterConfig } from '../../../server/protocol-adapter-v2.js';
 import type { ClaudeSpawnFn } from '../../../server/claude-stream-client.js';
 import { CHANNEL_ADAPTER_LAUNCH_CONTRACTS } from '../../../server/protocol-adapters/index.js';
 import claudeDetailFixture from '../../fixtures/agent-detail/claude.js';
+import { makeHarness } from './support/claude-child-double.js';
 import {
   applyAgentPatchV2,
   emptyAgentSessionV2,
@@ -30,121 +28,6 @@ import {
   type AgentPatchV2,
   type AgentSessionV2,
 } from '../../../shared/agent-chat-protocol-v2.js';
-
-// ── Fake child + spawn harness ────────────────────────────────────────────────
-
-interface MockChild extends EventEmitter {
-  stdin: PassThrough;
-  stdout: PassThrough;
-  stderr: PassThrough;
-  kill: ReturnType<typeof vi.fn>;
-  pid: number;
-  closed: boolean;
-  serverWrite(obj: unknown): void;
-  emitClose(code: number | null, signal?: NodeJS.Signals | null): void;
-  emitStderr(text: string): void;
-  frames(): Record<string, unknown>[];
-  waitForFrames(
-    count: number,
-    timeoutMs?: number
-  ): Promise<Record<string, unknown>[]>;
-}
-
-function makeMockChild(options?: { closeOnStdinEnd?: boolean }): MockChild {
-  const child = new EventEmitter() as MockChild;
-  child.stdin = new PassThrough();
-  child.stdout = new PassThrough();
-  child.stderr = new PassThrough();
-  child.pid = Math.floor(Math.random() * 100000);
-  child.closed = false;
-
-  const frames: Record<string, unknown>[] = [];
-  const waiters: Array<{
-    count: number;
-    resolve: (f: Record<string, unknown>[]) => void;
-  }> = [];
-  let buf = '';
-  child.stdin.on('data', (chunk: Buffer) => {
-    buf += chunk.toString();
-    let idx: number;
-    while ((idx = buf.indexOf('\n')) !== -1) {
-      const line = buf.slice(0, idx).trim();
-      buf = buf.slice(idx + 1);
-      if (!line) continue;
-      try {
-        frames.push(JSON.parse(line) as Record<string, unknown>);
-      } catch {
-        frames.push({ __raw: line });
-      }
-      for (let i = waiters.length - 1; i >= 0; i--) {
-        if (frames.length >= waiters[i]!.count) {
-          waiters.splice(i, 1)[0]!.resolve([...frames]);
-        }
-      }
-    }
-  });
-
-  child.emitClose = (code, signal = null) => {
-    if (child.closed) return;
-    child.closed = true;
-    child.emit('close', code, signal);
-    child.stdout.push(null);
-  };
-  child.kill = vi.fn((_signal?: string) => true);
-  if (options?.closeOnStdinEnd !== false) {
-    child.stdin.on('finish', () =>
-      setImmediate(() => child.emitClose(0, null))
-    );
-  }
-  child.serverWrite = (obj) => child.stdout.push(JSON.stringify(obj) + '\n');
-  child.emitStderr = (text) =>
-    child.stderr.push(text.endsWith('\n') ? text : text + '\n');
-  child.frames = () => [...frames];
-  child.waitForFrames = (count, timeoutMs = 1000) => {
-    if (frames.length >= count) return Promise.resolve([...frames]);
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(
-        () =>
-          reject(new Error(`timeout: ${frames.length}/${count} stdin frames`)),
-        timeoutMs
-      );
-      waiters.push({
-        count,
-        resolve: (f) => {
-          clearTimeout(timer);
-          resolve(f);
-        },
-      });
-    });
-  };
-  return child;
-}
-
-interface SpawnRecord {
-  command: string;
-  args: string[];
-  options: { cwd: string; env: Record<string, string>; stdio: 'pipe' };
-  child: MockChild;
-}
-
-function makeHarness() {
-  const spawns: SpawnRecord[] = [];
-  let nextOpts: { closeOnStdinEnd?: boolean } | undefined;
-  const spawnFn: ClaudeSpawnFn = (command, args, options) => {
-    const child = makeMockChild(nextOpts);
-    nextOpts = undefined;
-    spawns.push({ command, args, options, child });
-    return child as unknown as ChildProcess;
-  };
-  return {
-    spawnFn,
-    spawns,
-    latest: (): SpawnRecord => spawns[spawns.length - 1]!,
-    setNextChildOptions: (o: { closeOnStdinEnd?: boolean }) => {
-      nextOpts = o;
-    },
-  };
-}
 
 // A registry with no live GC timer — tests drive gcSweep() manually.
 function inertRegistry(): ClaudeProcessRegistry {

--- a/test/server/protocol-adapters/conformance/conformance.test.ts
+++ b/test/server/protocol-adapters/conformance/conformance.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Adapter conformance suite — the offline floor every registered
+ * `ProtocolAdapterV2` must clear.
+ *
+ * Discovery is the drift guard: the suite iterates `v2Adapters` itself, so
+ * registering an adapter without a conformance fixture fails here with an
+ * actionable message, and deleting/renaming an adapter orphans its fixture.
+ * Per-adapter deep tests stay authoritative for their own quirks; this suite
+ * only asserts the contract the repo states in prose.
+ *
+ * Run: `npx vitest run test/server/protocol-adapters/conformance/`
+ */
+import { describe, expect, it } from 'vitest';
+import { v2Adapters } from '../../../../server/protocol-adapters/index.js';
+import type { ProtocolAdapterV2 } from '../../../../server/protocol-adapter-v2.js';
+import { ALL_CAPABILITIES, describeAdapterConformance } from './harness.js';
+import type { AdapterConformanceFixture } from './fixture-types.js';
+
+declare global {
+  interface ImportMeta {
+    glob<T = unknown>(
+      pattern: string,
+      options: { eager: true }
+    ): Record<string, T>;
+  }
+}
+
+// Vite/vitest eager glob — no central registration file for fixture authors to
+// conflict on. One file per adapter under `fixtures/`.
+const fixtureModules = import.meta.glob<{ default: AdapterConformanceFixture }>(
+  './fixtures/*.fixture.ts',
+  { eager: true }
+);
+
+// The glob's type annotation is an unchecked cast, so `npm run check` cannot
+// catch a fixture whose default export was renamed or dropped. Without this
+// split such a file would still register its id — `fixtures.has(id)` true,
+// value undefined — and silently delete that adapter's whole floor.
+const fixtures = new Map<string, AdapterConformanceFixture>();
+const defaultlessFixtureModules: string[] = [];
+for (const [modulePath, module] of Object.entries(fixtureModules)) {
+  const id = modulePath.replace(/^.*\/(.+)\.fixture\.ts$/, '$1');
+  if (!module?.default) {
+    defaultlessFixtureModules.push(modulePath);
+    continue;
+  }
+  fixtures.set(id, module.default);
+}
+
+const adapterIds = Object.keys(v2Adapters);
+
+describe('adapter conformance', () => {
+  for (const adapterId of adapterIds) {
+    describe(adapterId, () => {
+      it('has a conformance fixture', () => {
+        expect(
+          fixtures.get(adapterId),
+          `Registered adapter '${adapterId}' has no usable conformance fixture. ` +
+            `Create test/server/protocol-adapters/conformance/fixtures/${adapterId}.fixture.ts ` +
+            `with a default export ` +
+            `(see fixture-types.ts for the contract and claude.fixture.ts for a worked example).`
+        ).toBeTruthy();
+      });
+
+      const fixture = fixtures.get(adapterId);
+      if (fixture) describeAdapterConformance(adapterId, fixture);
+    });
+  }
+
+  it('every fixture module exports a default fixture', () => {
+    expect(
+      defaultlessFixtureModules,
+      'a *.fixture.ts file has no default export — its adapter would silently lose its entire conformance floor'
+    ).toEqual([]);
+  });
+
+  it('has no orphan fixtures', () => {
+    const orphans = [...fixtures.keys()].filter((id) => !(id in v2Adapters));
+    expect(
+      orphans,
+      'conformance fixture without a registered adapter (renamed or removed?)'
+    ).toEqual([]);
+  });
+
+  it('capability reconciliation covers every flag a registered adapter declares', () => {
+    const known = new Set<string>(ALL_CAPABILITIES);
+    const missing = new Set<string>();
+    for (const adapterId of adapterIds) {
+      const adapter = (v2Adapters as Record<string, () => ProtocolAdapterV2>)[
+        adapterId
+      ]!();
+      for (const flag of Object.keys(adapter.capabilities)) {
+        if (!known.has(flag)) missing.add(`${adapterId}.${flag}`);
+      }
+    }
+    expect(
+      [...missing],
+      'a registered adapter declares a capability flag the conformance table does not know — add it to ALL_CAPABILITIES (and a detector when one is possible)'
+    ).toEqual([]);
+  });
+});

--- a/test/server/protocol-adapters/conformance/fixture-types.ts
+++ b/test/server/protocol-adapters/conformance/fixture-types.ts
@@ -1,0 +1,160 @@
+/**
+ * Fixture contract for the adapter conformance suite.
+ *
+ * A fixture is DATA plus a rig builder. Every native `event` payload must be
+ * transcribed from a real captured provider stream (the per-adapter deep tests
+ * under `test/server/protocol-adapters/` and `test/fixtures/`), never invented
+ * grammar. Provider quirks — event vocabularies, terminal shapes, which native
+ * events legally produce no patch — live here in the fixture. All sequencing
+ * and assertion choreography lives in `harness.ts`, mirroring the quirk vs
+ * choreography rule in `server/protocol-adapters/AGENTS.md`.
+ */
+import type {
+  AdapterConfig,
+  ProtocolAdapterV2,
+} from '../../../../server/protocol-adapter-v2.js';
+import type {
+  AgentApprovalDecisionV2,
+  AgentCapabilitySetV2,
+  AgentPatchV2,
+} from '../../../../shared/agent-chat-protocol-v2.js';
+
+/**
+ * One scripted move against the rig's offline transport.
+ *
+ * `native` and `server-request` are PROVIDER grammar and are therefore
+ * accountable to invariant (c). `operator` is a human action with no wire frame
+ * of its own — the harness performs it against the adapter directly and it is
+ * exempt from the silent-drop ledger, exactly like `close`. `transport-reply`
+ * is the provider's answer to a request the ADAPTER made (an HTTP response, an
+ * RPC reply): still provider grammar, still ledgered, but delivered through the
+ * rig's own transport double rather than an inbound event channel.
+ */
+export type FixtureFeedStep =
+  | { kind: 'native'; event: unknown; label?: string }
+  | {
+      kind: 'server-request';
+      id: string | number;
+      method: string;
+      params?: unknown;
+      label?: string;
+    }
+  /** The operator answers a structured question the agent asked. */
+  | {
+      kind: 'operator';
+      action: 'respondToInput';
+      requestId: string;
+      answers: Record<string, string[]>;
+      label?: string;
+    }
+  /** A reply to an adapter-initiated request lands now (deferred HTTP/RPC). */
+  | {
+      kind: 'transport-reply';
+      id: string | number;
+      payload?: unknown;
+      label?: string;
+    }
+  | { kind: 'close'; code?: number | null; label?: string };
+
+/**
+ * A seam-injected twin of `v2Adapters[id]()` wired to an offline transport.
+ * `createRig` must be callable repeatedly and must produce byte-identical
+ * patch streams for the same script — fixed pids, fixed provider session ids,
+ * scripted native ids.
+ */
+export interface ConformanceRig {
+  adapter: ProtocolAdapterV2;
+  config: AdapterConfig;
+  feed(step: FixtureFeedStep): void | Promise<void>;
+  /** Override the harness quiescence wait for transports that need longer. */
+  settle?(): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+export interface TurnExpectation {
+  /** Patch types that must appear at least once in the segment. */
+  requiredPatchTypes?: AgentPatchV2['type'][];
+  terminalStatus?: 'completed' | 'interrupted' | 'failed';
+  /** Sanity substrings that must appear in the segment's item text. */
+  textIncludes?: string[];
+}
+
+export interface TurnScript {
+  /** Default: `conformance <segment> turn`. */
+  prompt?: string;
+  steps: FixtureFeedStep[];
+  /**
+   * Interrupted turn only. The harness feeds `steps[0..interruptAfter)`, calls
+   * `interrupt()`, then feeds the remainder (provider ack / terminal frames).
+   */
+  interruptAfter?: number;
+  expect?: TurnExpectation;
+}
+
+export interface ApprovalScript {
+  prompt?: string;
+  /** Steps that surface a pending approval item. May be empty (self-scripted). */
+  request: FixtureFeedStep[];
+  decision: AgentApprovalDecisionV2;
+  /** Provider events after the decision, ending the turn. */
+  resolution: FixtureFeedStep[];
+  expect?: TurnExpectation;
+}
+
+export type InvariantId =
+  | 'a-terminal'
+  | 'b-approval-ids'
+  /** Full-lifecycle log, teardown included, leaves nothing pending. */
+  | 'b-teardown'
+  /** Disconnecting ON a live approval leaves nothing pending. */
+  | 'b-abandoned-approval'
+  | 'c-no-silent-drop'
+  | 'd-determinism'
+  | 'e-capability-drift';
+
+export interface AdapterConformanceFixture {
+  adapterId: string;
+  createRig(): ConformanceRig | Promise<ConformanceRig>;
+  /** Handshake/init events fed while `connect()` is in flight. */
+  connect: { steps: FixtureFeedStep[] };
+  simpleTurn: TurnScript;
+  interruptedTurn: TurnScript;
+  /** `exempt` needs a written justification; invariant (a)-on-error → UNKNOWN. */
+  errorTurn: TurnScript | { exempt: string };
+  /** Required iff registry `capabilities.approvals === true`, else `unexercisable`. */
+  approvalFlow?: ApprovalScript;
+  teardown?: { steps?: FixtureFeedStep[] };
+  /** Events that legally produce zero patches (acks, buffering). Reviewed prose. */
+  allowedSilentEvents?: Array<{
+    match: (step: FixtureFeedStep) => boolean;
+    reason: string;
+  }>;
+  /** Capabilities beyond the built-ins this transcript genuinely attempts. */
+  exercised?: Array<keyof AgentCapabilitySetV2>;
+  /** Declared-true capabilities this fixture cannot script → UNKNOWN, never drift. */
+  unexercisable?: Array<{
+    capability: keyof AgentCapabilitySetV2;
+    reason: string;
+  }>;
+  /**
+   * Honest escape hatch for pre-existing violations. `issue` must be a real
+   * `#<number>` citation and `reason` must be written prose — the harness
+   * enforces both, so `{ issue: 'TODO' }` cannot buy a skip.
+   *
+   * `capabilities` narrows an `e-capability-drift` gap to the named rows: the
+   * invariant still runs, still reports fixture-authoring errors, and still
+   * fails on drift in every other row. Prefer it to a whole-invariant skip.
+   */
+  knownGaps?: Partial<
+    Record<
+      InvariantId,
+      {
+        issue: string;
+        reason: string;
+        capabilities?: Array<keyof AgentCapabilitySetV2>;
+      }
+    >
+  >;
+  /** Determinism escape hatch for adapter-generated noise. Prefer fixing the rig. */
+  volatileJsonPaths?: string[];
+}

--- a/test/server/protocol-adapters/conformance/fixtures/claude.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/claude.fixture.ts
@@ -1,0 +1,319 @@
+/**
+ * Conformance fixture for the `claude` adapter (stream-json subprocess).
+ *
+ * Every native payload below is transcribed from a real captured stream-json
+ * shape already asserted in `claude-adapter.test.ts` — `system/init`,
+ * `assistant` content blocks (thinking / text / tool_use), the `user`
+ * tool_result echo, `control_request:can_use_tool`, `control_response`, and the
+ * terminal `result` line in both its success and `error_during_execution`
+ * forms. No grammar is invented here.
+ *
+ * Transport injection uses the adapter's existing `spawnFn` seam — zero
+ * production change. The fake child hands out a fixed pid so a replayed
+ * transcript is byte-identical.
+ */
+import {
+  ClaudeProcessRegistry,
+  ClaudeProtocolAdapter,
+} from '../../../../../server/protocol-adapters/claude-adapter.js';
+import {
+  makeClaudeChildHarness,
+  type MockChild,
+} from '../../support/claude-child-double.js';
+import type {
+  AdapterConformanceFixture,
+  FixtureFeedStep,
+} from '../fixture-types.js';
+
+const SESSION = 'claude-conf-1';
+
+/**
+ * Claude-local quirk: the interrupt ack must echo the `request_id` the ADAPTER
+ * generated on stdin, which the fixture cannot know statically. The rig
+ * substitutes this placeholder with the id it reads back off the fake child's
+ * stdin frames. Kept fixture-local — the harness never learns about it.
+ */
+const INTERRUPT_ACK_ID = '__HARNESS_LAST_INTERRUPT__';
+
+function native(event: unknown, label?: string): FixtureFeedStep {
+  return label === undefined
+    ? { kind: 'native', event }
+    : { kind: 'native', event, label };
+}
+
+function result(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    type: 'result',
+    subtype: 'success',
+    duration_ms: 1,
+    total_cost_usd: 0,
+    usage: { input_tokens: 10, output_tokens: 4 },
+    session_id: SESSION,
+    ...overrides,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForInterruptRequestId(child: MockChild): Promise<string> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    for (const frame of child.frames()) {
+      const request = frame.request as { subtype?: string } | undefined;
+      if (
+        frame.type === 'control_request' &&
+        request?.subtype === 'interrupt'
+      ) {
+        const requestId = frame.request_id;
+        if (typeof requestId === 'string') return requestId;
+      }
+    }
+    await sleep(1);
+  }
+  throw new Error(
+    'claude conformance rig: no interrupt control_request appeared on stdin'
+  );
+}
+
+const fixture: AdapterConformanceFixture = {
+  adapterId: 'claude',
+
+  createRig() {
+    const harness = makeClaudeChildHarness();
+    // Inert registry: the conformance floor drives the lifecycle explicitly and
+    // never wants a background GC sweep racing the transcript.
+    const adapter = new ClaudeProtocolAdapter(
+      harness.spawnFn,
+      new ClaudeProcessRegistry(1_000_000)
+    );
+
+    const currentChild = async (): Promise<MockChild> => {
+      const deadline = Date.now() + 1_000;
+      while (Date.now() < deadline) {
+        const record = harness.spawns[harness.spawns.length - 1];
+        if (record) return record.child;
+        await sleep(1);
+      }
+      throw new Error('claude conformance rig: no child process was spawned');
+    };
+
+    return {
+      adapter,
+      config: {
+        cwd: '/tmp/conformance-claude',
+        port: 3000,
+        sessionId: 'conf-claude',
+        hookToken: 'conf',
+        configDir: '/tmp/conf-config',
+      },
+      feed: async (step) => {
+        const child = await currentChild();
+        if (step.kind === 'close') {
+          child.emitClose(step.code ?? 0, null);
+          return;
+        }
+        if (step.kind !== 'native') {
+          throw new Error(
+            `claude conformance rig only feeds native stdout lines, got ${step.kind}`
+          );
+        }
+        const raw = JSON.stringify(step.event);
+        if (!raw.includes(INTERRUPT_ACK_ID)) {
+          child.serverWrite(step.event);
+          return;
+        }
+        const requestId = await waitForInterruptRequestId(child);
+        child.serverWrite(
+          JSON.parse(raw.replaceAll(INTERRUPT_ACK_ID, requestId))
+        );
+      },
+      dispose: async () => {
+        // The fake children die with `disconnect()`; nothing else is owned.
+      },
+    };
+  },
+
+  // The adapter spawns lazily on the first `sendMessage`, so `connect()`
+  // completes with no stdout at all — there is nothing to script here.
+  connect: { steps: [] },
+
+  simpleTurn: {
+    steps: [
+      native(
+        { type: 'system', subtype: 'init', session_id: SESSION },
+        'stream-json init'
+      ),
+      native(
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg-conf-1',
+            content: [
+              { type: 'thinking', thinking: 'conformance reasoning summary' },
+              { type: 'text', text: 'conformance says hi' },
+              {
+                type: 'tool_use',
+                id: 'tu-conf-1',
+                name: 'Bash',
+                input: { command: 'pwd' },
+              },
+            ],
+          },
+          session_id: SESSION,
+        },
+        'assistant echo: thinking + text + Bash tool_use'
+      ),
+      native(
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tu-conf-1',
+                content: '/tmp/conformance-claude',
+              },
+            ],
+          },
+          tool_use_result: { stdout: '/tmp/conformance-claude\n', stderr: '' },
+        },
+        'tool_result for the Bash call'
+      ),
+      native(result(), 'terminal result'),
+    ],
+    expect: {
+      terminalStatus: 'completed',
+      requiredPatchTypes: [
+        'agent-turn-started-v2',
+        'agent-item-started-v2',
+        'agent-item-delta-v2',
+        'agent-item-updated-v2',
+        'agent-turn-completed-v2',
+      ],
+      textIncludes: ['conformance says hi'],
+    },
+  },
+
+  interruptedTurn: {
+    steps: [
+      native(
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg-conf-2',
+            content: [{ type: 'text', text: 'conformance long answer' }],
+          },
+          session_id: SESSION,
+        },
+        'partial answer before the interrupt'
+      ),
+      // interruptAfter: 1 → the harness calls interrupt() here and the adapter
+      // writes a control_request(interrupt) frame to stdin; the CLI acks it.
+      native(
+        {
+          type: 'control_response',
+          response: { subtype: 'success', request_id: INTERRUPT_ACK_ID },
+        },
+        'interrupt ack'
+      ),
+    ],
+    interruptAfter: 1,
+    expect: { terminalStatus: 'interrupted' },
+  },
+
+  errorTurn: {
+    steps: [
+      native(
+        result({
+          subtype: 'error_during_execution',
+          is_error: true,
+          error: 'conformance provider failure',
+        }),
+        'provider failure terminal'
+      ),
+    ],
+    expect: { terminalStatus: 'failed' },
+  },
+
+  approvalFlow: {
+    request: [
+      native(
+        {
+          type: 'control_request',
+          request_id: 'ctrl-conf-approval',
+          request: {
+            subtype: 'can_use_tool',
+            tool_name: 'Bash',
+            input: { command: 'pwd' },
+          },
+        },
+        'can_use_tool permission prompt'
+      ),
+    ],
+    decision: { kind: 'accept', scope: 'once' },
+    resolution: [native(result(), 'post-approval terminal')],
+    expect: { terminalStatus: 'completed' },
+  },
+
+  allowedSilentEvents: [
+    {
+      match: (step) =>
+        step.kind === 'native' &&
+        (step.event as { type?: string }).type === 'control_response',
+      reason:
+        'a control_response resolves an in-flight control promise inside the adapter; emitting no patch of its own is the contract, and any user-visible consequence arrives from the control continuation',
+    },
+  ],
+
+  knownGaps: {
+    'b-abandoned-approval': {
+      issue: '#1407',
+      reason:
+        'onDisconnect writes the deny control_response to the child (correct on the wire) but emits no agent-item-updated-v2 resolving the approval item and no live-state patch draining activeRequestIds, so the reduced session keeps a permanently actionable approval card',
+    },
+  },
+
+  exercised: ['reasoning', 'commandExecution', 'streaming', 'telemetry'],
+
+  unexercisable: [
+    {
+      capability: 'resume',
+      reason:
+        'resume needs a second scripted process generation (--resume respawn); deep-tested in claude-adapter.test.ts',
+    },
+    {
+      capability: 'steer',
+      reason:
+        'steer frame choreography and its rejection races are deep-tested in claude-adapter.test.ts; the floor fixture drives one turn at a time',
+    },
+    {
+      capability: 'queue',
+      reason:
+        'the floor transcript never has two turns in flight, which is what queueing means here',
+    },
+    {
+      capability: 'compact',
+      reason:
+        'compaction arrives on a system/compact_boundary line the floor transcript does not script',
+    },
+    {
+      capability: 'tools',
+      reason:
+        'the scripted Bash tool_use maps to commandExecution; an mcp__ tool call is deep-tested in claude-adapter.test.ts',
+    },
+    {
+      capability: 'fileChanges',
+      reason:
+        'Edit/Write tool_use → fileChange mapping is deep-tested in claude-adapter.test.ts; the floor transcript scripts one Bash call instead',
+    },
+    {
+      capability: 'rateLimits',
+      reason: 'no rate-limit patch shape exists in AgentPatchV2 yet to detect',
+    },
+  ],
+};
+
+export default fixture;

--- a/test/server/protocol-adapters/conformance/fixtures/codex.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/codex.fixture.ts
@@ -1,0 +1,564 @@
+/**
+ * Conformance fixture for the `codex` adapter (app-server JSON-RPC subprocess).
+ *
+ * Every native payload below is transcribed from a real captured app-server
+ * frame already asserted elsewhere in the repo:
+ *
+ * - `turn/started` / `turn/completed` / `thread/tokenUsageUpdated`
+ *   — `codex-native-adapter.test.ts` (turn lifecycle + usage buffering).
+ * - `item/started` + `item/agentMessage/delta` + `item/completed`
+ *   — `codex-native-adapter.test.ts` and
+ *     `test/fixtures/channel-chat/codex-terminal-ordering.ts`.
+ * - `reasoning` / `commandExecution` / `fileChange` item shapes
+ *   — `test/fixtures/agent-detail/codex.ts` (hand-sanitized capture).
+ * - `mcpToolCall`, `item/commandExecution/requestApproval`,
+ *   `item/tool/requestUserInput` — `codex-native-adapter.test.ts`.
+ *
+ * No grammar is invented here.
+ *
+ * Transport injection uses the adapter's existing constructor seam
+ * (`new CodexNativeProtocolAdapter(factory)`) — zero production change. The
+ * stub client hands out fixed thread/turn/item ids so a replayed transcript is
+ * byte-identical.
+ *
+ * Codex-local sequencing rule: every streamed item is completed *before* its
+ * `turn/completed`. Codex defers a completed Relay turn for
+ * `CODEX_TERMINAL_ITEM_GRACE_MS` when an agentMessage/reasoning item is still
+ * open, and a floor transcript that leans on that timer would be measuring a
+ * wall clock instead of the contract.
+ */
+import { CodexNativeProtocolAdapter } from '../../../../../server/protocol-adapters/codex-native-adapter.js';
+import {
+  makeCodexClientStubHarness,
+  type StubCodexClient,
+} from '../stubs/codex.stub.js';
+import type {
+  AdapterConformanceFixture,
+  FixtureFeedStep,
+} from '../fixture-types.js';
+
+const THREAD_ID = 'thread-conformance-codex';
+const CWD = '/workspace/example';
+
+/** One app-server `notification` frame. */
+function notify(
+  method: string,
+  params: Record<string, unknown>,
+  label?: string
+): FixtureFeedStep {
+  const event = { method, params };
+  return label === undefined
+    ? { kind: 'native', event }
+    : { kind: 'native', event, label };
+}
+
+/** One app-server server-initiated `request` frame. */
+function request(
+  id: number,
+  method: string,
+  params: Record<string, unknown>,
+  label: string
+): FixtureFeedStep {
+  return { kind: 'server-request', id, method, params, label };
+}
+
+/**
+ * Codex answers an `item/tool/requestUserInput` server-request through
+ * `respondToInput()` — an operator move with no native frame of its own, so it
+ * rides the harness's first-class `operator` step kind rather than a
+ * fixture-local marker smuggled through `native`.
+ */
+function operatorAnswer(
+  requestId: string,
+  answers: Record<string, string[]>,
+  label: string
+): FixtureFeedStep {
+  return {
+    kind: 'operator',
+    action: 'respondToInput',
+    requestId,
+    answers,
+    label,
+  };
+}
+
+// ── Captured payload bodies ───────────────────────────────────────────────
+
+const REASONING_SUMMARY =
+  'Codex synthetic thought: verify the reducer contract before applying the patch.';
+const ANSWER_TEXT = 'Conformance codex answer.';
+const COMMAND = 'node scripts/synthetic-check.mjs';
+const COMMAND_OUTPUT =
+  'export const syntheticCodexValue = {\n  ready: true,\n};';
+const DIFF_PATH = 'src/synthetic/example.ts';
+const DIFF =
+  '--- a/src/synthetic/example.ts\n' +
+  '+++ b/src/synthetic/example.ts\n' +
+  '@@ -1 +1,2 @@\n' +
+  '-const ready = false;\n' +
+  '+const ready = true;\n' +
+  '+export default ready;\n';
+
+const TOKEN_USAGE = {
+  last: {
+    inputTokens: 100,
+    outputTokens: 50,
+    cachedInputTokens: 0,
+    reasoningOutputTokens: 0,
+    totalTokens: 150,
+  },
+  total: {
+    inputTokens: 100,
+    outputTokens: 50,
+    cachedInputTokens: 0,
+    reasoningOutputTokens: 0,
+    totalTokens: 150,
+  },
+  modelContextWindow: 128000,
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const fixture: AdapterConformanceFixture = {
+  adapterId: 'codex',
+
+  createRig() {
+    const harness = makeCodexClientStubHarness({
+      'thread/start': { thread: { id: THREAD_ID } },
+      // Empty catalogs keep the post-connect `model/list` / `skills/list`
+      // refresh deterministic without pretending the floor exercises
+      // slash-command discovery.
+      'model/list': [],
+      'skills/list': { skills: [] },
+    });
+    const adapter = new CodexNativeProtocolAdapter(harness.factory);
+
+    const client = (): StubCodexClient => harness.client;
+
+    return {
+      adapter,
+      config: {
+        cwd: CWD,
+        port: 3000,
+        sessionId: 'conf-codex',
+        hookToken: 'conf',
+        configDir: '/tmp/conf-config',
+        model: 'o4-mini',
+      },
+      feed: async (step) => {
+        if (step.kind === 'close') {
+          client().emit('close', step.code ?? 0);
+        } else if (step.kind === 'server-request') {
+          client().feedRequest(step.id, step.method, step.params);
+        } else if (step.kind === 'native') {
+          const { method, params } = step.event as {
+            method: string;
+            params: Record<string, unknown>;
+          };
+          client().feedNotification(method, params);
+        } else {
+          throw new Error(
+            `codex conformance rig cannot feed step kind '${step.kind}'`
+          );
+        }
+        // Codex's approval and input handlers are async: they park on a promise
+        // and resume only once the adapter settles it. Yield a macrotask so any
+        // continuation this frame released has emitted its patches before the
+        // harness samples the stream for this step.
+        await sleep(0);
+      },
+      dispose: async () => {
+        // The stub client dies with `disconnect()`; nothing else is owned.
+      },
+    };
+  },
+
+  // `connect()` drives `thread/start` (and the `model/list` / `skills/list`
+  // catalog refresh) over pre-seeded stub responses, so there is no inbound
+  // frame to script here.
+  connect: { steps: [] },
+
+  simpleTurn: {
+    prompt: 'conformance simple-turn',
+    steps: [
+      notify(
+        'turn/started',
+        { threadId: THREAD_ID, turn: { id: 'native-conf-simple' } },
+        'native turn opens'
+      ),
+      notify(
+        'item/started',
+        {
+          threadId: THREAD_ID,
+          turnId: 'native-conf-simple',
+          item: {
+            type: 'reasoning',
+            id: 'reason-conf-simple',
+            summary: [],
+            content: [],
+          },
+        },
+        'reasoning item opens'
+      ),
+      notify(
+        'item/reasoning/summaryTextDelta',
+        {
+          threadId: THREAD_ID,
+          turnId: 'native-conf-simple',
+          itemId: 'reason-conf-simple',
+          delta: REASONING_SUMMARY,
+          summaryIndex: 0,
+        },
+        'reasoning summary delta'
+      ),
+      notify(
+        'item/completed',
+        {
+          threadId: THREAD_ID,
+          turnId: 'native-conf-simple',
+          item: {
+            type: 'reasoning',
+            id: 'reason-conf-simple',
+            summary: [REASONING_SUMMARY],
+            content: [],
+          },
+        },
+        'reasoning item terminal'
+      ),
+      notify(
+        'item/started',
+        { item: { type: 'agentMessage', id: 'message-conf-simple' } },
+        'assistant message opens'
+      ),
+      notify(
+        'item/agentMessage/delta',
+        { itemId: 'message-conf-simple', delta: ANSWER_TEXT },
+        'assistant message delta'
+      ),
+      notify(
+        'item/completed',
+        {
+          item: {
+            type: 'agentMessage',
+            id: 'message-conf-simple',
+            text: ANSWER_TEXT,
+          },
+        },
+        'assistant message terminal'
+      ),
+      notify(
+        'item/started',
+        {
+          item: {
+            type: 'commandExecution',
+            id: 'command-conf-simple',
+            command: COMMAND,
+            cwd: CWD,
+          },
+        },
+        'command execution opens'
+      ),
+      notify(
+        'item/commandExecution/outputDelta',
+        { itemId: 'command-conf-simple', delta: COMMAND_OUTPUT },
+        'command output delta'
+      ),
+      notify(
+        'item/completed',
+        {
+          item: {
+            type: 'commandExecution',
+            id: 'command-conf-simple',
+            command: COMMAND,
+            cwd: CWD,
+            aggregatedOutput: COMMAND_OUTPUT,
+            exitCode: 0,
+          },
+        },
+        'command execution terminal'
+      ),
+      notify(
+        'item/started',
+        {
+          item: {
+            type: 'fileChange',
+            id: 'file-conf-simple',
+            changes: [{ path: DIFF_PATH, kind: { type: 'update' }, diff: '' }],
+          },
+        },
+        'file change opens'
+      ),
+      notify(
+        'item/fileChange/patchUpdated',
+        {
+          itemId: 'file-conf-simple',
+          changes: [{ path: DIFF_PATH, kind: { type: 'update' }, diff: DIFF }],
+        },
+        'cumulative patch update'
+      ),
+      notify(
+        'item/completed',
+        {
+          item: {
+            type: 'fileChange',
+            id: 'file-conf-simple',
+            changes: [
+              { path: DIFF_PATH, kind: { type: 'update' }, diff: DIFF },
+            ],
+            applyStatus: 'applied',
+          },
+        },
+        'file change terminal'
+      ),
+      notify(
+        'item/started',
+        {
+          item: {
+            type: 'mcpToolCall',
+            id: 'mcp-conf-simple',
+            server: 'github',
+            tool: 'search',
+            arguments: { query: 'fixture' },
+          },
+        },
+        'mcp tool call opens'
+      ),
+      notify(
+        'item/completed',
+        {
+          item: {
+            type: 'mcpToolCall',
+            id: 'mcp-conf-simple',
+            server: 'github',
+            tool: 'search',
+            result: [],
+          },
+        },
+        'mcp tool call terminal'
+      ),
+      request(
+        60,
+        'item/tool/requestUserInput',
+        { questions: [{ id: 'q1', prompt: 'What is your name?' }] },
+        'tool asks the operator a question'
+      ),
+      operatorAnswer(
+        'input-60',
+        { q1: ['Alice'] },
+        'operator answers the question'
+      ),
+      notify(
+        'thread/tokenUsageUpdated',
+        {
+          threadId: THREAD_ID,
+          turnId: 'native-conf-simple',
+          tokenUsage: TOKEN_USAGE,
+        },
+        'usage buffered for the terminal frame'
+      ),
+      notify(
+        'turn/completed',
+        {
+          threadId: THREAD_ID,
+          turn: { id: 'native-conf-simple', status: 'completed' },
+        },
+        'terminal turn frame'
+      ),
+    ],
+    expect: {
+      terminalStatus: 'completed',
+      requiredPatchTypes: [
+        'agent-turn-started-v2',
+        'agent-item-started-v2',
+        'agent-item-delta-v2',
+        'agent-item-updated-v2',
+        'agent-live-state-updated-v2',
+        'agent-turn-completed-v2',
+      ],
+      textIncludes: [ANSWER_TEXT, REASONING_SUMMARY, COMMAND],
+    },
+  },
+
+  interruptedTurn: {
+    prompt: 'conformance interrupted-turn',
+    steps: [
+      notify(
+        'turn/started',
+        { threadId: THREAD_ID, turn: { id: 'native-conf-interrupt' } },
+        'native turn opens'
+      ),
+      notify(
+        'item/started',
+        { item: { type: 'agentMessage', id: 'message-conf-interrupt' } },
+        'assistant message opens'
+      ),
+      notify(
+        'item/agentMessage/delta',
+        { itemId: 'message-conf-interrupt', delta: 'Partial handoff' },
+        'partial answer before the interrupt'
+      ),
+      // interruptAfter: 3 → the harness calls interrupt() here, which sends
+      // `turn/interrupt` against the live native turn id; the app-server then
+      // terminalizes the partial item and reports the interrupted turn.
+      notify(
+        'item/completed',
+        {
+          item: {
+            type: 'agentMessage',
+            id: 'message-conf-interrupt',
+            text: 'Partial handoff',
+          },
+        },
+        'partial assistant message terminal'
+      ),
+      notify(
+        'turn/completed',
+        {
+          threadId: THREAD_ID,
+          turn: { id: 'native-conf-interrupt', status: 'interrupted' },
+        },
+        'interrupted terminal turn frame'
+      ),
+    ],
+    interruptAfter: 3,
+    expect: { terminalStatus: 'interrupted' },
+  },
+
+  errorTurn: {
+    prompt: 'conformance error-turn',
+    steps: [
+      notify(
+        'turn/started',
+        { threadId: THREAD_ID, turn: { id: 'native-conf-error' } },
+        'native turn opens'
+      ),
+      notify(
+        'turn/completed',
+        {
+          threadId: THREAD_ID,
+          turn: {
+            id: 'native-conf-error',
+            status: 'failed',
+            error: { message: 'conformance provider failure' },
+          },
+        },
+        'failed terminal turn frame'
+      ),
+    ],
+    expect: { terminalStatus: 'failed' },
+  },
+
+  approvalFlow: {
+    prompt: 'conformance approval-flow',
+    request: [
+      notify(
+        'turn/started',
+        { threadId: THREAD_ID, turn: { id: 'native-conf-approval' } },
+        'native turn opens'
+      ),
+      request(
+        70,
+        'item/commandExecution/requestApproval',
+        { command: 'rm -rf tmp', cwd: CWD, commandActions: [] },
+        'command approval prompt'
+      ),
+    ],
+    decision: { kind: 'accept', scope: 'once' },
+    resolution: [
+      notify(
+        'turn/completed',
+        {
+          threadId: THREAD_ID,
+          turn: { id: 'native-conf-approval', status: 'completed' },
+        },
+        'post-approval terminal turn frame'
+      ),
+    ],
+    expect: { terminalStatus: 'completed' },
+  },
+
+  allowedSilentEvents: [
+    {
+      match: (step) =>
+        step.kind === 'native' &&
+        (step.event as { method?: string }).method ===
+          'thread/tokenUsageUpdated',
+      reason:
+        'Codex reports usage on its own cadence, decoupled from the turn boundary. The adapter buffers the breakdown by native turn id and attaches it to the terminal agent-turn-completed-v2 patch, so the frame itself is deliberately patch-free — the user-visible consequence arrives on the completion, which the telemetry detector asserts.',
+    },
+  ],
+
+  knownGaps: {
+    'b-abandoned-approval': {
+      issue: '#1407',
+      reason:
+        'teardownState() clears pendingApprovals/approvalMeta without settling the resolver, so handleCommandApprovalRequest never resumes: no native decision reaches the app-server and no agent-item-updated-v2 resolves the approval item. completeActiveTurn does drain live.activeRequestIds, but the reduced session keeps a permanently actionable approval card — the same shape as the claude gap',
+    },
+  },
+
+  exercised: [
+    'reasoning',
+    'tools',
+    'commandExecution',
+    'fileChanges',
+    'questions',
+    'streaming',
+    'telemetry',
+  ],
+
+  unexercisable: [
+    {
+      capability: 'plans',
+      reason:
+        'turn/plan/updated has no captured frame anywhere in the repo to transcribe, and the floor may not invent provider grammar; plan rendering is covered by the shared item mapping tests',
+    },
+    {
+      capability: 'slashCommands',
+      reason:
+        'the catalog is built from model/list + skills/list at connect; the floor seeds empty catalogs so the transcript stays deterministic, and catalog merging is deep-tested in codex-native-adapter.test.ts',
+    },
+    {
+      capability: 'steer',
+      reason:
+        'turn/steer choreography (successor ids, held terminals, rejection races) needs several turns in flight and is deep-tested in codex-native-adapter.test.ts',
+    },
+    {
+      capability: 'queue',
+      reason:
+        'the floor transcript never has two Relay turns in flight, which is what queueing means here',
+    },
+    {
+      capability: 'cancelQueued',
+      reason:
+        'nothing is ever queued in the floor transcript, so there is nothing to cancel',
+    },
+    {
+      capability: 'resume',
+      reason:
+        'resume needs a second client generation (thread/resume against a saved threadId); deep-tested in codex-native-adapter.test.ts',
+    },
+    {
+      capability: 'fork',
+      reason:
+        'forking a thread is a relay-control dispatch that opens a second provider conversation the floor lifecycle does not model',
+    },
+    {
+      capability: 'rollback',
+      reason:
+        'thread/rollback rewinds provider history; the floor drives one forward transcript and asserts nothing about rewound turns',
+    },
+    {
+      capability: 'compact',
+      reason:
+        'thread/compact/start is a relay-control dispatch, not a scripted native frame in this transcript',
+    },
+    {
+      capability: 'rateLimits',
+      reason: 'no rate-limit patch shape exists in AgentPatchV2 yet to detect',
+    },
+  ],
+};
+
+export default fixture;

--- a/test/server/protocol-adapters/conformance/fixtures/hermes.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/hermes.fixture.ts
@@ -1,0 +1,499 @@
+/**
+ * Conformance fixture for the `hermes` adapter (Responses-API gateway, wrapped
+ * by `LegacyProtocolAdapterV2Bridge`).
+ *
+ * Every native payload below is transcribed from a real captured Hermes
+ * Responses stream already asserted elsewhere in this repo:
+ *
+ * - `test/fixtures/agent-detail/hermes.ts` — the sanitized recorded transcript
+ *   (`response.created`, `reasoning_summary_text.delta/.done`,
+ *   `output_item.added/.done` for `run_command` and `apply_patch`).
+ * - `test/server/protocol-adapters/hermes-adapter.test.ts` — the v0.18.2
+ *   `message` output-item reply shape (lines 838-873), the
+ *   `function_call_arguments.delta/.done` buffering shape (lines 463-540), the
+ *   `apply_patch` unified-diff shape (lines 542-580), the `response.error`
+ *   failure shape (lines 348-379) and the `response.completed` usage payload
+ *   (lines 777-809).
+ *
+ * DELIBERATELY ABSENT: `response.output_text.delta`. The adapter maps it and
+ * `hermes-adapter.test.ts` scripts it, but the shipping Hermes gateway
+ * (v0.18.2) never emits it — it delivers the reply as a `message` output-item
+ * (#1305, continuing #1181). A floor fixture that manufactured token deltas
+ * would assert a stream the provider does not produce, so this transcript uses
+ * the shape the gateway actually sends and leaves `output_text.delta` to the
+ * deep tests.
+ *
+ * The permission shape is the one derived (not recorded) payload and is called
+ * out below.
+ *
+ * Transport: an in-process gateway (`../stubs/hermes.stub.ts`) reached through
+ * `config.extra.endpoint`/`apiToken`, which outrank every env and `config.yaml`
+ * lookup in `resolveHermesGatewaySettings` — so this fixture never touches HOME
+ * and cannot reach a developer's live Hermes.
+ */
+import { HermesProtocolAdapter } from '../../../../../server/protocol-adapters/hermes-adapter.js';
+import { LegacyProtocolAdapterV2Bridge } from '../../../../../server/protocol-adapters/legacy-v2-bridge.js';
+import {
+  startHermesGatewayStub,
+  type HermesGatewayStub,
+} from '../stubs/hermes.stub.js';
+import type {
+  AdapterConformanceFixture,
+  FixtureFeedStep,
+} from '../fixture-types.js';
+
+const SESSION = 'conf-hermes';
+
+/**
+ * Hand-transcribed twin of the `hermes` capability block in
+ * `server/protocol-adapters/index.ts` (lines 99-119), including the
+ * `telemetry: false` honesty note. The suite's registry-parity test compares
+ * this against the registered factory, so a drifted copy fails loudly.
+ */
+const HERMES_CAPABILITIES = {
+  text: true,
+  reasoning: true,
+  tools: true,
+  commandExecution: true,
+  fileChanges: true,
+  approvals: true,
+  slashCommands: false,
+  queue: false,
+  interrupt: true,
+  cancelQueued: false,
+  resume: true,
+  // `HermesProtocolAdapter` emits `chat:telemetry`, but
+  // `mapChatEventToAgentPatchV2` has no case for it, so the bridge drops it
+  // before the V2 stream (#1104). The flag stays false until that mapping
+  // exists; this fixture drives a real `usage` payload to keep that honest.
+  telemetry: false,
+} as const;
+
+/** Captured `apply_patch` output: a created-file unified diff. */
+const ADDED_FILE_DIFF =
+  '--- /dev/null\n+++ b/src/created.ts\n@@ -0,0 +1 @@\n+export const created = true;\n';
+
+const COMMAND_OUTPUT =
+  'export interface SyntheticHermesValue {\n  ready: boolean;\n}';
+
+const REASONING =
+  'Hermes synthetic thought: inspect the tool event before returning output.';
+
+const ASSISTANT_TEXT = 'Hello from the hermes conformance floor';
+
+function native(event: unknown, label?: string): FixtureFeedStep {
+  return label === undefined
+    ? { kind: 'native', event }
+    : { kind: 'native', event, label };
+}
+
+/**
+ * Hermes ends a turn on the SSE stream, but `sendMessage` only resolves once
+ * `consumeResponsesSse` sees end-of-stream — so every turn script closes the
+ * stream after its terminal frame. `close` steps are exempt from the
+ * no-silent-drop ledger by construction.
+ */
+const CLOSE_STREAM: FixtureFeedStep = {
+  kind: 'close',
+  label: 'gateway ends the response stream',
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function eventType(step: FixtureFeedStep): string | undefined {
+  if (step.kind !== 'native') return undefined;
+  const type = (step.event as { type?: unknown }).type;
+  return typeof type === 'string' ? type : undefined;
+}
+
+const fixture: AdapterConformanceFixture = {
+  adapterId: 'hermes',
+
+  async createRig() {
+    const gateway: HermesGatewayStub = await startHermesGatewayStub();
+    const adapter = new LegacyProtocolAdapterV2Bridge(
+      new HermesProtocolAdapter(),
+      HERMES_CAPABILITIES
+    );
+
+    // The rig counts patches itself so `settle()` can wait for real quiescence
+    // over a loopback socket: unlike an in-process stdout double, an SSE frame
+    // needs a kernel round trip before the adapter maps it, and the harness's
+    // default 3×1ms quiet poll can win that race and mis-file a live event as a
+    // silent drop.
+    let seen = 0;
+    adapter.onPatch(() => {
+      seen += 1;
+    });
+
+    return {
+      adapter,
+      config: {
+        cwd: '/tmp/conformance-hermes',
+        port: 3000,
+        sessionId: SESSION,
+        hookToken: 'conf',
+        configDir: '/tmp/conf-config',
+        extra: { endpoint: gateway.endpoint, apiToken: 'conf-hermes-key' },
+      },
+      feed: async (step) => {
+        if (step.kind === 'close') {
+          gateway.endStream();
+          return;
+        }
+        if (step.kind !== 'native') {
+          throw new Error(
+            `hermes conformance rig only feeds native SSE frames, got ${step.kind}`
+          );
+        }
+        await gateway.push(step.event);
+      },
+      settle: async () => {
+        const deadline = Date.now() + 500;
+        let stable = 0;
+        let last = seen;
+        while (Date.now() < deadline) {
+          await sleep(2);
+          if (seen === last) {
+            stable += 1;
+            if (stable >= 10) return;
+          } else {
+            stable = 0;
+            last = seen;
+          }
+        }
+      },
+      dispose: async () => {
+        await gateway.close();
+      },
+    };
+  },
+
+  // `connect()` only probes `/health` + `/v1/models` and then announces the
+  // session; there is no native frame to script.
+  connect: { steps: [] },
+
+  simpleTurn: {
+    prompt: 'run the synthetic check and patch the created file',
+    steps: [
+      native(
+        { type: 'response.created', response: { id: 'resp_conf_simple' } },
+        'response.created'
+      ),
+      native(
+        { type: 'response.reasoning_summary_text.delta', delta: REASONING },
+        'reasoning summary delta'
+      ),
+      native(
+        { type: 'response.reasoning_summary_text.done', text: REASONING },
+        'reasoning summary done'
+      ),
+      native(
+        {
+          type: 'response.output_item.added',
+          item: {
+            id: 'item_conf_command',
+            type: 'function_call',
+            call_id: 'call_conf_command',
+            name: 'run_command',
+            arguments: '{"command":"node scripts/synthetic-check.mjs"}',
+          },
+        },
+        'run_command function_call added'
+      ),
+      native(
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'item_conf_command',
+            type: 'function_call',
+            call_id: 'call_conf_command',
+            name: 'run_command',
+            arguments: '{"command":"node scripts/synthetic-check.mjs"}',
+            status: 'completed',
+            output: COMMAND_OUTPUT,
+          },
+        },
+        'run_command function_call done'
+      ),
+      native(
+        {
+          type: 'response.output_item.added',
+          item: {
+            id: 'item_conf_read',
+            type: 'function_call',
+            call_id: 'call_conf_read',
+            name: 'read_file',
+            arguments: '',
+          },
+        },
+        'read_file function_call added (empty arguments)'
+      ),
+      native(
+        {
+          type: 'response.function_call_arguments.delta',
+          item_id: 'item_conf_read',
+          delta: '{"path":',
+        },
+        'read_file arguments delta 1'
+      ),
+      native(
+        {
+          type: 'response.function_call_arguments.delta',
+          item_id: 'item_conf_read',
+          delta: '"a.txt"}',
+        },
+        'read_file arguments delta 2'
+      ),
+      native(
+        {
+          type: 'response.function_call_arguments.done',
+          item_id: 'item_conf_read',
+          arguments: '{"path":"a.txt"}',
+        },
+        'read_file arguments done'
+      ),
+      native(
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'item_conf_read',
+            type: 'function_call',
+            call_id: 'call_conf_read',
+            name: 'read_file',
+            arguments: '{"path":"a.txt"}',
+            status: 'completed',
+            output: 'file contents',
+          },
+        },
+        'read_file function_call done'
+      ),
+      native(
+        {
+          type: 'response.output_item.added',
+          item: {
+            id: 'item_conf_patch',
+            type: 'function_call',
+            call_id: 'call_conf_patch',
+            name: 'apply_patch',
+            arguments: JSON.stringify({ input: ADDED_FILE_DIFF }),
+          },
+        },
+        'apply_patch function_call added'
+      ),
+      native(
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'item_conf_patch',
+            type: 'function_call',
+            call_id: 'call_conf_patch',
+            name: 'apply_patch',
+            arguments: JSON.stringify({ input: ADDED_FILE_DIFF }),
+            status: 'completed',
+            output: ADDED_FILE_DIFF,
+          },
+        },
+        'apply_patch function_call done (unified diff output)'
+      ),
+      native(
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'msg_conf_out',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [
+              { type: 'output_text', text: ASSISTANT_TEXT, annotations: [] },
+            ],
+          },
+        },
+        'v0.18.2 assistant reply as a message output-item'
+      ),
+      native(
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_conf_simple',
+            status: 'completed',
+            model: 'hermes-conformance',
+            usage: {
+              input_tokens: 12,
+              output_tokens: 34,
+              input_tokens_details: { cached_tokens: 5 },
+            },
+          },
+        },
+        'response.completed with usage'
+      ),
+      CLOSE_STREAM,
+    ],
+    expect: {
+      terminalStatus: 'completed',
+      requiredPatchTypes: [
+        'agent-turn-started-v2',
+        'agent-item-delta-v2',
+        'agent-item-updated-v2',
+        'agent-session-updated-v2',
+        'agent-turn-completed-v2',
+      ],
+      textIncludes: [ASSISTANT_TEXT, 'node scripts/synthetic-check.mjs'],
+    },
+  },
+
+  interruptedTurn: {
+    // A turn cut in flight: the model has streamed a partial reasoning summary
+    // and nothing else when the operator interrupts. The adapter's abort path
+    // (`hermes-adapter.ts` ~line 933) owns the terminal patch, and `interrupt()`
+    // additionally posts `/session/:id/abort` (~line 978); the stub answers
+    // that route, which is what lets the harness's `guard(interrupt())` resolve
+    // rather than time out.
+    steps: [
+      native(
+        { type: 'response.created', response: { id: 'resp_conf_interrupt' } },
+        'response.created'
+      ),
+      native(
+        {
+          type: 'response.reasoning_summary_text.delta',
+          delta: 'Hermes synthetic thought: ',
+        },
+        'partial reasoning before the interrupt'
+      ),
+      CLOSE_STREAM,
+    ],
+    interruptAfter: 2,
+    expect: {
+      terminalStatus: 'interrupted',
+      requiredPatchTypes: ['agent-item-updated-v2', 'agent-turn-completed-v2'],
+    },
+  },
+
+  errorTurn: {
+    steps: [
+      native(
+        { type: 'response.created', response: { id: 'resp_conf_error' } },
+        'response.created'
+      ),
+      native(
+        { type: 'response.error', message: 'gateway blew up' },
+        'provider failure'
+      ),
+      CLOSE_STREAM,
+    ],
+    expect: {
+      terminalStatus: 'failed',
+      requiredPatchTypes: ['agent-error-v2', 'agent-turn-completed-v2'],
+    },
+  },
+
+  approvalFlow: {
+    request: [
+      native(
+        { type: 'response.created', response: { id: 'resp_conf_approval' } },
+        'response.created'
+      ),
+      // NOTE ON PROVENANCE: this repo has no captured Hermes permission stream
+      // — the SSE hardening tests never exercise `permission.requested`. The
+      // payload is therefore transcribed field-for-field from the only
+      // authority available, `HermesProtocolAdapter.handlePermissionRequested`
+      // (`hermes-adapter.ts` ~line 1535), using its primary key spellings
+      // (`requestID`, `permission.tool/description/target`) rather than its
+      // fallbacks. Treat it as derived, not recorded, until a live capture
+      // lands.
+      native(
+        {
+          type: 'permission.requested',
+          requestID: 'perm_conf_1',
+          permission: {
+            tool: 'run_command',
+            description: 'Run the synthetic check script',
+            target: 'node scripts/synthetic-check.mjs',
+          },
+        },
+        'permission.requested'
+      ),
+    ],
+    decision: { kind: 'accept', scope: 'once' },
+    resolution: [
+      native(
+        {
+          type: 'response.completed',
+          response: { id: 'resp_conf_approval', status: 'completed' },
+        },
+        'post-approval terminal'
+      ),
+      CLOSE_STREAM,
+    ],
+    expect: {
+      terminalStatus: 'completed',
+      requiredPatchTypes: ['agent-item-started-v2', 'agent-turn-completed-v2'],
+    },
+  },
+
+  allowedSilentEvents: [
+    {
+      match: (step) => eventType(step) === 'response.created',
+      reason:
+        "`handleResponseCreated` only records the response id as the next turn's `previous_response_id` chaining anchor. It has no user-visible consequence of its own; the id surfaces later as `agent-session-updated-v2` when the response completes.",
+    },
+    {
+      match: (step) =>
+        eventType(step) === 'response.function_call_arguments.delta' ||
+        eventType(step) === 'response.function_call_arguments.done',
+      reason:
+        'Tool arguments are buffered into `_pendingToolCalls` until the call is complete — emitting a patch per argument fragment would publish half-parsed JSON as tool input. The buffered value lands on the matching `response.output_item.done`.',
+    },
+  ],
+
+  exercised: [
+    'reasoning',
+    'commandExecution',
+    'tools',
+    'fileChanges',
+    // `telemetry` is attempted on purpose: the transcript drives a real
+    // `response.completed` usage payload so the reconciliation table records
+    // `declared=false attempted=true manifested=false → honest false`, which is
+    // the standing claim of the `telemetry: false` note in index.ts (#1104).
+    'telemetry',
+  ],
+
+  knownGaps: {
+    'a-terminal': {
+      issue: '#1411',
+      reason:
+        "the error turn emits TWO agent-turn-completed-v2 patches for conf-error: mapChatEventToAgentPatchV2 synthesizes one from chat:error (it carries a turnId) and hermes's failCurrentTurn then fires its own chat:turn-completed. Every hermes failure path fires both events, so no fixture can script a single-terminal failed turn. The simple and interrupted turns DO emit exactly one terminal patch each — that half stays asserted through expect.requiredPatchTypes on every segment",
+    },
+    'b-abandoned-approval': {
+      issue: '#1407',
+      reason:
+        'LegacyProtocolAdapterV2Bridge.onDisconnect unsubscribes from the inner adapter BEFORE calling inner.disconnect(), so the abort-driven chat:turn-completed and idle chat:session-status that would drain the approval are mapped to nothing. Same family as the claude/mock/codex gaps: the wire side is fine, the patch stream keeps a permanently actionable approval card',
+    },
+    'e-capability-drift': {
+      issue: '#1305',
+      // Scoped: only the `streaming` row is gapped, so `fixtureErrors` and the
+      // other nineteen rows — telemetry honesty included — keep biting.
+      capabilities: ['streaming'],
+      reason:
+        "streaming reads as DRIFT (manifested, declared false) without any token streaming happening: hermes deliberately leaves the flag unset until the gateway emits response.output_text.delta (#1305 names the one-line index.ts change as step (b) behind an upstream bump), while the compat bridge carries a COMPLETED tool result on agent-item-delta-v2 — which is all the harness's streaming detector looks for. Tightening that detector to require delta.text would clear this without touching the adapter. Every other row reconciles OK today, telemetry included",
+    },
+  },
+
+  unexercisable: [
+    {
+      capability: 'resume',
+      reason:
+        'hermes resume is `previous_response_id` chaining restored by `resumeSession`, which needs a second connect generation against the same gateway; deep-tested in hermes-adapter.test.ts.',
+    },
+    {
+      capability: 'questions',
+      reason:
+        '`respondToInput` is a documented no-op — the Hermes gateway has no structured question channel, so no fixture can drive one.',
+    },
+  ],
+};
+
+export default fixture;

--- a/test/server/protocol-adapters/conformance/fixtures/mock.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/mock.fixture.ts
@@ -1,0 +1,113 @@
+/**
+ * Conformance fixture for the `mock` adapter (`MockProtocolAdapterV2`).
+ *
+ * The mock is the harness's own smoke test: it proves the suite can drive a
+ * registered adapter end to end with ZERO transport doubles. Every segment is
+ * self-scripted by the adapter, so `feed()` is never called — a feed step here
+ * would mean the harness drifted away from the mock's contract.
+ *
+ * Note the registry has exactly one mock key (`mock` → `MockProtocolAdapterV2`).
+ * The v1 `mock-adapter.ts` is not in `v2Adapters`, so discovery correctly
+ * ignores it and no exemption list is needed.
+ */
+import { MockProtocolAdapterV2 } from '../../../../../server/protocol-adapters/mock-v2-adapter.js';
+import type { AdapterConformanceFixture } from '../fixture-types.js';
+
+const fixture: AdapterConformanceFixture = {
+  adapterId: 'mock',
+
+  createRig() {
+    // Same class the registry builds; only the scripted delays differ, and
+    // delays are not part of the capability set the parity test compares.
+    // `stepMs` is wide enough that the harness's interrupt lands inside the
+    // first scripted sleep on every machine.
+    const adapter = new MockProtocolAdapterV2({ connectMs: 1, stepMs: 30 });
+    return {
+      adapter,
+      config: {
+        cwd: '/tmp/conformance-mock',
+        port: 3000,
+        sessionId: 'conf-mock',
+        hookToken: 'conf',
+        configDir: '/tmp/conf-config',
+      },
+      feed: (step) => {
+        throw new Error(
+          `mock conformance rig is self-scripted and has no transport to feed: ${JSON.stringify(step)}`
+        );
+      },
+      dispose: async () => {
+        // Nothing to tear down — the mock owns no process, socket, or file.
+      },
+    };
+  },
+
+  connect: { steps: [] },
+
+  simpleTurn: {
+    steps: [],
+    expect: {
+      terminalStatus: 'completed',
+      requiredPatchTypes: [
+        'agent-turn-started-v2',
+        'agent-item-started-v2',
+        'agent-item-delta-v2',
+        'agent-turn-completed-v2',
+      ],
+      textIncludes: ['Mock v2 response complete.'],
+    },
+  },
+
+  interruptedTurn: {
+    // The mock aborts through its AbortController: the harness interrupts
+    // before any scripted step, while `runHappyPath` is parked in its sleep.
+    steps: [],
+    interruptAfter: 0,
+    expect: { terminalStatus: 'interrupted' },
+  },
+
+  errorTurn: {
+    exempt:
+      'MockProtocolAdapterV2.runTurn only distinguishes abort (interrupted) from a thrown error (failed), and nothing outside the adapter can make it throw — there is no scriptable provider-failure path. Adding one means a prompt-keyword failure trigger in mock-v2-adapter.ts; flagged, not taken, in this slice.',
+  },
+
+  approvalFlow: {
+    // `isApprovalScenario` matches /\bapproval\b/i on the prompt.
+    prompt: 'please request approval before running the command',
+    request: [],
+    decision: { kind: 'accept', scope: 'once' },
+    resolution: [],
+    expect: { terminalStatus: 'completed' },
+  },
+
+  exercised: [
+    'reasoning',
+    'commandExecution',
+    'fileChanges',
+    'tools',
+    'streaming',
+  ],
+
+  knownGaps: {
+    'b-abandoned-approval': {
+      issue: '#1407',
+      reason:
+        'onDisconnect aborts the turn controller and runTurn DOES emit the resolution, but BaseProtocolAdapterV2.disconnect() clears its handler set first, so no onPatch subscriber ever sees it — the approval stays pending for every consumer, not just this suite',
+    },
+  },
+
+  unexercisable: [
+    {
+      capability: 'telemetry',
+      reason:
+        'no input to MockProtocolAdapterV2 produces a usage payload on its completion patch, so the flag cannot be driven from a fixture',
+    },
+    {
+      capability: 'questions',
+      reason:
+        'the v2 mock has no question/input scenario (respondToInput is a documented no-op)',
+    },
+  ],
+};
+
+export default fixture;

--- a/test/server/protocol-adapters/conformance/fixtures/opencode-attached.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/opencode-attached.fixture.ts
@@ -1,0 +1,357 @@
+/**
+ * Conformance fixture for the `opencode-attached` adapter
+ * (`OpenCodeAttachedAdapter` behind `LegacyProtocolAdapterV2Bridge`).
+ *
+ * Transport: no spawn. The rig builds the same two-plane twin the registry
+ * builds — inner `new OpenCodeAttachedAdapter()` pointed at
+ * `config.extra.endpoint`, wrapped in the bridge with the capability set
+ * transcribed from `server/protocol-adapters/index.ts` lines 80-98 — and hands
+ * it an offline `fetch` double (`../stubs/opencode-attached.stub.ts`) serving
+ * `/global/health` plus a held-open `/event` SSE stream.
+ *
+ * Native payloads below are transcribed from real captured OpenCode streams,
+ * not invented:
+ *   - `message.part.updated` (`{ part, delta }`) — `opencode-adapter.test.ts`
+ *     lines 158-187 (both the web and attached drives) and the recorded server
+ *     double `test/fixtures/opencode-serve-stub.cjs` `emitTurn()`.
+ *   - `session.status` — same serve stub; see the QUIRK note below on the two
+ *     status encodings.
+ *   - `tool.execute.before` / `tool.execute.after` / `permission.asked` — the
+ *     property names both OpenCode adapters read off the wire
+ *     (`opencode-adapter.ts` `handleToolStarted` / `handleToolFinished` /
+ *     `handlePermissionAsked` accept exactly these keys, and the real plugin
+ *     hook payloads in `server/opencode-relay.ts` carry the same `tool` /
+ *     `result` nesting).
+ *
+ * ── Known adapter shortfalls this fixture pins (#1412, all `knownGaps`) ──────
+ * The attached adapter is the only registered OpenCode surface that never
+ * fires `chat:turn-completed`: `OpenCodeProtocolAdapter.handleSessionStatus`
+ * closes the turn on `session.status` idle/error, the attached adapter's
+ * `session.status` handler only re-broadcasts `chat:session-status`. Nothing
+ * else in it produces a terminal either — its `chat:error` carries no `turnId`,
+ * so `mapChatEventToAgentPatchV2` cannot synthesize the failed terminal it
+ * synthesizes for turn-scoped errors. Consequence: no turn this adapter starts
+ * can ever end, for any transcript.
+ *
+ * The harness's cited-gap escape (see `awaitTerminal` in `harness.ts`) lets the
+ * lifecycle run past a terminal that never arrives when — and only when — a
+ * fixture cites an `a-terminal` gap. So (c) no-silent-drop and (d) determinism
+ * are NOT gapped here: both are asserted and both hold. Only the invariants the
+ * missing terminal genuinely blocks are skipped.
+ *
+ * Not a UI hang today: `channel-agent-binder.ts` `handleLiveState` finalizes a
+ * channel turn on a bare `live.status === 'idle'` "even when a matching
+ * `agent-turn-completed-v2` never fired". The floor still asserts it, because
+ * the invariant is stated at the ADAPTER boundary — and that compensation is
+ * explicitly skipped while an approval is outstanding, which is exactly the
+ * state this adapter can also never leave (see the `b-*` gaps).
+ *
+ * Two smaller shape gaps are documented here but deliberately kept OUT of the
+ * scripted transcript, so invariant (c) keeps its teeth for whoever fixes the
+ * terminal gap:
+ *   - `session.status` on the real wire is `{ status: { type: 'idle' } }`
+ *     (serve stub `emitTurn()`; `opencode-adapter.ts` `statusType()` unwraps
+ *     both encodings). The attached handler compares `status === 'idle'` as a
+ *     bare string, so the object encoding maps to nothing at all.
+ *   - `question.asked` fires `chat:input-request`, for which
+ *     `mapChatEventToAgentPatchV2` has no case — a guaranteed silent drop
+ *     through the bridge.
+ */
+import { OpenCodeAttachedAdapter } from '../../../../../server/protocol-adapters/opencode-attached-adapter.js';
+import { LegacyProtocolAdapterV2Bridge } from '../../../../../server/protocol-adapters/legacy-v2-bridge.js';
+import {
+  CONFORMANCE_OPENCODE_ENDPOINT,
+  makeOpenCodeAttachedServerDouble,
+} from '../stubs/opencode-attached.stub.js';
+import type {
+  AdapterConformanceFixture,
+  FixtureFeedStep,
+} from '../fixture-types.js';
+
+/** Relay session id; the adapter builds every session route from it. */
+const SESSION = 'conf-opencode-attached';
+
+/** Root cause every gap below shares. */
+const NO_TERMINAL_TURN_PATCH =
+  'OpenCodeAttachedAdapter never fires chat:turn-completed (its session.status handler only re-broadcasts chat:session-status, unlike OpenCodeProtocolAdapter.handleSessionStatus which closes the turn) and its chat:error carries no turnId, so the compat bridge cannot synthesize a failed terminal either. No scripted transcript can end a turn, so every invariant that reads a terminal patch is unevaluable.';
+
+/**
+ * Capability set transcribed from `index.ts` lines 80-98. The registry-parity
+ * test compares this against the real factory, so any registry edit that is not
+ * mirrored here fails loudly instead of quietly weakening the floor.
+ */
+const REGISTERED_CAPABILITIES = {
+  text: true,
+  reasoning: true,
+  tools: true,
+  commandExecution: true,
+  fileChanges: true,
+  approvals: true,
+  slashCommands: false,
+  queue: false,
+  interrupt: true,
+  cancelQueued: false,
+  resume: false,
+  telemetry: true,
+  streaming: true,
+} as const;
+
+function native(event: unknown, label?: string): FixtureFeedStep {
+  return label === undefined
+    ? { kind: 'native', event }
+    : { kind: 'native', event, label };
+}
+
+/** `session.status` in the string encoding this adapter's handler accepts. */
+function sessionStatus(status: 'active' | 'idle' | 'error'): unknown {
+  return {
+    type: 'session.status',
+    properties: { sessionID: SESSION, status },
+  };
+}
+
+/** One streamed assistant text chunk, real `{ part, delta }` shape. */
+function textDelta(partText: string, delta: string): unknown {
+  return {
+    type: 'message.part.updated',
+    properties: {
+      sessionID: SESSION,
+      part: {
+        id: 'prt_conf_1',
+        sessionID: SESSION,
+        messageID: 'msg_conf_1',
+        type: 'text',
+        text: partText,
+      },
+      delta,
+    },
+  };
+}
+
+const fixture: AdapterConformanceFixture = {
+  adapterId: 'opencode-attached',
+
+  createRig() {
+    const server = makeOpenCodeAttachedServerDouble();
+    const adapter = new LegacyProtocolAdapterV2Bridge(
+      new OpenCodeAttachedAdapter(),
+      { ...REGISTERED_CAPABILITIES }
+    );
+
+    return {
+      adapter,
+      config: {
+        cwd: '/tmp/conformance-opencode-attached',
+        port: 3000,
+        sessionId: SESSION,
+        hookToken: 'conf',
+        configDir: '/tmp/conf-config',
+        extra: { endpoint: CONFORMANCE_OPENCODE_ENDPOINT },
+      },
+      feed: (step) => {
+        if (step.kind === 'close') {
+          server.closeEventStream();
+          return;
+        }
+        if (step.kind !== 'native') {
+          throw new Error(
+            `opencode-attached conformance rig only feeds native SSE events, got ${step.kind}`
+          );
+        }
+        server.push(step.event);
+      },
+      dispose: async () => {
+        server.dispose();
+      },
+    };
+  },
+
+  // `connect()` does the health probe and opens `/event` itself; the double
+  // answers both synchronously, so there is nothing to script here.
+  connect: { steps: [] },
+
+  simpleTurn: {
+    steps: [
+      native(sessionStatus('active'), 'server acknowledges the prompt'),
+      native(textDelta('conformance ', 'conformance '), 'streamed text chunk'),
+      native(
+        textDelta('conformance says hi', 'says hi'),
+        'streamed text chunk'
+      ),
+      native(
+        {
+          type: 'tool.execute.before',
+          properties: {
+            sessionID: SESSION,
+            toolCallId: 'tool_conf_bash',
+            tool: {
+              name: 'bash',
+              description: 'Run a shell command',
+              input: { command: 'pwd' },
+            },
+          },
+        },
+        'bash tool starts (→ commandExecution item)'
+      ),
+      native(
+        {
+          type: 'tool.execute.after',
+          properties: {
+            sessionID: SESSION,
+            toolCallId: 'tool_conf_bash',
+            toolName: 'bash',
+            result: {
+              output: '/tmp/conformance-opencode-attached',
+              durationMs: 3,
+            },
+          },
+        },
+        'bash tool finishes'
+      ),
+      native(
+        {
+          type: 'tool.execute.before',
+          properties: {
+            sessionID: SESSION,
+            toolCallId: 'tool_conf_read',
+            tool: {
+              name: 'read',
+              description: 'Read a file',
+              input: { filePath: 'README.md' },
+            },
+          },
+        },
+        'non-command tool starts (→ dynamicToolCall item)'
+      ),
+      native(
+        {
+          type: 'tool.execute.after',
+          properties: {
+            sessionID: SESSION,
+            toolCallId: 'tool_conf_read',
+            toolName: 'read',
+            result: { output: '# relay-ide', durationMs: 1 },
+          },
+        },
+        'non-command tool finishes'
+      ),
+      native(sessionStatus('idle'), 'server goes idle — the turn is over'),
+    ],
+    expect: {
+      terminalStatus: 'completed',
+      // `agent-turn-completed-v2` is deliberately absent: it is the one patch
+      // this adapter can never emit (#1412), and invariant (a) — not this
+      // sanity list — is where that is recorded. Re-add it the moment the
+      // adapter closes turns, so the gap cannot silently reopen.
+      requiredPatchTypes: [
+        'agent-turn-started-v2',
+        'agent-item-delta-v2',
+        'agent-item-updated-v2',
+        'agent-live-state-updated-v2',
+      ],
+      textIncludes: ['pwd'],
+    },
+  },
+
+  interruptedTurn: {
+    steps: [
+      native(sessionStatus('active'), 'server acknowledges the prompt'),
+      native(
+        textDelta('conformance long ', 'conformance long '),
+        'partial answer before the interrupt'
+      ),
+      // interruptAfter: 2 → the harness calls interrupt() here; the adapter
+      // POSTs `/session/<id>/abort` and the server settles back to idle.
+      native(sessionStatus('idle'), 'server idles after the abort'),
+    ],
+    interruptAfter: 2,
+    expect: { terminalStatus: 'interrupted' },
+  },
+
+  errorTurn: {
+    steps: [
+      native(sessionStatus('active'), 'server acknowledges the prompt'),
+      native(
+        {
+          type: 'session.error',
+          properties: {
+            sessionID: SESSION,
+            error: 'conformance provider failure',
+          },
+        },
+        'provider failure'
+      ),
+    ],
+    expect: { terminalStatus: 'failed' },
+  },
+
+  approvalFlow: {
+    request: [
+      native(sessionStatus('active'), 'server acknowledges the prompt'),
+      native(
+        {
+          type: 'permission.asked',
+          properties: {
+            sessionID: SESSION,
+            requestID: 'per_conf_1',
+            toolName: 'bash',
+            description: 'Run pwd in the workspace',
+            target: 'pwd',
+          },
+        },
+        'permission prompt for the bash tool'
+      ),
+    ],
+    decision: { kind: 'accept', scope: 'once' },
+    resolution: [
+      native(sessionStatus('idle'), 'server idles after the permission reply'),
+    ],
+    expect: { terminalStatus: 'completed' },
+  },
+
+  exercised: ['tools', 'commandExecution', 'streaming'],
+
+  unexercisable: [
+    {
+      capability: 'reasoning',
+      reason:
+        'OpenCodeAttachedAdapter has no chat:reasoning emitter at all (its whole handler table is session.status / message.part.updated / permission.asked / question.asked / tool.execute.before / tool.execute.after / session.error), so no transcript can drive the flag — suspected unbacked capability, flagged not asserted',
+    },
+    {
+      capability: 'fileChanges',
+      reason:
+        'the attached adapter never fires chat:file-change; edits surface only as tool.execute.* events, which map to tool items, so a fileChange item is unreachable from this transport — suspected unbacked capability, flagged not asserted',
+    },
+    {
+      capability: 'telemetry',
+      reason:
+        'the attached adapter has no chat:telemetry emitter (only OpenCodeProtocolAdapter.handleTelemetry does), and mapChatEventToAgentPatchV2 has no chat:telemetry case anyway — the same trap index.ts documents on hermes, here still declared true',
+    },
+  ],
+
+  knownGaps: {
+    'a-terminal': { issue: '#1412', reason: NO_TERMINAL_TURN_PATCH },
+    'b-approval-ids': {
+      issue: '#1412',
+      reason: `${NO_TERMINAL_TURN_PATCH} Independently: respondToApproval() POSTs /permission/<id>/allow and fires nothing, so the pending approval item never reaches a resolved state either.`,
+    },
+    'b-teardown': {
+      issue: '#1412',
+      reason: `${NO_TERMINAL_TURN_PATCH} Independently: nothing drains live.activeRequestIds, so the approval raised by permission.asked stays pending through disconnect().`,
+    },
+    'b-abandoned-approval': {
+      issue: '#1412',
+      reason: `${NO_TERMINAL_TURN_PATCH} Independently: onDetach() only aborts the SSE and message controllers — it neither denies the outstanding permission on the wire nor emits any patch resolving the approval item.`,
+    },
+    // (c) and (d) are NOT gapped: with the harness's cited-gap escape the run
+    // completes, and both hold — every scripted event maps to a patch and two
+    // replays agree. They stay asserted so the terminal gap cannot be used as
+    // cover for a second regression.
+    'e-capability-drift': {
+      issue: '#1412',
+      reason: `${NO_TERMINAL_TURN_PATCH} Independently: capabilities.interrupt is declared true, but with no terminal patch of any status the interrupt detector can never see an interrupted turn, so the flag is unbacked end to end.`,
+    },
+  },
+};
+
+export default fixture;

--- a/test/server/protocol-adapters/conformance/fixtures/opencode.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/opencode.fixture.ts
@@ -1,0 +1,425 @@
+/**
+ * Conformance fixture for the `opencode` adapter (HTTP + SSE, bridged to V2).
+ *
+ * Shape provenance — nothing below is invented grammar:
+ *
+ * - `message.part.updated` is transcribed from the captured shape asserted in
+ *   `opencode-adapter.test.ts` lines 157-188 (`properties.part = { type:'text',
+ *   id, messageID, text }` plus a sibling `properties.delta` string).
+ * - the HTTP script (`/global/health` 200, `POST /session` → fixed id,
+ *   `/global/event` 200) is the same responder that test installs at lines
+ *   41-108, extended with the message / abort / permission routes the adapter
+ *   actually calls.
+ * - `message.updated`, `tool.execute.before`, `tool.execute.after`,
+ *   `permission.asked`, `permission.replied` and `tui.toast.show` are the
+ *   remaining `mapOpenCodeEvent` cases in
+ *   `server/protocol-adapters/opencode-adapter.ts`; each payload carries
+ *   exactly the fields its handler reads, and the terminal/error vocabulary is
+ *   the one `shared/agent-chat-v1-compat.ts` maps into `AgentPatchV2`.
+ *
+ * Rig shape: the registry builds `LegacyProtocolAdapterV2Bridge(new
+ * OpenCodeProtocolAdapter(), <capability literal>)`, so the rig builds the same
+ * pair with the spawn seam injected. The capability object is hand-copied from
+ * `server/protocol-adapters/index.ts` lines 58-79 and the suite's registry
+ * parity test guards the copy against drift.
+ *
+ * Turn boundary quirk: an OpenCode turn is bounded by the message POST, not by
+ * an event. `chat:turn-completed` fires when `POST /session/:id/message`
+ * resolves, so every completing turn ends with a `transport-reply` step that
+ * hands the double the provider's HTTP reply. Interrupt and the toast-driven
+ * failure path both end the turn by aborting that same request instead.
+ */
+import { LegacyProtocolAdapterV2Bridge } from '../../../../../server/protocol-adapters/legacy-v2-bridge.js';
+import { OpenCodeProtocolAdapter } from '../../../../../server/protocol-adapters/opencode-adapter.js';
+import type { AgentCapabilitySetV2 } from '../../../../../shared/agent-chat-protocol-v2.js';
+import {
+  makeOpenCodeTransportStub,
+  OPENCODE_SESSION_ID,
+} from '../stubs/opencode.stub.js';
+import type {
+  AdapterConformanceFixture,
+  FixtureFeedStep,
+} from '../fixture-types.js';
+
+/**
+ * Hand-copied from `v2Adapters.opencode` in `server/protocol-adapters/index.ts`
+ * (lines 58-79). The suite's `registry parity` test asserts this equals the
+ * registered set, so a registry edit that skips this file fails there rather
+ * than silently reconciling against a stale literal.
+ */
+const OPENCODE_BRIDGE_CAPABILITIES: AgentCapabilitySetV2 = {
+  text: true,
+  reasoning: true,
+  tools: true,
+  commandExecution: true,
+  fileChanges: true,
+  approvals: true,
+  slashCommands: false,
+  queue: false,
+  interrupt: true,
+  cancelQueued: false,
+  resume: false,
+  telemetry: true,
+  streaming: true,
+};
+
+interface OpenCodeEventLike {
+  type: string;
+  properties?: Record<string, unknown>;
+}
+
+function native(event: OpenCodeEventLike, label: string): FixtureFeedStep {
+  return { kind: 'native', event, label };
+}
+
+/**
+ * The step that ends a completing turn: the deferred `POST /session/:id/message`
+ * the ADAPTER issued finally gets its reply. That is a transport reply, not a
+ * server-initiated request, so it uses the harness's `transport-reply` kind.
+ */
+function messageResponse(
+  messageId: string,
+  text: string,
+  label: string
+): FixtureFeedStep {
+  return {
+    kind: 'transport-reply',
+    id: messageId,
+    payload: {
+      info: {
+        id: messageId,
+        role: 'assistant',
+        sessionID: OPENCODE_SESSION_ID,
+      },
+      parts: [
+        {
+          id: `${messageId}-text`,
+          sessionID: OPENCODE_SESSION_ID,
+          messageID: messageId,
+          type: 'text',
+          text,
+        },
+      ],
+    },
+    label,
+  };
+}
+
+function textPart(
+  messageId: string,
+  text: string,
+  delta: string
+): OpenCodeEventLike {
+  return {
+    type: 'message.part.updated',
+    properties: {
+      part: {
+        id: `${messageId}-text`,
+        sessionID: OPENCODE_SESSION_ID,
+        messageID: messageId,
+        type: 'text',
+        text,
+      },
+      delta,
+    },
+  };
+}
+
+const SIMPLE_TEXT = 'Conformance floor holds.';
+
+const fixture: AdapterConformanceFixture = {
+  adapterId: 'opencode',
+
+  createRig() {
+    const stub = makeOpenCodeTransportStub();
+    const inner = new OpenCodeProtocolAdapter(stub.spawnFn);
+    const adapter = new LegacyProtocolAdapterV2Bridge(
+      inner,
+      OPENCODE_BRIDGE_CAPABILITIES
+    );
+
+    // The event plane. `mapOpenCodeEvent` is the dispatcher every SSE frame
+    // reaches after parsing, and the seam the existing deep tests already drive
+    // (`driveOpenCodeEvent`, opencode-adapter.test.ts lines 23-37).
+    const dispatch = inner as unknown as {
+      mapOpenCodeEvent(event: OpenCodeEventLike): void;
+    };
+
+    // Patch-count quiescence, rig-owned. The harness default assumes a fed step
+    // produces its patches synchronously; here a turn-ending step resolves an
+    // HTTP request whose body still has to be read, so the wait has to outlast
+    // a `Response.json()`.
+    let seen = 0;
+    adapter.onPatch(() => {
+      seen += 1;
+    });
+    const tick = (ms: number): Promise<void> =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+
+    return {
+      adapter,
+      config: {
+        cwd: '/tmp/conformance-opencode',
+        port: 3000,
+        sessionId: 'conf-opencode',
+        hookToken: 'conf',
+        configDir: '/tmp/conf-config',
+      },
+      feed: async (step) => {
+        if (step.kind === 'native') {
+          dispatch.mapOpenCodeEvent(step.event as OpenCodeEventLike);
+          return;
+        }
+        if (step.kind === 'transport-reply') {
+          await stub.completeMessagePost(step.payload);
+          return;
+        }
+        throw new Error(
+          `opencode conformance rig cannot feed step: ${JSON.stringify(step)}`
+        );
+      },
+      settle: async () => {
+        // Let any in-flight body read and its continuation land before the
+        // stability count starts; otherwise a real patch can arrive after the
+        // wait and read as a silent drop.
+        for (let i = 0; i < 3; i += 1) await tick(2);
+        let stable = 0;
+        let last = seen;
+        const deadline = Date.now() + 400;
+        while (stable < 6 && Date.now() < deadline) {
+          await tick(2);
+          if (seen === last) stable += 1;
+          else {
+            stable = 0;
+            last = seen;
+          }
+        }
+      },
+      dispose: async () => {
+        stub.restore();
+      },
+    };
+  },
+
+  // `connect()` is self-driving over the command plane: health probe, then
+  // `POST /session`, then the SSE subscription. Nothing to script.
+  connect: { steps: [] },
+
+  simpleTurn: {
+    steps: [
+      native(
+        {
+          type: 'message.updated',
+          properties: {
+            info: {
+              id: 'msg-conf-simple',
+              role: 'assistant',
+              sessionID: OPENCODE_SESSION_ID,
+            },
+          },
+        },
+        'message.updated: classify msg-conf-simple as assistant'
+      ),
+      native(
+        textPart('msg-conf-simple', 'Conformance floor ', 'Conformance floor '),
+        'streamed text delta'
+      ),
+      native(
+        {
+          type: 'tool.execute.before',
+          properties: {
+            sessionID: OPENCODE_SESSION_ID,
+            toolCallId: 'call-conf-bash',
+            tool: {
+              name: 'bash',
+              description: 'Print the working directory',
+              input: { command: 'pwd' },
+            },
+          },
+        },
+        'bash tool starts'
+      ),
+      native(
+        {
+          type: 'tool.execute.after',
+          properties: {
+            sessionID: OPENCODE_SESSION_ID,
+            toolCallId: 'call-conf-bash',
+            tool: { name: 'bash' },
+            result: { output: '/tmp/conformance-opencode\n', durationMs: 3 },
+          },
+        },
+        'bash tool finishes'
+      ),
+      native(
+        {
+          type: 'tool.execute.before',
+          properties: {
+            sessionID: OPENCODE_SESSION_ID,
+            toolCallId: 'call-conf-read',
+            tool: {
+              name: 'read',
+              description: 'Read a file',
+              input: { filePath: 'README.md' },
+            },
+          },
+        },
+        'non-command tool starts'
+      ),
+      native(
+        {
+          type: 'tool.execute.after',
+          properties: {
+            sessionID: OPENCODE_SESSION_ID,
+            toolCallId: 'call-conf-read',
+            tool: { name: 'read' },
+            result: { output: '# relay-ide\n', durationMs: 1 },
+          },
+        },
+        'non-command tool finishes'
+      ),
+      native(
+        textPart('msg-conf-simple', SIMPLE_TEXT, 'holds.'),
+        'final text delta'
+      ),
+      messageResponse('msg-conf-simple', SIMPLE_TEXT, 'turn reply lands'),
+    ],
+    expect: {
+      terminalStatus: 'completed',
+      requiredPatchTypes: [
+        'agent-turn-started-v2',
+        'agent-item-delta-v2',
+        'agent-item-updated-v2',
+        'agent-turn-completed-v2',
+      ],
+      textIncludes: [SIMPLE_TEXT],
+    },
+  },
+
+  interruptedTurn: {
+    steps: [
+      native(
+        textPart(
+          'msg-conf-interrupt',
+          'Working on the long ',
+          'Working on the long '
+        ),
+        'partial answer before the interrupt'
+      ),
+      // interruptAfter: 1 → `interrupt()` aborts the in-flight message POST and
+      // fires `POST /session/:id/abort`; the aborted request is what terminates
+      // the turn, so there is no provider frame left to script.
+    ],
+    interruptAfter: 1,
+    expect: { terminalStatus: 'interrupted' },
+  },
+
+  errorTurn: {
+    steps: [
+      native(
+        {
+          type: 'tui.toast.show',
+          properties: {
+            sessionID: OPENCODE_SESSION_ID,
+            variant: 'error',
+            title: 'OpenCode',
+            message: 'conformance provider failure',
+          },
+        },
+        'error toast fails the live turn'
+      ),
+    ],
+    expect: { terminalStatus: 'failed' },
+  },
+
+  approvalFlow: {
+    request: [
+      native(
+        {
+          type: 'permission.asked',
+          properties: {
+            sessionID: OPENCODE_SESSION_ID,
+            requestID: 'perm-conf-1',
+            permission: {
+              tool: 'bash',
+              description: 'Run pwd in the workspace',
+              target: 'pwd',
+            },
+          },
+        },
+        'permission prompt'
+      ),
+    ],
+    decision: { kind: 'accept', scope: 'once' },
+    resolution: [
+      native(
+        {
+          type: 'permission.replied',
+          properties: { sessionID: OPENCODE_SESSION_ID },
+        },
+        'provider acknowledges the reply and resumes'
+      ),
+      messageResponse(
+        'msg-conf-approval',
+        'Approved command finished.',
+        'post-approval turn reply'
+      ),
+    ],
+    expect: { terminalStatus: 'completed' },
+  },
+
+  allowedSilentEvents: [
+    {
+      match: (step) =>
+        step.kind === 'native' &&
+        (step.event as OpenCodeEventLike).type === 'message.updated',
+      reason:
+        '`handleMessageUpdated` is pure bookkeeping: it records whether a message id belongs to the user or the assistant so a later `message.part.updated` echoing the prompt can be suppressed. Its user-visible consequence is the ABSENCE of a duplicated user bubble, and it arrives on the part events, so emitting a patch of its own would be wrong rather than missing.',
+    },
+  ],
+
+  exercised: ['commandExecution', 'tools', 'streaming'],
+
+  unexercisable: [
+    {
+      capability: 'reasoning',
+      reason:
+        'SUSPECTED REGISTRY DRIFT, not a fixture gap: `OpenCodeProtocolAdapter` never fires `chat:reasoning` on any code path (`handleMessagePartUpdated` returns early unless `part.type === "text"`), so no transcript over this transport can manifest it. Reported as UNKNOWN rather than DRIFT because the harness cannot distinguish "adapter has no path" from "fixture did not drive it" — see the fixture notes on #1407-adjacent capability honesty.',
+    },
+    {
+      capability: 'fileChanges',
+      reason:
+        'SUSPECTED REGISTRY DRIFT, same shape as `reasoning`: the adapter never fires `chat:file-change`, and OpenCode edit/write tools arrive as `tool.execute.*`, which `mapChatEventToAgentPatchV2` maps to `dynamicToolCall`, never to a `fileChange` item.',
+    },
+    {
+      capability: 'telemetry',
+      reason:
+        'SUSPECTED REGISTRY DRIFT: the only producer is `handleTelemetry`, reachable solely through `handleHookEvent("telemetry.updated")` on the legacy hook-router plane, not through `mapOpenCodeEvent`; and even from there `mapChatEventToAgentPatchV2` has no `chat:telemetry` case, so the bridge drops it — the exact gap `index.ts` cites when it keeps hermes at `telemetry: false`.',
+    },
+    {
+      capability: 'questions',
+      reason:
+        'declared false and honest to leave alone: `question.asked` does fire `chat:input-request`, but the compat bridge has no case for it, so the floor would have to license a genuine drop to script it.',
+    },
+    {
+      capability: 'resume',
+      reason:
+        'declared false: `resumeSession` is a documented no-op and the bridge throws on resume when the flag is false',
+    },
+    {
+      capability: 'queue',
+      reason:
+        'declared false: the floor transcript never has two turns in flight, which is what queueing would mean here',
+    },
+  ],
+
+  knownGaps: {
+    'b-abandoned-approval': {
+      issue: '#1407',
+      reason:
+        'opencode variant of the shared teardown gap: `LegacyProtocolAdapterV2Bridge.onDisconnect` unsubscribes from the inner adapter BEFORE awaiting `inner.disconnect()`, so the `chat:turn-completed` + idle `chat:session-status` the aborted message POST produces are mapped by nobody. The pending approval item and `live.activeRequestIds` survive into the reduced session.',
+    },
+  },
+};
+
+export default fixture;

--- a/test/server/protocol-adapters/conformance/fixtures/pi.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/pi.fixture.ts
@@ -1,0 +1,316 @@
+/**
+ * Conformance fixture for the `pi` adapter (`pi --mode rpc` JSONL child).
+ *
+ * Every native payload below is transcribed from a real captured Pi RPC frame
+ * already asserted in `pi-agent-adapter.test.ts`: the `get_state` start payload
+ * (`sessionId` / `sessionFile` / `isStreaming`, lines 20-46), `message_start`,
+ * `message_update` with `text_delta` / `thinking_delta`, the
+ * `tool_execution_start` / `_update` / `_end` triple with its MCP-style
+ * `{ content: [{ type: 'text', text }] }` result, `message_end` with the
+ * `{ input, output, cacheRead, cacheWrite, cost: { total } }` usage payload,
+ * `auto_retry_end`, `agent_end`, and `agent_settled`. No grammar is invented.
+ *
+ * Transport injection uses the adapter's existing client-factory seam — zero
+ * production change. See `../stubs/pi.stub.ts`.
+ *
+ * Pi declares `approvals: false` (`respondToApproval` throws outright), so this
+ * fixture scripts no approval flow and approvals reconciles as UNKNOWN.
+ */
+import { PiAgentProtocolAdapter } from '../../../../../server/protocol-adapters/pi-agent-adapter.js';
+import type { PiAgentRpcMessage } from '../../../../../server/pi-agent-rpc-client.js';
+import { makePiRpcClientDouble } from '../stubs/pi.stub.js';
+import type {
+  AdapterConformanceFixture,
+  FixtureFeedStep,
+} from '../fixture-types.js';
+
+function native(event: unknown, label?: string): FixtureFeedStep {
+  return label === undefined
+    ? { kind: 'native', event }
+    : { kind: 'native', event, label };
+}
+
+/** MCP-style tool result envelope Pi wraps every tool payload in. */
+function toolResult(text: string): Record<string, unknown> {
+  return { content: [{ type: 'text', text }] };
+}
+
+function eventType(step: FixtureFeedStep): string | undefined {
+  return step.kind === 'native'
+    ? (step.event as { type?: string }).type
+    : undefined;
+}
+
+const fixture: AdapterConformanceFixture = {
+  adapterId: 'pi',
+
+  createRig() {
+    const rpc = makePiRpcClientDouble();
+    const adapter = new PiAgentProtocolAdapter(rpc.factory);
+
+    return {
+      adapter,
+      config: {
+        cwd: '/tmp/conformance-pi',
+        port: 3000,
+        sessionId: 'conf-pi',
+        hookToken: 'conf',
+        configDir: '/tmp/conf-config',
+      },
+      feed: (step) => {
+        if (step.kind !== 'native') {
+          throw new Error(
+            `pi conformance rig only feeds native RPC frames, got ${step.kind}`
+          );
+        }
+        rpc.emit(step.event as PiAgentRpcMessage);
+      },
+      dispose: async () => {
+        // The double owns no child process, socket, or file — `stop()` is spied
+        // and `disconnect()` already drove it.
+      },
+    };
+  },
+
+  // `connect()` resolves on the spied `start()` (the `get_state` response), so
+  // no native frame can land while it is in flight.
+  connect: { steps: [] },
+
+  simpleTurn: {
+    steps: [
+      native(
+        { type: 'message_start', message: { role: 'assistant' } },
+        'assistant message opens'
+      ),
+      native(
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'text_delta',
+            contentIndex: 0,
+            delta: 'Pi conformance ',
+          },
+        },
+        'first text_delta'
+      ),
+      native(
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'text_delta',
+            contentIndex: 0,
+            delta: 'answer',
+          },
+        },
+        'second text_delta on the same content index'
+      ),
+      native(
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'thinking_delta',
+            contentIndex: 1,
+            delta: 'conformance thought',
+          },
+        },
+        'thinking_delta'
+      ),
+      native(
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'pi-conf-bash-1',
+          toolName: 'bash',
+          args: { command: 'pwd' },
+        },
+        'bash tool starts'
+      ),
+      native(
+        {
+          type: 'tool_execution_update',
+          toolCallId: 'pi-conf-bash-1',
+          toolName: 'bash',
+          args: { command: 'pwd' },
+          partialResult: toolResult('/tmp/conf'),
+        },
+        'partial bash output'
+      ),
+      native(
+        {
+          type: 'tool_execution_end',
+          toolCallId: 'pi-conf-bash-1',
+          toolName: 'bash',
+          args: { command: 'pwd' },
+          result: toolResult('/tmp/conformance-pi'),
+          isError: false,
+        },
+        'bash tool completes'
+      ),
+      native(
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'pi-conf-edit-1',
+          toolName: 'edit',
+          args: { path: '/tmp/conformance-pi/answer.ts' },
+        },
+        'edit tool starts (fileChange item)'
+      ),
+      native(
+        {
+          type: 'tool_execution_end',
+          toolCallId: 'pi-conf-edit-1',
+          toolName: 'edit',
+          args: { path: '/tmp/conformance-pi/answer.ts' },
+          result: toolResult('applied'),
+          isError: false,
+        },
+        'edit tool completes'
+      ),
+      native(
+        {
+          type: 'message_end',
+          message: {
+            role: 'assistant',
+            usage: {
+              input: 10,
+              output: 4,
+              cacheRead: 2,
+              cacheWrite: 1,
+              cost: { total: 0.25 },
+            },
+          },
+        },
+        'message_end carrying usage'
+      ),
+      native(
+        { type: 'agent_end', messages: [] },
+        'agent_end (not the boundary)'
+      ),
+      native(
+        { type: 'agent_settled' },
+        'agent_settled — the Relay turn boundary'
+      ),
+    ],
+    expect: {
+      terminalStatus: 'completed',
+      requiredPatchTypes: [
+        'agent-turn-started-v2',
+        'agent-item-started-v2',
+        'agent-item-delta-v2',
+        'agent-item-updated-v2',
+        'agent-turn-completed-v2',
+      ],
+      textIncludes: ['Pi conformance answer', 'conformance thought'],
+    },
+  },
+
+  interruptedTurn: {
+    steps: [
+      native(
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'text_delta',
+            contentIndex: 0,
+            delta: 'Pi conformance long answer',
+          },
+        },
+        'partial answer before the interrupt'
+      ),
+      // interruptAfter: 1 → the harness calls interrupt() here; the adapter
+      // sends the `abort` RPC and Pi still emits its settled boundary.
+      native({ type: 'agent_settled' }, 'agent_settled after abort'),
+    ],
+    interruptAfter: 1,
+    expect: {
+      terminalStatus: 'interrupted',
+      requiredPatchTypes: ['agent-item-delta-v2', 'agent-turn-completed-v2'],
+    },
+  },
+
+  errorTurn: {
+    steps: [
+      native(
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'pi-conf-error-tool',
+          toolName: 'bash',
+          args: { command: 'sleep 1' },
+        },
+        'tool still running when generation fails'
+      ),
+      native(
+        {
+          type: 'auto_retry_end',
+          success: false,
+          finalError: 'Pi conformance quota exhausted',
+        },
+        'exhausted retry marks the turn failed'
+      ),
+      native({ type: 'agent_settled' }, 'agent_settled after the failure'),
+    ],
+    expect: {
+      terminalStatus: 'failed',
+      requiredPatchTypes: [
+        'agent-error-v2',
+        'agent-item-updated-v2',
+        'agent-turn-completed-v2',
+      ],
+    },
+  },
+
+  allowedSilentEvents: [
+    {
+      match: (step) => eventType(step) === 'message_start',
+      reason:
+        'message_start only opens a native assistant message and advances the per-message index the adapter builds stable item ids from; nothing is renderable until the first content delta arrives, which is the patch that creates the item',
+    },
+    {
+      match: (step) => eventType(step) === 'agent_end',
+      reason:
+        'Pi emits agent_end BEFORE agent_settled and may still follow it with an automatic retry, compaction retry, or queued continuation. Completing a Relay turn on agent_end would terminalize a turn the provider has not finished, so producing no patch here is the contract — agent_settled is the boundary (deep-tested in pi-agent-adapter.test.ts)',
+    },
+  ],
+
+  exercised: [
+    'reasoning',
+    'commandExecution',
+    'fileChanges',
+    'streaming',
+    'telemetry',
+  ],
+
+  unexercisable: [
+    {
+      capability: 'tools',
+      reason:
+        'the `tools` detector looks for mcpToolCall/dynamicToolCall, but Pi maps `bash` to commandExecution and `edit` to fileChange, and those are the only tool names present in any captured Pi stream in this repo — driving dynamicToolCall would mean inventing a tool name',
+    },
+    {
+      capability: 'approvals',
+      reason:
+        'the registry declares approvals:false and respondToApproval throws "Pi RPC approvals are not mapped"; no permission-request frame exists in the captured Pi RPC grammar to script, so approvals stays UNKNOWN rather than a false pass',
+    },
+    {
+      capability: 'questions',
+      reason:
+        'declared false and respondToInput throws "Pi RPC questions are not mapped"; no question/input frame appears in any captured Pi stream',
+    },
+    {
+      capability: 'queue',
+      reason:
+        'Relay-local queueing means two overlapping turns, and the floor drives one turn at a time; the queue-advance ladder and its agent_settled boundaries are deep-tested in pi-agent-adapter.test.ts',
+    },
+    {
+      capability: 'resume',
+      reason:
+        'resume needs a second connect generation carrying --session-id, which the single-rig floor transcript does not script; deep-tested in pi-agent-adapter.test.ts',
+    },
+    {
+      capability: 'compact',
+      reason:
+        'compaction runs through the native `compact` RPC (a /compact prompt) or a compaction_end frame, neither of which the floor transcript scripts',
+    },
+  ],
+};
+
+export default fixture;

--- a/test/server/protocol-adapters/conformance/fixtures/prime-agent.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/prime-agent.fixture.ts
@@ -1,0 +1,318 @@
+/**
+ * Conformance fixture for the `prime-agent` adapter (JSONL RPC subprocess).
+ *
+ * Every native payload below is transcribed from a real captured Prime RPC
+ * event already asserted in `prime-agent-adapter.test.ts` — `message_start`,
+ * `message_update` with `text_delta` / `thinking_delta`,
+ * `tool_execution_start` / `_update` / `_end`, `session_action_update`,
+ * `extension_error`, `message_end` with its usage block, `turn_end`,
+ * `auto_retry_end`, and the terminal `agent_end`. The `edit` tool shapes come
+ * from the sibling Pi transcript (`pi-agent-adapter.test.ts` lines 940-990),
+ * which is the same native Prime-family grammar the designer notes point at.
+ * No grammar is invented here.
+ *
+ * Transport injection uses the adapter's existing `ClientFactory` constructor
+ * seam — zero production change. See `../stubs/prime-agent.stub.ts`.
+ */
+import { PrimeAgentProtocolAdapter } from '../../../../../server/protocol-adapters/prime-agent-adapter.js';
+import { makePrimeAgentTransportDouble } from '../stubs/prime-agent.stub.js';
+import type {
+  AdapterConformanceFixture,
+  FixtureFeedStep,
+} from '../fixture-types.js';
+
+function native(event: unknown, label?: string): FixtureFeedStep {
+  return label === undefined
+    ? { kind: 'native', event }
+    : { kind: 'native', event, label };
+}
+
+/** `{ content: [{ type: 'text', text }] }` — Prime's tool result envelope. */
+function toolResult(text: string): Record<string, unknown> {
+  return { content: [{ type: 'text', text }] };
+}
+
+const fixture: AdapterConformanceFixture = {
+  adapterId: 'prime-agent',
+
+  createRig() {
+    const transport = makePrimeAgentTransportDouble();
+    const adapter = new PrimeAgentProtocolAdapter(transport.clientFactory);
+
+    return {
+      adapter,
+      config: {
+        cwd: '/tmp/conformance-prime-agent',
+        port: 3000,
+        sessionId: 'conf-prime-agent',
+        hookToken: 'conf',
+        configDir: '/tmp/conf-config',
+      },
+      feed: (step) => {
+        if (step.kind !== 'native') {
+          throw new Error(
+            `prime-agent conformance rig only feeds native RPC events, got ${step.kind}`
+          );
+        }
+        transport.feed(step.event);
+      },
+      dispose: async () => {
+        // The double owns no OS resources; `disconnect()` already stopped the
+        // stubbed client and the adapter dropped its listeners with it.
+      },
+    };
+  },
+
+  // `connect()` spawns the RPC client, awaits its `start()` readiness
+  // `get_state`, then discovers the model catalog over the control lane. Both
+  // are request/response, so no event-channel frame is scriptable here.
+  connect: { steps: [] },
+
+  simpleTurn: {
+    steps: [
+      native(
+        { type: 'message_start', message: { role: 'assistant' } },
+        'assistant message boundary'
+      ),
+      native(
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'text_delta',
+            contentIndex: 0,
+            delta: 'prime conformance answer',
+          },
+        },
+        'streamed answer text'
+      ),
+      native(
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'thinking_delta',
+            contentIndex: 1,
+            delta: 'prime conformance reasoning',
+          },
+        },
+        'streamed reasoning summary'
+      ),
+      native(
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'conf-tool-bash',
+          toolName: 'bash',
+          args: { command: 'pwd' },
+        },
+        'bash tool start → commandExecution'
+      ),
+      native(
+        {
+          type: 'tool_execution_update',
+          toolCallId: 'conf-tool-bash',
+          toolName: 'bash',
+          args: { command: 'pwd' },
+          partialResult: toolResult('/tmp'),
+        },
+        'partial bash output (replace-mode delta)'
+      ),
+      native(
+        {
+          type: 'tool_execution_end',
+          toolCallId: 'conf-tool-bash',
+          toolName: 'bash',
+          args: { command: 'pwd' },
+          result: toolResult('/tmp/conformance-prime-agent'),
+          isError: false,
+        },
+        'bash tool end'
+      ),
+      native(
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'conf-tool-edit',
+          toolName: 'edit',
+          args: { path: '/tmp/conformance-prime-agent/a.ts' },
+        },
+        'edit tool with a path → fileChange'
+      ),
+      native(
+        {
+          type: 'tool_execution_end',
+          toolCallId: 'conf-tool-edit',
+          toolName: 'edit',
+          args: { path: '/tmp/conformance-prime-agent/a.ts' },
+          result: toolResult('edited'),
+          isError: false,
+        },
+        'edit tool end → applied'
+      ),
+      // Prime-local quirk, captured verbatim at pi-agent-adapter.test.ts:940 —
+      // an `edit` can arrive with empty args. The adapter's file-tool branch is
+      // gated on a non-empty path, so this real shape falls through to the
+      // generic tool lane and is the only captured Prime event that reaches
+      // `dynamicToolCall`. It proves the generic lane maps id, arguments, and
+      // result; it does NOT claim a Prime MCP tool was exercised.
+      native(
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'conf-tool-generic',
+          toolName: 'edit',
+          args: {},
+        },
+        'pathless edit → dynamicToolCall'
+      ),
+      native(
+        {
+          type: 'tool_execution_end',
+          toolCallId: 'conf-tool-generic',
+          toolName: 'edit',
+          args: {},
+          result: toolResult('missing path'),
+          isError: false,
+        },
+        'pathless edit end'
+      ),
+      native(
+        { type: 'session_action_update', actions: { queuedCount: 0 } },
+        'native queue depth report'
+      ),
+      native(
+        { type: 'extension_error', error: 'conformance hook failed' },
+        'nonfatal extension diagnostic'
+      ),
+      native(
+        {
+          type: 'message_end',
+          message: {
+            role: 'assistant',
+            usage: {
+              input: 10,
+              output: 4,
+              cacheRead: 2,
+              cacheWrite: 1,
+              cost: { total: 0.25 },
+            },
+          },
+        },
+        'assistant message end + usage'
+      ),
+      native({ type: 'turn_end' }, 'native turn boundary'),
+      native({ type: 'agent_end' }, 'terminal agent_end'),
+    ],
+    expect: {
+      terminalStatus: 'completed',
+      requiredPatchTypes: [
+        'agent-turn-started-v2',
+        'agent-item-started-v2',
+        'agent-item-delta-v2',
+        'agent-item-updated-v2',
+        'agent-live-state-updated-v2',
+        'agent-turn-completed-v2',
+      ],
+      textIncludes: ['prime conformance answer', 'prime conformance reasoning'],
+    },
+  },
+
+  interruptedTurn: {
+    steps: [
+      native(
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'text_delta',
+            contentIndex: 0,
+            delta: 'prime conformance partial answer',
+          },
+        },
+        'partial answer before the interrupt'
+      ),
+      // interruptAfter: 1 → the harness calls interrupt() here, which issues an
+      // `abort` RPC; Prime then closes the run with its ordinary agent_end and
+      // the adapter attributes the abort it requested.
+      native({ type: 'agent_end' }, 'agent_end after abort'),
+    ],
+    interruptAfter: 1,
+    expect: {
+      terminalStatus: 'interrupted',
+      requiredPatchTypes: ['agent-turn-completed-v2'],
+    },
+  },
+
+  errorTurn: {
+    steps: [
+      native(
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'conf-tool-running',
+          toolName: 'bash',
+          args: { command: 'sleep 1' },
+        },
+        'tool still running when the failure lands'
+      ),
+      native(
+        {
+          type: 'auto_retry_end',
+          success: false,
+          finalError: 'conformance quota exhausted',
+        },
+        'exhausted retry → generation failure'
+      ),
+      native({ type: 'agent_end' }, 'terminal agent_end after failure'),
+    ],
+    expect: {
+      terminalStatus: 'failed',
+      requiredPatchTypes: ['agent-error-v2', 'agent-turn-completed-v2'],
+    },
+  },
+
+  // No `approvalFlow`: the registry declares `approvals: false` and
+  // `respondToApproval()` throws "Prime Agent RPC approvals are not mapped".
+  // Prime's RPC surface has no permission-request frame to transcribe.
+
+  allowedSilentEvents: [
+    {
+      match: (step) =>
+        step.kind === 'native' &&
+        (step.event as { type?: string }).type === 'message_start',
+      reason:
+        "message_start only advances the adapter-local assistant-message sequence so a tool loop's second assistant message gets fresh item ids; the content it announces arrives on later message_update frames, so emitting a patch here would invent an empty item",
+    },
+    {
+      match: (step) =>
+        step.kind === 'native' &&
+        ((step.event as { type?: string }).type === 'turn_start' ||
+          (step.event as { type?: string }).type === 'turn_end'),
+      reason:
+        'a Prime run contains several native turns but exactly one Relay turn; only agent_end is the Relay turn boundary, so mapping turn_start/turn_end to patches would terminalize a turn that is still running',
+    },
+  ],
+
+  exercised: [
+    'reasoning',
+    'tools',
+    'commandExecution',
+    'fileChanges',
+    'streaming',
+    'telemetry',
+  ],
+
+  unexercisable: [
+    {
+      capability: 'resume',
+      reason:
+        'resume needs a second scripted client generation (--resume respawn) and is deep-tested in prime-agent-adapter.test.ts; the floor fixture drives one connection',
+    },
+    {
+      capability: 'queue',
+      reason:
+        'queueing here means a second Relay turn in flight behind an unfinished one, which the one-turn-at-a-time floor transcript never creates; deep-tested in prime-agent-adapter.test.ts',
+    },
+    {
+      capability: 'slashCommands',
+      reason:
+        'the /model and /thinking catalog is discovered over the control lane and executed via executeControlCommand, which the lifecycle harness does not drive; deep-tested in prime-agent-adapter.test.ts',
+    },
+  ],
+};
+
+export default fixture;

--- a/test/server/protocol-adapters/conformance/harness-self.test.ts
+++ b/test/server/protocol-adapters/conformance/harness-self.test.ts
@@ -1,0 +1,354 @@
+/**
+ * The conformance floor is only worth landing if it actually bites. These tests
+ * mutate the claude fixture on purpose and assert the harness reports the
+ * violation, so a future refactor cannot quietly turn the suite vacuous.
+ */
+import { describe, expect, it } from 'vitest';
+import claudeFixture from './fixtures/claude.fixture.js';
+import {
+  CAPABILITIES_WITHOUT_DETECTOR,
+  describeMalformedGap,
+  normalizePatchForReplay,
+  pendingApprovalIds,
+  reconcileCapabilities,
+  renderableText,
+  runAbandonedApprovalProbe,
+  runLifecycle,
+  type LifecycleRun,
+} from './harness.js';
+import type {
+  AdapterConformanceFixture,
+  FixtureFeedStep,
+} from './fixture-types.js';
+import type { AgentPatchV2 } from '../../../../shared/agent-chat-protocol-v2.js';
+
+/**
+ * A second `system/init` carrying the session id the adapter already knows is
+ * real stream-json traffic that maps to no patch — the exact shape invariant
+ * (c) exists to notice.
+ */
+const REDUNDANT_INIT: FixtureFeedStep = {
+  kind: 'native',
+  event: { type: 'system', subtype: 'init', session_id: 'claude-conf-1' },
+  label: 'redundant init (already-known session id)',
+};
+
+function withRedundantInit(
+  overrides?: Partial<AdapterConformanceFixture>
+): AdapterConformanceFixture {
+  return {
+    ...claudeFixture,
+    simpleTurn: {
+      ...claudeFixture.simpleTurn,
+      steps: [
+        ...claudeFixture.simpleTurn.steps.slice(0, 1),
+        REDUNDANT_INIT,
+        ...claudeFixture.simpleTurn.steps.slice(1),
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function withoutApprovalFlow(
+  fixture: AdapterConformanceFixture
+): AdapterConformanceFixture {
+  const { approvalFlow: _approvalFlow, ...rest } = fixture;
+  return rest;
+}
+
+function stubRun(patches: AgentPatchV2[]): LifecycleRun {
+  return {
+    adapterId: 'stub',
+    patches,
+    segments: {
+      connect: [],
+      'simple-turn': patches,
+      'interrupted-turn': [],
+      'error-turn': [],
+      'approval-flow': [],
+      teardown: [],
+    },
+    turnIds: {},
+    expectedTerminal: {},
+    silentDrops: [],
+    approvalIdTimeline: [],
+    finalSession: {
+      id: 'stub',
+      provider: 'mock',
+      capabilities: {},
+      config: { cwd: '/tmp' },
+      live: {
+        status: 'idle',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        proposedPlanItemId: null,
+        queueLength: 0,
+        fastModeAvailable: false,
+        error: null,
+      },
+      turns: [],
+    },
+  };
+}
+
+const interruptedTerminal: AgentPatchV2 = {
+  type: 'agent-turn-completed-v2',
+  sessionId: 'stub',
+  timestamp: '2026-01-01T00:00:00.000Z',
+  turnId: 'turn-1',
+  status: 'interrupted',
+};
+
+describe('conformance harness self-tests', () => {
+  it('(c) records a native event that produced no patch', async () => {
+    const run = await runLifecycle(withRedundantInit());
+    expect(
+      run.silentDrops.map((drop) => drop.step.label ?? drop.step.kind)
+    ).toEqual(['redundant init (already-known session id)']);
+    expect(run.silentDrops[0]?.segment).toBe('simple-turn');
+  }, 30_000);
+
+  it('(c) an allowedSilentEvents entry suppresses that same drop', async () => {
+    const run = await runLifecycle(
+      withRedundantInit({
+        allowedSilentEvents: [
+          ...(claudeFixture.allowedSilentEvents ?? []),
+          {
+            match: (step) =>
+              step.kind === 'native' &&
+              (step.event as { subtype?: string }).subtype === 'init',
+            reason: 'self-test only',
+          },
+        ],
+      })
+    );
+    expect(run.silentDrops).toEqual([]);
+  }, 30_000);
+
+  it('(d) normalization blanks wall-clock and nothing else', () => {
+    const patch: AgentPatchV2 = {
+      type: 'agent-item-started-v2',
+      sessionId: 'session-1',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      turnId: 'turn-1',
+      item: {
+        type: 'assistantMessage',
+        id: 'msg-turn-1-0',
+        text: 'hello',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        completedAt: '2026-01-01T00:00:01.000Z',
+      },
+    };
+    expect(normalizePatchForReplay(patch)).toEqual({
+      type: 'agent-item-started-v2',
+      sessionId: 'session-1',
+      timestamp: '<volatile>',
+      turnId: 'turn-1',
+      item: {
+        type: 'assistantMessage',
+        // Ids are deliberately NOT normalized — id stability is part of
+        // determinism, so a rig with random ids must fail invariant (d).
+        id: 'msg-turn-1-0',
+        text: 'hello',
+        startedAt: '<volatile>',
+        completedAt: '<volatile>',
+      },
+    });
+  });
+
+  it('(d) two runs of the same fixture agree, and a changed id would not', async () => {
+    const first = await runLifecycle(claudeFixture);
+    const second = await runLifecycle(claudeFixture);
+    const normalize = (patches: AgentPatchV2[]): unknown[] =>
+      patches.map((patch) => normalizePatchForReplay(patch));
+    expect(normalize(second.patches)).toEqual(normalize(first.patches));
+    expect(first.patches.length).toBeGreaterThan(20);
+
+    const tampered = structuredClone(second.patches);
+    const target = tampered.find(
+      (patch) => patch.type === 'agent-item-started-v2'
+    );
+    if (target?.type !== 'agent-item-started-v2')
+      throw new Error('expected an item-started patch to tamper with');
+    target.item = { ...target.item, id: `${target.item.id}-tampered` };
+    expect(normalize(tampered)).not.toEqual(normalize(first.patches));
+  }, 60_000);
+
+  it('(e) records exactly which capabilities are UNKNOWN-only in v1', () => {
+    // Live documentation of the floor's ceiling: adding a detector must update
+    // this list, so "UNKNOWN" never quietly grows to cover a real regression.
+    expect([...CAPABILITIES_WITHOUT_DETECTOR]).toEqual([
+      'plans',
+      'slashCommands',
+      'queue',
+      'steer',
+      'cancelQueued',
+      'resume',
+      'fork',
+      'rollback',
+      'compact',
+      'rateLimits',
+    ]);
+  });
+
+  it('(e) a capability that manifests while declared false is DRIFT', () => {
+    const report = reconcileCapabilities({
+      declared: { text: true, interrupt: false },
+      run: stubRun([interruptedTerminal]),
+      fixture: claudeFixture,
+    });
+    const row = report.rows.find((entry) => entry.capability === 'interrupt');
+    expect(row?.verdict).toBe('drift');
+    expect(report.drift.map((entry) => entry.capability)).toContain(
+      'interrupt'
+    );
+  });
+
+  it('(e) a declared capability that was exercised and never manifested is DRIFT', () => {
+    const report = reconcileCapabilities({
+      declared: { text: true, interrupt: true },
+      run: stubRun([]),
+      fixture: claudeFixture,
+    });
+    expect(
+      report.drift.map((entry) => `${entry.capability}:${entry.note}`)
+    ).toContain('interrupt:declared true and exercised, but never manifested');
+  });
+
+  it('(e) an unexercised capability is UNKNOWN, never drift, whatever it declares', () => {
+    const report = reconcileCapabilities({
+      declared: { fileChanges: true, questions: true, text: true },
+      run: stubRun([interruptedTerminal]),
+      fixture: { ...withoutApprovalFlow(claudeFixture), exercised: [] },
+    });
+    for (const capability of ['fileChanges', 'questions'] as const) {
+      expect(
+        report.rows.find((entry) => entry.capability === capability)?.verdict
+      ).toBe('unknown');
+    }
+    expect(report.drift.map((entry) => entry.capability)).not.toContain(
+      'fileChanges'
+    );
+  });
+
+  it('(e) rejects a fixture that attests a capability the harness cannot observe', () => {
+    const report = reconcileCapabilities({
+      declared: { text: true, interrupt: true },
+      run: stubRun([interruptedTerminal]),
+      fixture: { ...claudeFixture, exercised: ['resume'] },
+    });
+    expect(report.fixtureErrors.join('\n')).toMatch(
+      /exercised\['resume'\] has no conformance detector/
+    );
+  });
+
+  it('(e) rejects an unexercisable claim on a built-in the harness always drives', () => {
+    const report = reconcileCapabilities({
+      declared: { text: true, interrupt: true },
+      run: stubRun([interruptedTerminal]),
+      fixture: {
+        ...claudeFixture,
+        unexercisable: [{ capability: 'interrupt', reason: 'nope' }],
+      },
+    });
+    expect(report.fixtureErrors.join('\n')).toMatch(
+      /unexercisable\['interrupt'\] is a built-in/
+    );
+  });
+
+  it('(b) the abandoned-approval probe reports the stranded approval claude leaves (#1407)', async () => {
+    // Red-to-green pin for #1407. The probe is otherwise dead code today (every
+    // approval-bearing fixture gaps `b-abandoned-approval`), so this is the one
+    // place it actually runs — and it must SEE the defect, not shrug at it.
+    // When #1407 lands, this expectation flips to `toEqual([])` and the
+    // per-fixture `b-abandoned-approval` gaps come out.
+    const abandoned = await runAbandonedApprovalProbe(claudeFixture);
+    expect(
+      pendingApprovalIds(abandoned).length,
+      'claude disconnects with the approval still pending — if this is now empty, #1407 is fixed: drop the knownGaps entries and invert this test'
+    ).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('(b) the probe fails loudly when a transcript surfaces no approval at all', async () => {
+    // Without this the probe would pass vacuously against an adapter that
+    // regressed to never raising the approval item in the first place.
+    await expect(
+      runAbandonedApprovalProbe({
+        ...claudeFixture,
+        approvalFlow: { ...claudeFixture.approvalFlow!, request: [] },
+      })
+    ).rejects.toThrow(/surfaced no pending approval item/);
+  }, 30_000);
+
+  it('textIncludes matches rendered text, not raw item JSON', () => {
+    // The needle must not be satisfiable by a key name, an id, or a tool
+    // argument blob the timeline never renders.
+    const rendered = renderableText({
+      type: 'commandExecution',
+      id: 'cmd-1',
+      command: 'pwd',
+      output: '/tmp',
+    });
+    expect(rendered).toContain('pwd');
+    expect(rendered).not.toContain('cmd-1');
+    expect(
+      renderableText({
+        type: 'mcpToolCall',
+        id: 'mcp-1',
+        server: 'github',
+        tool: 'search',
+        arguments: { query: 'secret-needle' },
+      })
+    ).not.toContain('secret-needle');
+  });
+
+  it('known gaps must cite a #issue and a written reason', () => {
+    expect(
+      describeMalformedGap('a-terminal', {
+        issue: 'TODO',
+        reason: 'a perfectly long written justification',
+      })
+    ).toMatch(/must be a '#<number>' citation/);
+    expect(
+      describeMalformedGap('a-terminal', { issue: '#1412', reason: 'nope' })
+    ).toMatch(/needs a written justification/);
+    expect(
+      describeMalformedGap('c-no-silent-drop', {
+        issue: '#1412',
+        reason: 'a perfectly long written justification',
+        capabilities: ['streaming'],
+      })
+    ).toMatch(/only narrows 'e-capability-drift'/);
+    expect(
+      describeMalformedGap('e-capability-drift', {
+        issue: '#1305',
+        reason: 'a perfectly long written justification',
+        capabilities: ['streaming'],
+      })
+    ).toBeUndefined();
+  });
+
+  it('(e) a declared-true capability that is neither exercised nor waived is a fixture error', () => {
+    const report = reconcileCapabilities({
+      declared: { text: true, interrupt: true, questions: true },
+      run: stubRun([interruptedTerminal]),
+      fixture: { ...claudeFixture, exercised: [], unexercisable: [] },
+    });
+    expect(report.fixtureErrors.join('\n')).toMatch(
+      /declared-true capability 'questions' is neither exercised nor waived/
+    );
+  });
+
+  it('(e) rejects an approvals:true adapter with no approvalFlow and no waiver', () => {
+    const report = reconcileCapabilities({
+      declared: { approvals: true, text: true, interrupt: true },
+      run: stubRun([interruptedTerminal]),
+      fixture: withoutApprovalFlow(claudeFixture),
+    });
+    expect(report.fixtureErrors.join('\n')).toMatch(
+      /declares approvals:true but the fixture has no approvalFlow/
+    );
+  });
+});

--- a/test/server/protocol-adapters/conformance/harness.ts
+++ b/test/server/protocol-adapters/conformance/harness.ts
@@ -1,0 +1,1323 @@
+/**
+ * Shared lifecycle harness for the adapter conformance suite.
+ *
+ * One transcript discipline drives every registered `ProtocolAdapterV2`:
+ * connect → simple turn → interrupted turn → error turn → approval flow →
+ * teardown, feeding one scripted native event at a time and letting the patch
+ * stream go quiet between steps. That serialization is what makes invariant (c)
+ * (no native event silently dropped) accountable per event and invariant (d)
+ * (identical replay) free of race noise.
+ *
+ * Everything in this file is provider-agnostic CHOREOGRAPHY. Provider quirks
+ * belong in `fixtures/<id>.fixture.ts`.
+ */
+import { beforeAll, expect, it } from 'vitest';
+import {
+  applyAgentPatchV2,
+  emptyAgentSessionV2,
+  type AgentApprovalItemV2,
+  type AgentCapabilitySetV2,
+  type AgentItemV2,
+  type AgentPatchV2,
+  type AgentSessionV2,
+} from '../../../../shared/agent-chat-protocol-v2.js';
+import type { ProtocolAdapterV2 } from '../../../../server/protocol-adapter-v2.js';
+import { v2Adapters } from '../../../../server/protocol-adapters/index.js';
+import type {
+  AdapterConformanceFixture,
+  ApprovalScript,
+  ConformanceRig,
+  FixtureFeedStep,
+  InvariantId,
+  TurnScript,
+} from './fixture-types.js';
+
+// ── Tunables ─────────────────────────────────────────────────────────────────
+
+/** Consecutive quiet polls before a fed step is considered fully drained. */
+const QUIESCENCE_POLLS = 3;
+/** Upper bound on one step's quiescence wait. */
+const QUIESCENCE_BUDGET_MS = 250;
+/** Upper bound on any single `waitFor` predicate. */
+const WAIT_TIMEOUT_MS = 3_000;
+/**
+ * Shorter budget for a wait the fixture has already told us will fail (a cited
+ * `a-terminal` gap). Spending the full budget four times per run, twice per
+ * determinism check, is pure wall clock — nothing is asserted on the result.
+ */
+const GAPPED_WAIT_TIMEOUT_MS = 500;
+/** Upper bound on one whole lifecycle run. */
+export const LIFECYCLE_TIMEOUT_MS = 30_000;
+
+export type SegmentName =
+  | 'connect'
+  | 'simple-turn'
+  | 'interrupted-turn'
+  | 'error-turn'
+  | 'approval-flow'
+  | 'teardown';
+
+const TURN_SEGMENTS = {
+  'simple-turn': 'conf-simple',
+  'interrupted-turn': 'conf-interrupt',
+  'error-turn': 'conf-error',
+  'approval-flow': 'conf-approval',
+} as const;
+
+type TurnSegmentName = keyof typeof TURN_SEGMENTS;
+
+export type TerminalStatus = 'completed' | 'interrupted' | 'failed';
+
+const DEFAULT_TERMINAL: Record<TurnSegmentName, TerminalStatus> = {
+  'simple-turn': 'completed',
+  'interrupted-turn': 'interrupted',
+  'error-turn': 'failed',
+  'approval-flow': 'completed',
+};
+
+// ── Capability reconciliation table ──────────────────────────────────────────
+
+/**
+ * Every flag on `AgentCapabilitySetV2`. The discovery suite cross-checks this
+ * list against what registered adapters actually declare, so a new protocol
+ * flag cannot slip past reconciliation unnoticed.
+ */
+export const ALL_CAPABILITIES = [
+  'text',
+  'reasoning',
+  'tools',
+  'commandExecution',
+  'fileChanges',
+  'approvals',
+  'questions',
+  'plans',
+  'slashCommands',
+  'queue',
+  'steer',
+  'interrupt',
+  'cancelQueued',
+  'resume',
+  'fork',
+  'rollback',
+  'compact',
+  'telemetry',
+  'rateLimits',
+  'streaming',
+] as const satisfies readonly (keyof AgentCapabilitySetV2)[];
+
+export type CapabilityName = (typeof ALL_CAPABILITIES)[number];
+
+/**
+ * Patch-evidence predicates. Adapter-agnostic by construction: a capability
+ * "manifested" only when the V2 stream carried the shape a renderer needs.
+ * Flags absent from this table are UNKNOWN-only in v1 — detectors are added as
+ * the floor rises.
+ */
+const CAPABILITY_DETECTORS: Partial<
+  Record<CapabilityName, (run: LifecycleRun) => boolean>
+> = {
+  text: (run) =>
+    runItems(run).some(
+      (item) => item.type === 'assistantMessage' && item.text.length > 0
+    ) ||
+    run.patches.some(
+      (patch) =>
+        patch.type === 'agent-item-delta-v2' &&
+        typeof patch.delta.text === 'string' &&
+        patch.delta.text.length > 0
+    ),
+  reasoning: (run) => runItems(run).some((item) => item.type === 'reasoning'),
+  tools: (run) =>
+    runItems(run).some(
+      (item) => item.type === 'mcpToolCall' || item.type === 'dynamicToolCall'
+    ),
+  commandExecution: (run) =>
+    runItems(run).some((item) => item.type === 'commandExecution'),
+  fileChanges: (run) =>
+    runItems(run).some((item) => item.type === 'fileChange'),
+  approvals: (run) =>
+    runItems(run).some(
+      (item) => item.type === 'approval' && item.status === 'pending'
+    ),
+  questions: (run) => runItems(run).some((item) => item.type === 'question'),
+  streaming: (run) =>
+    run.patches.some((patch) => patch.type === 'agent-item-delta-v2'),
+  interrupt: (run) =>
+    run.patches.some(
+      (patch) =>
+        patch.type === 'agent-turn-completed-v2' &&
+        patch.status === 'interrupted'
+    ),
+  telemetry: (run) =>
+    run.patches.some(
+      (patch) =>
+        patch.type === 'agent-turn-completed-v2' &&
+        patch.usage !== undefined &&
+        Object.keys(patch.usage).length > 0
+    ),
+};
+
+export const CAPABILITIES_WITHOUT_DETECTOR: readonly CapabilityName[] =
+  ALL_CAPABILITIES.filter((name) => CAPABILITY_DETECTORS[name] === undefined);
+
+// ── Lifecycle run ────────────────────────────────────────────────────────────
+
+export interface SilentDrop {
+  segment: SegmentName;
+  index: number;
+  step: FixtureFeedStep;
+}
+
+export interface ApprovalIdEvent {
+  requestId: string;
+  itemId: string;
+  phase: 'requested' | 'resolved';
+}
+
+export interface LifecycleRun {
+  adapterId: string;
+  patches: AgentPatchV2[];
+  segments: Record<SegmentName, AgentPatchV2[]>;
+  /** Turn id opened by the harness per turn-bearing segment that actually ran. */
+  turnIds: Partial<Record<TurnSegmentName, string>>;
+  expectedTerminal: Partial<Record<TurnSegmentName, TerminalStatus>>;
+  silentDrops: SilentDrop[];
+  approvalIdTimeline: ApprovalIdEvent[];
+  finalSession: AgentSessionV2;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function emptySegments(): Record<SegmentName, AgentPatchV2[]> {
+  return {
+    connect: [],
+    'simple-turn': [],
+    'interrupted-turn': [],
+    'error-turn': [],
+    'approval-flow': [],
+    teardown: [],
+  };
+}
+
+/** The turn a patch belongs to, or undefined for session-scoped patches. */
+export function patchTurnId(patch: AgentPatchV2): string | undefined {
+  switch (patch.type) {
+    case 'agent-turn-started-v2':
+      return patch.turn.id;
+    case 'agent-item-started-v2':
+    case 'agent-item-updated-v2':
+    case 'agent-item-delta-v2':
+    case 'agent-turn-completed-v2':
+      return patch.turnId;
+    case 'agent-error-v2':
+      return patch.turnId;
+    default:
+      return undefined;
+  }
+}
+
+function patchItems(patch: AgentPatchV2): AgentItemV2[] {
+  switch (patch.type) {
+    case 'agent-item-started-v2':
+    case 'agent-item-updated-v2':
+      return [patch.item];
+    case 'agent-turn-started-v2':
+      return patch.turn.items;
+    case 'agent-session-snapshot-v2':
+      return patch.session.turns.flatMap((turn) => turn.items);
+    default:
+      return [];
+  }
+}
+
+function runItems(run: LifecycleRun): AgentItemV2[] {
+  return run.patches.flatMap(patchItems);
+}
+
+function approvalItems(patches: AgentPatchV2[]): AgentApprovalItemV2[] {
+  return patches
+    .flatMap(patchItems)
+    .filter((item): item is AgentApprovalItemV2 => item.type === 'approval');
+}
+
+/** Approval items a reduced session still shows as awaiting a human. */
+export function pendingApprovalIds(session: AgentSessionV2): string[] {
+  return session.turns
+    .flatMap((turn) => turn.items)
+    .filter(
+      (item) =>
+        item.type === 'approval' &&
+        (item.status === 'pending' || item.status === 'running')
+    )
+    .map((item) => item.id);
+}
+
+function hasTerminal(patches: AgentPatchV2[], turnId: string): boolean {
+  return patches.some(
+    (patch) =>
+      patch.type === 'agent-turn-completed-v2' && patch.turnId === turnId
+  );
+}
+
+/**
+ * Renderable text only. `textIncludes` needles are a content assertion, so
+ * matching them against `JSON.stringify(item)` would let a needle be satisfied
+ * by a key name, an item id, or a raw tool-argument blob the UI never shows.
+ * This projection is the set of fields a renderer actually puts on screen.
+ */
+type RenderableFields = {
+  [K in AgentItemV2['type']]?: (
+    item: Extract<AgentItemV2, { type: K }>
+  ) => Array<string | undefined>;
+};
+
+/**
+ * `sessionBreak` and `providerExtension` are absent on purpose: neither renders
+ * free text a fixture could legitimately assert on.
+ */
+const RENDERABLE_FIELDS: RenderableFields = {
+  userMessage: (item) => [item.text, item.expandedText, item.command?.name],
+  assistantMessage: (item) => [item.text],
+  reasoning: (item) => [item.summary, item.detail],
+  plan: (item) => [item.text, ...(item.steps ?? []).map((step) => step.step)],
+  commandExecution: (item) => [
+    item.command,
+    item.output,
+    ...(item.parsedActions ?? []),
+  ],
+  fileChange: (item) => [
+    ...item.paths.flatMap((entry) => [entry.path, entry.oldPath]),
+    item.patch,
+  ],
+  mcpToolCall: (item) => [item.server, item.tool, item.progress],
+  dynamicToolCall: (item) => [item.namespace, item.tool, item.content],
+  approval: (item) => [item.description, item.target, item.detail],
+  question: (item) => [item.question],
+  compaction: (item) => [item.summary],
+  webSearch: (item) => [item.query, item.action],
+  imageView: (item) => [item.source, item.description],
+  imageGeneration: (item) => [item.prompt],
+  hookPrompt: (item) => [item.prompt, item.source],
+  errorMessage: (item) => [item.message, item.context],
+};
+
+export function renderableText(item: AgentItemV2): string {
+  const project = RENDERABLE_FIELDS[item.type] as
+    | ((value: AgentItemV2) => Array<string | undefined>)
+    | undefined;
+  return (project?.(item) ?? [])
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n');
+}
+
+class SegmentTimeoutError extends Error {}
+
+/**
+ * Perform one operator action against the adapter. Operator moves are
+ * choreography, not provider grammar: every adapter answers a question the same
+ * way, so the harness drives them rather than each rig inventing a marker.
+ */
+async function runOperatorAction(
+  adapter: ProtocolAdapterV2,
+  step: Extract<FixtureFeedStep, { kind: 'operator' }>
+): Promise<void> {
+  if (step.action === 'respondToInput') {
+    await adapter.respondToInput({
+      requestId: step.requestId,
+      answers: step.answers,
+    });
+    return;
+  }
+  throw new Error(
+    `unknown conformance operator action: ${JSON.stringify(step)}`
+  );
+}
+
+/**
+ * Drive one fixture through the full lifecycle. Every wait is bounded and
+ * `disconnect()`/`dispose()` are guaranteed, so a broken adapter fails the
+ * suite instead of hanging it.
+ */
+export async function runLifecycle(
+  fixture: AdapterConformanceFixture
+): Promise<LifecycleRun> {
+  const rig: ConformanceRig = await fixture.createRig();
+  const adapter = rig.adapter;
+  const patches: AgentPatchV2[] = [];
+  const segments = emptySegments();
+  const silentDrops: SilentDrop[] = [];
+  const turnIds: LifecycleRun['turnIds'] = {};
+  const expectedTerminal: LifecycleRun['expectedTerminal'] = {};
+
+  const unsubscribe = adapter.onPatch((patch) => {
+    patches.push(patch);
+  });
+
+  const settle = async (): Promise<void> => {
+    if (rig.settle) {
+      await rig.settle();
+      return;
+    }
+    let stable = 0;
+    let last = patches.length;
+    const deadline = Date.now() + QUIESCENCE_BUDGET_MS;
+    while (stable < QUIESCENCE_POLLS && Date.now() < deadline) {
+      await sleep(1);
+      if (patches.length === last) stable += 1;
+      else {
+        stable = 0;
+        last = patches.length;
+      }
+    }
+  };
+
+  const waitFor = async (
+    predicate: () => boolean,
+    label: string,
+    budgetMs: number = WAIT_TIMEOUT_MS
+  ): Promise<void> => {
+    const deadline = Date.now() + budgetMs;
+    while (Date.now() < deadline) {
+      if (predicate()) return;
+      await sleep(1);
+    }
+    throw new SegmentTimeoutError(
+      `[${fixture.adapterId}] timed out after ${budgetMs}ms waiting for ${label}`
+    );
+  };
+
+  const guard = async <T>(
+    promise: Promise<T>,
+    label: string,
+    budgetMs: number = WAIT_TIMEOUT_MS
+  ): Promise<T> => {
+    let timer: NodeJS.Timeout | undefined;
+    const bomb = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(
+            new SegmentTimeoutError(
+              `[${fixture.adapterId}] ${label} did not settle within ${budgetMs}ms`
+            )
+          ),
+        budgetMs
+      );
+    });
+    try {
+      return await Promise.race([promise, bomb]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+
+  const feedTracked = async (
+    segment: SegmentName,
+    index: number,
+    step: FixtureFeedStep
+  ): Promise<void> => {
+    if (step.kind === 'operator') {
+      // Not provider grammar: the harness performs the operator move itself and
+      // it never enters the silent-drop ledger.
+      await guard(
+        runOperatorAction(adapter, step),
+        `operator ${step.action}()`
+      );
+      await settle();
+      return;
+    }
+    const before = patches.length;
+    await rig.feed(step);
+    await settle();
+    if (patches.length !== before) return;
+    if (step.kind === 'close') return;
+    if (fixture.allowedSilentEvents?.some((allowed) => allowed.match(step)))
+      return;
+    silentDrops.push({ segment, index, step });
+  };
+
+  /**
+   * Invariant (a) is the one gap that can abort the whole run: an adapter that
+   * never ends a turn stalls every later segment. When the fixture cites an
+   * `a-terminal` gap the harness keeps going, so the remaining invariants stay
+   * assessable instead of collapsing into one un-diagnosable timeout. Any other
+   * adapter still fails here, loudly.
+   */
+  const terminalGapped = fixture.knownGaps?.['a-terminal'] !== undefined;
+  const turnBudgetMs = terminalGapped
+    ? GAPPED_WAIT_TIMEOUT_MS
+    : WAIT_TIMEOUT_MS;
+
+  const awaitTerminal = async (
+    segment: TurnSegmentName,
+    turnId: string
+  ): Promise<void> => {
+    try {
+      await waitFor(
+        () => hasTerminal(patches, turnId),
+        `${segment} terminal turn patch (${turnId})`,
+        turnBudgetMs
+      );
+    } catch (err) {
+      if (!terminalGapped) throw err;
+    }
+  };
+
+  /** Same tolerance for the promises a never-ending turn can strand. */
+  const guardTurnPromise = async (
+    promise: Promise<unknown>,
+    label: string
+  ): Promise<void> => {
+    try {
+      await guard(promise, label, turnBudgetMs);
+    } catch (err) {
+      if (!terminalGapped) throw err;
+    }
+  };
+
+  const runTurnSegment = async (
+    segment: TurnSegmentName,
+    script: TurnScript
+  ): Promise<void> => {
+    const turnId = TURN_SEGMENTS[segment];
+    const start = patches.length;
+    turnIds[segment] = turnId;
+    expectedTerminal[segment] =
+      script.expect?.terminalStatus ?? DEFAULT_TERMINAL[segment];
+
+    const send = adapter.sendMessage({
+      turnId,
+      content: script.prompt ?? `conformance ${segment} turn`,
+    });
+    void send.catch(() => undefined);
+
+    const cut = Math.min(
+      script.interruptAfter ?? script.steps.length,
+      script.steps.length
+    );
+    for (let i = 0; i < cut; i += 1) {
+      await feedTracked(segment, i, script.steps[i]!);
+    }
+
+    let interrupted: Promise<void> | undefined;
+    if (script.interruptAfter !== undefined) {
+      interrupted = adapter.interrupt({ turnId });
+      void interrupted.catch(() => undefined);
+      await settle();
+    }
+
+    for (let i = cut; i < script.steps.length; i += 1) {
+      await feedTracked(segment, i, script.steps[i]!);
+    }
+
+    await awaitTerminal(segment, turnId);
+    if (interrupted)
+      await guardTurnPromise(interrupted, `${segment} interrupt()`);
+    await guardTurnPromise(send, `${segment} sendMessage()`);
+    await settle();
+    segments[segment] = patches.slice(start);
+  };
+
+  const runApprovalSegment = async (script: ApprovalScript): Promise<void> => {
+    const segment = 'approval-flow' as const;
+    const turnId = TURN_SEGMENTS[segment];
+    const start = patches.length;
+    turnIds[segment] = turnId;
+    expectedTerminal[segment] =
+      script.expect?.terminalStatus ?? DEFAULT_TERMINAL[segment];
+
+    const send = adapter.sendMessage({
+      turnId,
+      content: script.prompt ?? `conformance ${segment} turn`,
+    });
+    void send.catch(() => undefined);
+
+    for (let i = 0; i < script.request.length; i += 1) {
+      await feedTracked(segment, i, script.request[i]!);
+    }
+
+    const pendingOf = (): AgentApprovalItemV2 | undefined =>
+      approvalItems(patches.slice(start)).find(
+        (item) => item.status === 'pending'
+      );
+    await waitFor(() => pendingOf() !== undefined, 'pending approval item');
+    const pending = pendingOf()!;
+
+    await guard(
+      adapter.respondToApproval({
+        requestId: pending.requestId,
+        decision: script.decision,
+      }),
+      'respondToApproval()'
+    );
+    await settle();
+
+    for (let i = 0; i < script.resolution.length; i += 1) {
+      await feedTracked(
+        segment,
+        script.request.length + i,
+        script.resolution[i]!
+      );
+    }
+
+    await awaitTerminal(segment, turnId);
+    await guardTurnPromise(send, `${segment} sendMessage()`);
+    await settle();
+    segments[segment] = patches.slice(start);
+  };
+
+  try {
+    // 1. connect
+    const connectStart = patches.length;
+    const connecting = adapter.connect(rig.config);
+    void connecting.catch(() => undefined);
+    for (let i = 0; i < fixture.connect.steps.length; i += 1) {
+      await feedTracked('connect', i, fixture.connect.steps[i]!);
+    }
+    await guard(connecting, 'connect()');
+    await settle();
+    segments.connect = patches.slice(connectStart);
+    expect(
+      adapter.status,
+      `[${fixture.adapterId}] connect() must leave the adapter connected`
+    ).toBe('connected');
+
+    // 2-4. turn segments
+    await runTurnSegment('simple-turn', fixture.simpleTurn);
+    await runTurnSegment('interrupted-turn', fixture.interruptedTurn);
+    if (!('exempt' in fixture.errorTurn)) {
+      await runTurnSegment('error-turn', fixture.errorTurn);
+    }
+
+    // 5. approval flow
+    if (fixture.approvalFlow) await runApprovalSegment(fixture.approvalFlow);
+
+    // 6. teardown
+    const teardownStart = patches.length;
+    const teardownSteps = fixture.teardown?.steps ?? [];
+    for (let i = 0; i < teardownSteps.length; i += 1) {
+      await feedTracked('teardown', i, teardownSteps[i]!);
+    }
+    await guard(adapter.disconnect(), 'disconnect()');
+    await settle();
+    segments.teardown = patches.slice(teardownStart);
+  } finally {
+    // A failed segment must not leak a live adapter into the next run: a
+    // scripted transcript that times out mid-turn still owes teardown.
+    if (adapter.status !== 'disconnected') {
+      await adapter.disconnect().catch(() => undefined);
+    }
+    unsubscribe();
+    await rig.dispose();
+  }
+
+  return {
+    adapterId: fixture.adapterId,
+    patches,
+    segments,
+    turnIds,
+    expectedTerminal,
+    silentDrops,
+    approvalIdTimeline: approvalItems(patches).map((item) => ({
+      requestId: item.requestId,
+      itemId: item.id,
+      phase: item.status === 'pending' ? 'requested' : 'resolved',
+    })),
+    finalSession: reducePatches(patches, rig, adapter),
+  };
+}
+
+function reducePatches(
+  patches: AgentPatchV2[],
+  rig: ConformanceRig,
+  adapter: ProtocolAdapterV2
+): AgentSessionV2 {
+  let session = emptyAgentSessionV2({
+    id: rig.config.sessionId,
+    provider: adapter.agentType,
+    cwd: rig.config.cwd,
+    capabilities: adapter.capabilities,
+  });
+  for (const patch of patches) session = applyAgentPatchV2(session, patch);
+  return session;
+}
+
+/**
+ * The teardown half of invariant (b): abandon a live approval and disconnect.
+ * Returns the session reduced from everything the adapter emitted.
+ */
+export async function runAbandonedApprovalProbe(
+  fixture: AdapterConformanceFixture
+): Promise<AgentSessionV2> {
+  const script = fixture.approvalFlow;
+  if (!script) throw new Error('runAbandonedApprovalProbe needs approvalFlow');
+  const rig = await fixture.createRig();
+  const adapter = rig.adapter;
+  const patches: AgentPatchV2[] = [];
+  adapter.onPatch((patch) => patches.push(patch));
+
+  const settle = async (): Promise<void> => {
+    if (rig.settle) return rig.settle();
+    let stable = 0;
+    let last = patches.length;
+    const deadline = Date.now() + QUIESCENCE_BUDGET_MS;
+    while (stable < QUIESCENCE_POLLS && Date.now() < deadline) {
+      await sleep(1);
+      if (patches.length === last) stable += 1;
+      else {
+        stable = 0;
+        last = patches.length;
+      }
+    }
+  };
+
+  try {
+    const connecting = adapter.connect(rig.config);
+    void connecting.catch(() => undefined);
+    for (const step of fixture.connect.steps) {
+      await rig.feed(step);
+      await settle();
+    }
+    await connecting;
+
+    const send = adapter.sendMessage({
+      turnId: 'conf-approval-abandoned',
+      content: script.prompt ?? 'conformance approval-flow turn',
+    });
+    void send.catch(() => undefined);
+    for (const step of script.request) {
+      await rig.feed(step);
+      await settle();
+    }
+
+    // The probe is only meaningful if there IS a live approval to abandon. An
+    // adapter that never surfaces the pending item would otherwise sail through
+    // the "nothing left pending" assertion vacuously, so a missing approval is
+    // a hard failure of the probe rather than a silent skip.
+    const deadline = Date.now() + WAIT_TIMEOUT_MS;
+    let surfaced = false;
+    while (Date.now() < deadline) {
+      if (approvalItems(patches).some((item) => item.status === 'pending')) {
+        surfaced = true;
+        break;
+      }
+      await sleep(1);
+    }
+    if (!surfaced) {
+      throw new Error(
+        `[${fixture.adapterId}] abandoned-approval probe: the scripted approvalFlow surfaced no pending approval item within ${WAIT_TIMEOUT_MS}ms, so there is nothing to abandon`
+      );
+    }
+
+    await adapter.disconnect();
+    await settle();
+    await send.catch(() => undefined);
+  } finally {
+    if (adapter.status !== 'disconnected') {
+      await adapter.disconnect().catch(() => undefined);
+    }
+    await rig.dispose();
+  }
+
+  return reducePatches(patches, rig, adapter);
+}
+
+// ── Replay normalization ─────────────────────────────────────────────────────
+
+/** Wall-clock fields an adapter legitimately re-derives on every run. */
+const VOLATILE_KEYS = new Set([
+  'timestamp',
+  'startedAt',
+  'completedAt',
+  'durationMs',
+]);
+const VOLATILE_PLACEHOLDER = '<volatile>';
+
+function blankPath(root: unknown, path: string): void {
+  const segments = path.split('.');
+  const last = segments.pop();
+  if (!last) return;
+  let cursors: unknown[] = [root];
+  for (const segment of segments) {
+    cursors = cursors.flatMap((cursor) => {
+      if (Array.isArray(cursor)) return cursor.flatMap((entry) => [entry]);
+      if (cursor && typeof cursor === 'object')
+        return [(cursor as Record<string, unknown>)[segment]];
+      return [];
+    });
+  }
+  for (const cursor of cursors) {
+    if (Array.isArray(cursor)) {
+      for (const entry of cursor) {
+        if (entry && typeof entry === 'object')
+          (entry as Record<string, unknown>)[last] = VOLATILE_PLACEHOLDER;
+      }
+      continue;
+    }
+    if (cursor && typeof cursor === 'object')
+      (cursor as Record<string, unknown>)[last] = VOLATILE_PLACEHOLDER;
+  }
+}
+
+/**
+ * Blank wall-clock only. IDs are deliberately NOT normalized: id stability is
+ * part of determinism, so rigs must pin pids, provider session ids, and any
+ * scripted native ids.
+ */
+export function normalizePatchForReplay(
+  patch: AgentPatchV2,
+  volatilePaths: string[] = []
+): unknown {
+  const clone: unknown = structuredClone(patch);
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const entry of node) walk(entry);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const record = node as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      if (VOLATILE_KEYS.has(key)) record[key] = VOLATILE_PLACEHOLDER;
+      else walk(record[key]);
+    }
+  };
+  walk(clone);
+  for (const path of volatilePaths) blankPath(clone, path);
+  return clone;
+}
+
+// ── Capability reconciliation ────────────────────────────────────────────────
+
+export type CapabilityVerdict = 'ok' | 'drift' | 'unknown';
+
+export interface CapabilityRow {
+  capability: CapabilityName;
+  declared: boolean;
+  attempted: boolean;
+  manifested: boolean;
+  verdict: CapabilityVerdict;
+  note: string;
+}
+
+export interface CapabilityReport {
+  rows: CapabilityRow[];
+  drift: CapabilityRow[];
+  /** Fixture-authoring mistakes: fake attestations, missing approval scripts. */
+  fixtureErrors: string[];
+  table: string;
+}
+
+function builtInAttempts(
+  fixture: AdapterConformanceFixture
+): Set<CapabilityName> {
+  const attempts = new Set<CapabilityName>(['text', 'interrupt']);
+  if (fixture.approvalFlow) attempts.add('approvals');
+  return attempts;
+}
+
+/**
+ * DRIFT is only ever claimed from evidence: a capability the transcript SAW
+ * working while the registry declares it false, or one the transcript actively
+ * exercised while the registry declares it true and nothing manifested. A
+ * capability the fixture never drove is UNKNOWN and never fails.
+ */
+export function reconcileCapabilities(input: {
+  declared: AgentCapabilitySetV2;
+  run: LifecycleRun;
+  fixture: AdapterConformanceFixture;
+}): CapabilityReport {
+  const { declared, run, fixture } = input;
+  const fixtureErrors: string[] = [];
+  const builtIns = builtInAttempts(fixture);
+
+  const attempted = new Set<CapabilityName>(builtIns);
+  for (const capability of fixture.exercised ?? []) {
+    if (CAPABILITY_DETECTORS[capability as CapabilityName] === undefined) {
+      fixtureErrors.push(
+        `exercised['${capability}'] has no conformance detector — a fixture may not attest a capability the harness cannot observe`
+      );
+      continue;
+    }
+    attempted.add(capability as CapabilityName);
+  }
+
+  const unexercisable = new Map<CapabilityName, string>();
+  for (const entry of fixture.unexercisable ?? []) {
+    const capability = entry.capability as CapabilityName;
+    if (builtIns.has(capability)) {
+      fixtureErrors.push(
+        `unexercisable['${capability}'] is a built-in the harness always exercises — remove the entry or fix the transcript`
+      );
+      continue;
+    }
+    unexercisable.set(capability, entry.reason);
+  }
+
+  if (declared.approvals === true && !fixture.approvalFlow) {
+    if (!unexercisable.has('approvals')) {
+      fixtureErrors.push(
+        'registry declares approvals:true but the fixture has no approvalFlow and no unexercisable entry for it'
+      );
+    }
+  }
+
+  const rows: CapabilityRow[] = ALL_CAPABILITIES.map((capability) => {
+    const detector = CAPABILITY_DETECTORS[capability];
+    const isDeclared = declared[capability] === true;
+    const isAttempted = attempted.has(capability);
+    const manifested = detector ? detector(run) : false;
+    let verdict: CapabilityVerdict;
+    let note = '';
+    if (manifested && !isDeclared) {
+      verdict = 'drift';
+      note = 'observed working but declared false';
+    } else if (manifested) {
+      verdict = 'ok';
+    } else if (!isAttempted) {
+      verdict = 'unknown';
+      note = detector
+        ? (unexercisable.get(capability) ?? 'not exercised by this fixture')
+        : 'no detector in v1';
+    } else if (isDeclared) {
+      verdict = 'drift';
+      note = 'declared true and exercised, but never manifested';
+    } else {
+      verdict = 'ok';
+      note = 'honest false';
+    }
+    return {
+      capability,
+      declared: isDeclared,
+      attempted: isAttempted,
+      manifested,
+      verdict,
+      note,
+    };
+  });
+
+  // Fixture silence is not free. A capability the registry declares true, that
+  // the harness CAN observe, must either be driven by the transcript or carry a
+  // written `unexercisable` waiver — otherwise deleting a transcript step
+  // quietly downgrades a real row to UNKNOWN and the floor stops biting there.
+  for (const row of rows) {
+    if (!row.declared || row.attempted || row.manifested) continue;
+    if (CAPABILITY_DETECTORS[row.capability] === undefined) continue;
+    if (unexercisable.has(row.capability)) continue;
+    // Already reported above with a more specific message.
+    if (row.capability === 'approvals' && !fixture.approvalFlow) continue;
+    fixtureErrors.push(
+      `declared-true capability '${row.capability}' is neither exercised nor waived — add it to \`exercised\` (and drive it in the transcript) or write an \`unexercisable\` entry saying why this fixture cannot`
+    );
+  }
+
+  return {
+    rows,
+    drift: rows.filter((row) => row.verdict === 'drift'),
+    fixtureErrors,
+    table: formatCapabilityTable(run.adapterId, rows),
+  };
+}
+
+function formatCapabilityTable(
+  adapterId: string,
+  rows: CapabilityRow[]
+): string {
+  const header = `capability reconciliation — ${adapterId}`;
+  const body = rows.map((row) =>
+    [
+      row.capability.padEnd(17),
+      `declared=${String(row.declared).padEnd(5)}`,
+      `attempted=${String(row.attempted).padEnd(5)}`,
+      `manifested=${String(row.manifested).padEnd(5)}`,
+      row.verdict.toUpperCase().padEnd(7),
+      row.note,
+    ].join(' ')
+  );
+  return [header, ...body].join('\n');
+}
+
+// ── Suite registration ───────────────────────────────────────────────────────
+
+function registeredAdapter(adapterId: string): ProtocolAdapterV2 {
+  const factory = (v2Adapters as Record<string, () => ProtocolAdapterV2>)[
+    adapterId
+  ];
+  if (!factory) throw new Error(`no registered adapter for '${adapterId}'`);
+  return factory();
+}
+
+/** A skip must cite a real issue and say why, on the record. */
+const GAP_ISSUE_PATTERN = /^#\d+$/;
+/** Same floor the `errorTurn.exempt` escape hatch already carries. */
+const MIN_JUSTIFICATION_LENGTH = 10;
+
+export function describeMalformedGap(
+  id: InvariantId,
+  gap: { issue: string; reason: string; capabilities?: readonly string[] }
+): string | undefined {
+  if (!GAP_ISSUE_PATTERN.test(gap.issue)) {
+    return `knownGaps['${id}'].issue must be a '#<number>' citation, got ${JSON.stringify(gap.issue)}`;
+  }
+  if (gap.reason.trim().length <= MIN_JUSTIFICATION_LENGTH) {
+    return `knownGaps['${id}'].reason needs a written justification (>${MIN_JUSTIFICATION_LENGTH} chars), got ${JSON.stringify(gap.reason)}`;
+  }
+  if (gap.capabilities !== undefined && id !== 'e-capability-drift') {
+    return `knownGaps['${id}'].capabilities only narrows 'e-capability-drift'`;
+  }
+  if (gap.capabilities?.length === 0) {
+    return `knownGaps['${id}'].capabilities is empty — drop the field to skip the whole invariant, or name the drifting rows`;
+  }
+  return undefined;
+}
+
+function describeDrop(drop: SilentDrop): string {
+  const label =
+    'label' in drop.step && drop.step.label ? ` (${drop.step.label})` : '';
+  const body =
+    drop.step.kind === 'native'
+      ? JSON.stringify(drop.step.event)
+      : JSON.stringify(drop.step);
+  return `${drop.segment}[${drop.index}]${label}: ${body}`;
+}
+
+/**
+ * Register the conformance floor for one adapter. Every `it` here is generic —
+ * a fixture contributes data and a rig, never assertions.
+ */
+export function describeAdapterConformance(
+  adapterId: string,
+  fixture: AdapterConformanceFixture
+): void {
+  let run: LifecycleRun | undefined;
+  let runError: unknown;
+
+  beforeAll(async () => {
+    try {
+      run = await runLifecycle(fixture);
+    } catch (err) {
+      runError = err;
+    }
+  }, LIFECYCLE_TIMEOUT_MS);
+
+  const requireRun = (): LifecycleRun => {
+    if (runError) throw runError;
+    if (!run)
+      throw new Error(`[${adapterId}] lifecycle run did not produce a result`);
+    return run;
+  };
+
+  const invariant = (
+    id: InvariantId,
+    name: string,
+    fn: () => Promise<void> | void
+  ): void => {
+    const gap = fixture.knownGaps?.[id];
+    if (gap) {
+      // A skip is only honest if it cites something a reader can go read. An
+      // unparseable citation buys a FAILING test, not a green skip.
+      const malformed = describeMalformedGap(id, gap);
+      if (malformed) {
+        it(`${name} [invalid known gap]`, () => {
+          expect.fail(`[${adapterId}] ${malformed}`);
+        });
+        return;
+      }
+      it.skip(`${name} [known gap ${gap.issue}: ${gap.reason}]`, fn);
+      return;
+    }
+    it(name, fn, LIFECYCLE_TIMEOUT_MS);
+  };
+
+  it('fixture adapterId matches its registration', () => {
+    expect(fixture.adapterId).toBe(adapterId);
+  });
+
+  it('every known gap cites a real issue and a written reason', () => {
+    const malformed = Object.entries(fixture.knownGaps ?? {}).flatMap(
+      ([id, gap]) => {
+        const problem = describeMalformedGap(id as InvariantId, gap);
+        return problem ? [problem] : [];
+      }
+    );
+    expect(
+      malformed,
+      `[${adapterId}] knownGaps entries must cite an issue as '#<number>' and carry a written reason`
+    ).toEqual([]);
+  });
+
+  it(
+    'registry parity: rig adapter is a faithful twin of the registered factory',
+    async () => {
+      const registered = registeredAdapter(adapterId);
+      const rig = await fixture.createRig();
+      try {
+        expect(rig.adapter.agentType).toBe(registered.agentType);
+        expect(
+          rig.adapter.capabilities,
+          `[${adapterId}] the rig's seam-injected twin must declare the registry's exact capability set`
+        ).toEqual(registered.capabilities);
+      } finally {
+        await rig.dispose();
+      }
+    },
+    LIFECYCLE_TIMEOUT_MS
+  );
+
+  it('scripted segment expectations hold', () => {
+    const result = requireRun();
+    const expectations: Array<[TurnSegmentName, TurnScript | ApprovalScript]> =
+      [
+        ['simple-turn', fixture.simpleTurn],
+        ['interrupted-turn', fixture.interruptedTurn],
+      ];
+    if (!('exempt' in fixture.errorTurn))
+      expectations.push(['error-turn', fixture.errorTurn]);
+    if (fixture.approvalFlow)
+      expectations.push(['approval-flow', fixture.approvalFlow]);
+
+    for (const [segment, script] of expectations) {
+      const expectation = script.expect;
+      if (!expectation) continue;
+      const patches = result.segments[segment];
+      for (const patchType of expectation.requiredPatchTypes ?? []) {
+        expect(
+          patches.map((patch) => patch.type),
+          `[${adapterId}/${segment}] required patch type ${patchType} never appeared`
+        ).toContain(patchType);
+      }
+
+      // The declared terminal STATUS is asserted here as well as in invariant
+      // (a), because an `a-terminal` gap is whole-invariant: without this the
+      // status floor would vanish for every segment of a fixture whose gap is
+      // really about one segment (hermes double-terminals only its error turn).
+      if (expectation.terminalStatus) {
+        const completions = patches.filter(
+          (patch) => patch.type === 'agent-turn-completed-v2'
+        );
+        if (completions.length === 0) {
+          expect(
+            fixture.knownGaps?.['a-terminal'],
+            `[${adapterId}/${segment}] no agent-turn-completed-v2 in the segment and no cited a-terminal known gap`
+          ).toBeDefined();
+        } else {
+          const terminal = completions[completions.length - 1]!;
+          expect(
+            terminal.type === 'agent-turn-completed-v2' && terminal.status,
+            `[${adapterId}/${segment}] terminal status`
+          ).toBe(expectation.terminalStatus);
+        }
+      }
+
+      if (!expectation.textIncludes?.length) continue;
+      // Renderable text only — see `renderableText`. Matching raw JSON would
+      // let a needle pass on a key name, an id, or a tool-argument blob.
+      const text = patches.flatMap(patchItems).map(renderableText).join('\n');
+      for (const needle of expectation.textIncludes) {
+        expect(
+          text.includes(needle),
+          `[${adapterId}/${segment}] expected rendered item text to include ${JSON.stringify(needle)}`
+        ).toBe(true);
+      }
+    }
+  });
+
+  invariant(
+    'a-terminal',
+    '(a) every turn ends with exactly one terminal turn-completed patch',
+    () => {
+      const result = requireRun();
+      const segmentNames = Object.keys(result.turnIds) as TurnSegmentName[];
+      expect(
+        segmentNames.length,
+        `[${adapterId}] no turn segments ran`
+      ).toBeGreaterThan(0);
+      for (const segment of segmentNames) {
+        const turnId = result.turnIds[segment]!;
+        const completions = result.patches.filter(
+          (patch) =>
+            patch.type === 'agent-turn-completed-v2' && patch.turnId === turnId
+        );
+        expect(
+          completions.length,
+          `[${adapterId}/${segment}] expected exactly one agent-turn-completed-v2 for ${turnId}`
+        ).toBe(1);
+        const terminal = completions[0]!;
+        const carrying = result.patches.filter(
+          (patch) => patchTurnId(patch) === turnId
+        );
+        expect(
+          carrying[carrying.length - 1],
+          `[${adapterId}/${segment}] a patch for ${turnId} was emitted after its terminal patch`
+        ).toBe(terminal);
+        expect(
+          terminal.type === 'agent-turn-completed-v2' && terminal.status,
+          `[${adapterId}/${segment}] terminal status`
+        ).toBe(result.expectedTerminal[segment]);
+      }
+      if ('exempt' in fixture.errorTurn) {
+        expect(
+          fixture.errorTurn.exempt.length,
+          `[${adapterId}] errorTurn exemption needs a written justification`
+        ).toBeGreaterThan(10);
+      } else {
+        const errorTurnId = result.turnIds['error-turn']!;
+        const failedByPatch = result.patches.some(
+          (patch) =>
+            patch.type === 'agent-error-v2' && patch.turnId === errorTurnId
+        );
+        const failedByField = result.patches.some(
+          (patch) =>
+            patch.type === 'agent-turn-completed-v2' &&
+            patch.turnId === errorTurnId &&
+            typeof patch.error === 'string' &&
+            patch.error.length > 0
+        );
+        expect(
+          failedByPatch || failedByField,
+          `[${adapterId}] a failed turn must carry an agent-error-v2 patch or an error on its completion`
+        ).toBe(true);
+      }
+    }
+  );
+
+  invariant(
+    'b-approval-ids',
+    '(b) approval ids stay stable across the approval lifecycle',
+    () => {
+      const result = requireRun();
+      const byRequest = new Map<string, Set<string>>();
+      for (const event of result.approvalIdTimeline) {
+        const ids = byRequest.get(event.requestId) ?? new Set<string>();
+        ids.add(event.itemId);
+        byRequest.set(event.requestId, ids);
+      }
+      for (const [requestId, itemIds] of byRequest) {
+        expect(
+          [...itemIds],
+          `[${adapterId}] approval ${requestId} changed item id mid-lifecycle`
+        ).toHaveLength(1);
+      }
+      if (fixture.approvalFlow) {
+        expect(
+          byRequest.size,
+          `[${adapterId}] approvalFlow surfaced no approval item`
+        ).toBeGreaterThan(0);
+        expect(
+          result.approvalIdTimeline.some((event) => event.phase === 'resolved'),
+          `[${adapterId}] the approval never reached a resolved state`
+        ).toBe(true);
+      }
+    }
+  );
+
+  invariant(
+    'b-teardown',
+    '(b) no approval is left pending after teardown',
+    () => {
+      const result = requireRun();
+      expect(
+        pendingApprovalIds(result.finalSession),
+        `[${adapterId}] approval item still pending in the reduced session after teardown`
+      ).toEqual([]);
+      expect(
+        result.finalSession.live.activeRequestIds,
+        `[${adapterId}] live.activeRequestIds not drained after teardown`
+      ).toEqual([]);
+    }
+  );
+
+  // The harder half: tear down while an approval is still outstanding. A
+  // fixture without an approvalFlow has nothing to abandon.
+  if (fixture.approvalFlow) {
+    invariant(
+      'b-abandoned-approval',
+      '(b) disconnecting on a live approval resolves it',
+      async () => {
+        requireRun();
+        const abandoned = await runAbandonedApprovalProbe(fixture);
+        expect(
+          pendingApprovalIds(abandoned),
+          `[${adapterId}] disconnecting on a live approval left it pending`
+        ).toEqual([]);
+        expect(
+          abandoned.live.activeRequestIds,
+          `[${adapterId}] disconnecting on a live approval left live.activeRequestIds populated`
+        ).toEqual([]);
+      }
+    );
+  }
+
+  invariant(
+    'c-no-silent-drop',
+    '(c) no scripted native event is silently dropped',
+    () => {
+      const result = requireRun();
+      expect(
+        result.silentDrops.map(describeDrop),
+        `[${adapterId}] these native events produced no patch and no allowedSilentEvents entry covers them`
+      ).toEqual([]);
+    }
+  );
+
+  invariant(
+    'd-determinism',
+    '(d) replaying the transcript yields an identical patch sequence',
+    async () => {
+      const first = requireRun();
+      const second = await runLifecycle(fixture);
+      const normalize = (patches: AgentPatchV2[]): unknown[] =>
+        patches.map((patch) =>
+          normalizePatchForReplay(patch, fixture.volatileJsonPaths ?? [])
+        );
+      expect(
+        second.patches.map((patch) => patch.type),
+        `[${adapterId}] replay produced a different patch-type sequence`
+      ).toEqual(first.patches.map((patch) => patch.type));
+      expect(
+        normalize(second.patches),
+        `[${adapterId}] replay produced different patch payloads`
+      ).toEqual(normalize(first.patches));
+    }
+  );
+
+  // Invariant (e) is the one gap that can be scoped: a `capabilities` list on
+  // the gap excludes only the cited rows, so `fixtureErrors` and the other
+  // rows keep biting instead of the whole reconciliation table going dark.
+  const capabilityGap = fixture.knownGaps?.['e-capability-drift'];
+  const gappedCapabilities = new Set<string>(capabilityGap?.capabilities ?? []);
+  const capabilityInvariantName =
+    gappedCapabilities.size > 0 && capabilityGap
+      ? `(e) declared capabilities reconcile with observed behavior [known gap ${capabilityGap.issue} scoped to ${[...gappedCapabilities].join(', ')}]`
+      : '(e) declared capabilities reconcile with observed behavior';
+
+  const reconcile = (): void => {
+    const result = requireRun();
+    const declared = registeredAdapter(adapterId).capabilities;
+    const report = reconcileCapabilities({ declared, run: result, fixture });
+    expect(
+      report.fixtureErrors,
+      `[${adapterId}] fixture authoring errors`
+    ).toEqual([]);
+    const drift = report.drift.filter(
+      (row) => !gappedCapabilities.has(row.capability)
+    );
+    expect(
+      drift.map((row) => `${row.capability}: ${row.note}`),
+      `[${adapterId}] capability drift\n\n${report.table}\n`
+    ).toEqual([]);
+    // A scoped gap that no longer drifts is a stale gap: delete the entry.
+    for (const capability of gappedCapabilities) {
+      expect(
+        report.drift.some((row) => row.capability === capability),
+        `[${adapterId}] knownGaps['e-capability-drift'].capabilities still cites '${capability}', but it no longer drifts — remove it`
+      ).toBe(true);
+    }
+  };
+
+  if (gappedCapabilities.size > 0) {
+    it(capabilityInvariantName, reconcile, LIFECYCLE_TIMEOUT_MS);
+  } else {
+    invariant('e-capability-drift', capabilityInvariantName, reconcile);
+  }
+}

--- a/test/server/protocol-adapters/conformance/stubs/codex.stub.ts
+++ b/test/server/protocol-adapters/conformance/stubs/codex.stub.ts
@@ -1,0 +1,142 @@
+/**
+ * Offline transport double for the Codex app-server JSON-RPC client.
+ *
+ * `CodexNativeProtocolAdapter` takes a `CodexClientFactory` in its constructor,
+ * so the conformance rig injects this stub instead of spawning
+ * `codex app-server`. The stub is a faithful copy of the seam already used by
+ * `codex-native-adapter.test.ts` (`StubCodexClient` / `makeStubFactory`),
+ * lifted here so the conformance fixture and the deep tests drive the adapter
+ * through exactly the same door.
+ *
+ * Everything here is Codex-local: the JSON-RPC call/notification/server-request
+ * vocabulary is a provider quirk and never leaks into the shared harness.
+ */
+import { EventEmitter } from 'node:events';
+import type {
+  CodexAppServerClient,
+  CodexAppServerClientOptions,
+  CodexNotification,
+  CodexServerRequest,
+} from '../../../../../server/codex-app-server-client.js';
+import type { CodexClientFactory } from '../../../../../server/protocol-adapters/codex-native-adapter.js';
+
+/** One outbound RPC the adapter made, in call order. */
+export interface StubCodexCall {
+  method: string;
+  params: unknown;
+}
+
+/**
+ * Stub for `CodexAppServerClient`. `feedNotification` / `feedRequest` are the
+ * inbound half (what the app-server would push at us); `calls` is the outbound
+ * half (what the adapter asked the app-server to do), including the
+ * `__respond:<id>` / `__error:<id>` pseudo-entries for server-request replies.
+ */
+export class StubCodexClient extends EventEmitter {
+  readonly calls: StubCodexCall[] = [];
+  /** Pre-seeded results per RPC method. An `Error` value makes the call reject. */
+  readonly serverResponses = new Map<string, unknown>();
+  stopped = false;
+
+  async start(): Promise<void> {
+    // The real client performs the initialize handshake here; nothing to do.
+  }
+
+  async call<T = unknown>(method: string, params?: unknown): Promise<T> {
+    this.calls.push({ method, params: params ?? null });
+    if (this.serverResponses.has(method)) {
+      const response = this.serverResponses.get(method);
+      if (response instanceof Error) throw response;
+      return response as T;
+    }
+    return {} as T;
+  }
+
+  respondToServerRequest(id: number | string, result: unknown): void {
+    this.calls.push({ method: `__respond:${String(id)}`, params: result });
+  }
+
+  respondToServerRequestError(
+    id: number | string,
+    code: number,
+    message: string
+  ): void {
+    this.calls.push({
+      method: `__error:${String(id)}`,
+      params: { code, message },
+    });
+  }
+
+  async stop(_signal?: string): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.emit('close', 0);
+  }
+
+  // ── Inbound feed helpers ───────────────────────────────────────────────
+
+  /** Push a native `notification` frame (`turn/*`, `item/*`, `thread/*`). */
+  feedNotification(method: string, params?: unknown): void {
+    const notification: CodexNotification = { method, params };
+    this.emit('notification', notification);
+  }
+
+  /** Push a native server-initiated `request` frame (approvals, elicitation). */
+  feedRequest(id: number | string, method: string, params?: unknown): void {
+    const request: CodexServerRequest = { id, method, params };
+    this.emit('request', request);
+  }
+}
+
+export interface CodexClientStubHarness {
+  factory: CodexClientFactory;
+  /** The stub the adapter is currently wired to. Re-read after any reconnect. */
+  readonly client: StubCodexClient;
+  /** Every stub handed out, oldest first. */
+  readonly clients: readonly StubCodexClient[];
+  readonly lastOptions: CodexAppServerClientOptions | undefined;
+}
+
+/**
+ * Build a factory that hands the adapter a stub client. A second connect
+ * generation (resume / reconnect) gets a fresh stub carrying the same seeded
+ * responses, mirroring the real client's one-process-per-connection lifetime,
+ * and `harness.client` always points at the live one.
+ */
+export function makeCodexClientStubHarness(
+  seedResponses: Record<string, unknown> = {}
+): CodexClientStubHarness {
+  const newStub = (): StubCodexClient => {
+    const stub = new StubCodexClient();
+    for (const [method, response] of Object.entries(seedResponses)) {
+      stub.serverResponses.set(method, response);
+    }
+    return stub;
+  };
+
+  const clients: StubCodexClient[] = [newStub()];
+  let handedOut = 0;
+  let lastOptions: CodexAppServerClientOptions | undefined;
+
+  const factory: CodexClientFactory = (options) => {
+    lastOptions = options;
+    // The first factory call adopts the pre-built stub so a fixture can seed
+    // responses before `connect()`; later generations get a fresh one.
+    if (handedOut > 0) clients.push(newStub());
+    handedOut += 1;
+    return clients[clients.length - 1]! as unknown as CodexAppServerClient;
+  };
+
+  return {
+    factory,
+    get client() {
+      return clients[clients.length - 1]!;
+    },
+    get clients() {
+      return clients;
+    },
+    get lastOptions() {
+      return lastOptions;
+    },
+  };
+}

--- a/test/server/protocol-adapters/conformance/stubs/hermes.stub.ts
+++ b/test/server/protocol-adapters/conformance/stubs/hermes.stub.ts
@@ -1,0 +1,158 @@
+/**
+ * Offline Hermes gateway stub for the adapter conformance suite.
+ *
+ * `HermesProtocolAdapter` talks to a real HTTP gateway, so the conformance
+ * seam is the gateway itself rather than a spawn hook: an in-process
+ * `http.Server` bound to loopback, handed to the adapter through
+ * `config.extra.endpoint` / `config.extra.apiToken`. Those two keys win over
+ * every env/`config.yaml` lookup in `resolveHermesGatewaySettings`, so the rig
+ * needs no HOME sandboxing and cannot pick up a developer's live Hermes.
+ *
+ * The routes are lifted from the inline gateway already used by
+ * `hermes-adapter.test.ts` (`/health`, `/v1/models`, `/v1/responses` SSE) and
+ * extended with the two control routes the lifecycle needs:
+ * `POST /session/:id/abort` (interrupt, `hermes-adapter.ts` ~line 978) and
+ * `POST /permission/:id/(allow|deny)` (approval, ~line 992).
+ *
+ * The one behavioural difference from that test helper is PUSH mode. The test
+ * helper writes a whole scripted stream in one callback; the conformance
+ * harness must release exactly one native event at a time so a silent drop is
+ * attributable to a single event. So `/v1/responses` holds the response open
+ * and `push()` writes one SSE frame into it; `endStream()` ends it, which is
+ * what lets the adapter's `consumeResponsesSse` return and `sendMessage`
+ * resolve.
+ *
+ * This file is a transport double only — it contains no assertions and no
+ * provider grammar. Event payloads live in `fixtures/hermes.fixture.ts`.
+ */
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+/** Upper bound on waiting for the adapter's `/v1/responses` POST to arrive. */
+const STREAM_WAIT_MS = 3_000;
+
+export interface HermesGatewayStub {
+  /** `http://127.0.0.1:<port>` — feed straight into `config.extra.endpoint`. */
+  endpoint: string;
+  /** Parsed bodies POSTed to `/v1/responses`, in arrival order. */
+  responsesRequests: Array<Record<string, unknown>>;
+  /** Paths hit on the abort/permission control routes, in arrival order. */
+  controlCalls: string[];
+  /** Release exactly one SSE frame on the turn's open response stream. */
+  push(event: unknown): Promise<void>;
+  /** End the open response stream (no-op when none is open). */
+  endStream(): void;
+  close(): Promise<void>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const CONTROL_ROUTE =
+  /^\/(?:permission\/[^/]+\/(?:allow|deny)|session\/[^/]+\/abort)$/;
+
+export async function startHermesGatewayStub(): Promise<HermesGatewayStub> {
+  const responsesRequests: Array<Record<string, unknown>> = [];
+  const controlCalls: string[] = [];
+  let active: http.ServerResponse | null = null;
+
+  const detach = (res: http.ServerResponse): void => {
+    if (active === res) active = null;
+  };
+
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += String(chunk);
+    });
+    req.on('end', () => {
+      const url = req.url ?? '';
+
+      if (url === '/health') {
+        res.writeHead(200);
+        res.end('ok');
+        return;
+      }
+
+      if (url === '/v1/models') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ id: 'hermes-conformance-stub' }] }));
+        return;
+      }
+
+      if (url === '/v1/responses') {
+        try {
+          responsesRequests.push(JSON.parse(body) as Record<string, unknown>);
+        } catch {
+          responsesRequests.push({});
+        }
+        // A new turn supersedes any stream the previous turn left open, so a
+        // stale response can never absorb the next turn's frames.
+        const previous = active;
+        active = null;
+        if (previous && !previous.writableEnded) previous.end();
+
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+        });
+        // Flush now so the adapter's `fetch` resolves and starts reading before
+        // the first frame is pushed — one fed step, one observable frame.
+        res.flushHeaders();
+        active = res;
+        res.on('close', () => detach(res));
+        return;
+      }
+
+      if (CONTROL_ROUTE.test(url)) {
+        controlCalls.push(url);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{}');
+        return;
+      }
+
+      res.writeHead(404);
+      res.end();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  const waitForStream = async (): Promise<http.ServerResponse> => {
+    const deadline = Date.now() + STREAM_WAIT_MS;
+    while (Date.now() < deadline) {
+      if (active && !active.writableEnded) return active;
+      await sleep(1);
+    }
+    throw new Error(
+      'hermes conformance stub: no /v1/responses stream was open to push into'
+    );
+  };
+
+  return {
+    endpoint: `http://127.0.0.1:${port}`,
+    responsesRequests,
+    controlCalls,
+    push: async (event) => {
+      const res = await waitForStream();
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+    },
+    endStream: () => {
+      const res = active;
+      active = null;
+      if (res && !res.writableEnded) res.end();
+    },
+    close: async () => {
+      const res = active;
+      active = null;
+      if (res && !res.writableEnded) res.end();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}

--- a/test/server/protocol-adapters/conformance/stubs/opencode-attached.stub.ts
+++ b/test/server/protocol-adapters/conformance/stubs/opencode-attached.stub.ts
@@ -1,0 +1,182 @@
+/**
+ * Offline transport double for the `opencode-attached` adapter.
+ *
+ * `OpenCodeAttachedAdapter` spawns nothing: it talks to an already-running
+ * `opencode serve` / `opencode web` over plain `fetch` (see
+ * `server/protocol-adapters/opencode-attached-adapter.ts` lines 10-90 for the
+ * endpoint, `/global/health` probe, and `/event` SSE wiring). So the seam is
+ * `globalThis.fetch`, spied exactly the way `opencode-adapter.test.ts` already
+ * spies it for the attached probe test (lines 126-151) — same routes, same
+ * status codes, no new grammar.
+ *
+ * The `/event` route hands back a held-open `Response` whose body is a
+ * `ReadableStream` this double owns. `push()` writes one real SSE frame
+ * (`data: <json>\n\n`) into it, which lands in the adapter's own
+ * `consumeSse` → `mapOpenCodeEvent` path — the identical dispatcher the
+ * existing attached-adapter delta test drives directly (lines 175-187).
+ *
+ * Nothing here is opinionated about the conformance transcript: the double is
+ * a server, the fixture is the script.
+ */
+import { vi } from 'vitest';
+
+/** Every HTTP call the adapter made, in order, for post-run assertions. */
+export interface RecordedOpenCodeRequest {
+  method: string;
+  url: string;
+  body?: string;
+}
+
+export interface OpenCodeAttachedServerDouble {
+  readonly endpoint: string;
+  readonly requests: RecordedOpenCodeRequest[];
+  /** Deliver one native OpenCode SSE event to every live `/event` reader. */
+  push(event: unknown): void;
+  /** End the SSE stream cleanly, as a server hang-up would. */
+  closeEventStream(): void;
+  /** Restore `globalThis.fetch` and drop any held-open stream. */
+  dispose(): void;
+}
+
+export interface OpenCodeAttachedServerDoubleOptions {
+  /** Must match `config.extra.endpoint`. Default is a fixed offline port. */
+  endpoint?: string;
+}
+
+/**
+ * Fixed, non-default port: the adapter's built-in default is
+ * `http://127.0.0.1:4096`, and a real opencode server on the developer's box
+ * must never be able to satisfy a conformance run by accident.
+ */
+export const CONFORMANCE_OPENCODE_ENDPOINT = 'http://127.0.0.1:14096';
+
+export function makeOpenCodeAttachedServerDouble(
+  options?: OpenCodeAttachedServerDoubleOptions
+): OpenCodeAttachedServerDouble {
+  const endpoint = (options?.endpoint ?? CONFORMANCE_OPENCODE_ENDPOINT).replace(
+    /\/$/,
+    ''
+  );
+  const requests: RecordedOpenCodeRequest[] = [];
+  const encoder = new TextEncoder();
+  const controllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
+
+  const closeController = (
+    controller: ReadableStreamDefaultController<Uint8Array>
+  ): void => {
+    if (!controllers.delete(controller)) return;
+    try {
+      controller.close();
+    } catch {
+      // Already closed by a cancelled reader; nothing to unwind.
+    }
+  };
+
+  const newEventStream = (
+    signal: AbortSignal | null | undefined
+  ): ReadableStream<Uint8Array> => {
+    let owned: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        owned = controller;
+        controllers.add(controller);
+      },
+      cancel() {
+        if (owned) controllers.delete(owned);
+      },
+    });
+    // `onDetach()` aborts the SSE controller. Closing (not erroring) the stream
+    // makes the adapter's read loop finish normally, which is what a graceful
+    // server hang-up looks like and keeps `AbortError` noise out of the run.
+    if (signal && owned) {
+      const controller = owned;
+      if (signal.aborted) closeController(controller);
+      else
+        signal.addEventListener('abort', () => closeController(controller), {
+          once: true,
+        });
+    }
+    return stream;
+  };
+
+  const json = (payload: unknown, status = 200): Response =>
+    new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  const spy = vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input, init) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      const method = (init?.method ?? 'GET').toUpperCase();
+      const body = typeof init?.body === 'string' ? init.body : undefined;
+      requests.push({
+        method,
+        url,
+        ...(body === undefined ? {} : { body }),
+      });
+
+      // Health probe used by both `onConnect` and `probeOpenCodeAttachedApi`.
+      if (url === `${endpoint}/global/health`) {
+        return json({ healthy: true, version: 'conformance-double' });
+      }
+
+      // Held-open SSE stream — the adapter's only inbound channel.
+      if (url === `${endpoint}/event`) {
+        return new Response(newEventStream(init?.signal), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+          },
+        });
+      }
+
+      if (method === 'POST' && url.startsWith(`${endpoint}/session/`)) {
+        if (url.endsWith('/prompt_async')) return json({ ok: true });
+        if (url.endsWith('/abort')) return json(true);
+      }
+
+      if (
+        method === 'POST' &&
+        url.startsWith(`${endpoint}/permission/`) &&
+        (url.endsWith('/allow') || url.endsWith('/deny'))
+      ) {
+        return json({ ok: true });
+      }
+
+      if (
+        method === 'POST' &&
+        url.startsWith(`${endpoint}/question/`) &&
+        url.endsWith('/reply')
+      ) {
+        return json({ ok: true });
+      }
+
+      throw new Error(
+        `opencode-attached conformance double: unexpected ${method} ${url}`
+      );
+    });
+
+  return {
+    endpoint,
+    requests,
+    push: (event) => {
+      const frame = encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
+      for (const controller of [...controllers]) controller.enqueue(frame);
+    },
+    closeEventStream: () => {
+      for (const controller of [...controllers]) closeController(controller);
+    },
+    dispose: () => {
+      for (const controller of [...controllers]) closeController(controller);
+      spy.mockRestore();
+    },
+  };
+}

--- a/test/server/protocol-adapters/conformance/stubs/opencode.stub.ts
+++ b/test/server/protocol-adapters/conformance/stubs/opencode.stub.ts
@@ -1,0 +1,214 @@
+/**
+ * Offline transport double for the `opencode` conformance fixture.
+ *
+ * OpenCode is a two-plane provider and the double keeps those planes separate,
+ * exactly as the real transport does:
+ *
+ * - **Command plane** — an HTTP surface the adapter drives with `fetch`
+ *   (`/global/health`, `POST /session`, `POST /session/:id/message`,
+ *   `POST /session/:id/abort`, `POST /session/:id/permissions/:requestId`).
+ *   Scripted here with a `vi.spyOn(globalThis, 'fetch')` responder, the same
+ *   seam `opencode-adapter.test.ts` already uses (lines 41-108).
+ * - **Event plane** — the SSE subscription on `/global/event`. The fixture
+ *   feeds native events straight into the adapter's `mapOpenCodeEvent`
+ *   dispatcher (the repo-blessed seam behind `driveOpenCodeEvent`), so this
+ *   double only has to keep the stream *open* rather than re-encode SSE frames.
+ *
+ * The one thing the double must get right beyond "answer the request" is
+ * TIMING. An OpenCode turn is bounded by the message POST: the adapter fires
+ * `chat:turn-completed` when that response lands. So the POST is deferred — it
+ * stays in flight while the fixture streams events into the event plane, and a
+ * fixture step completes it to end the turn. `interrupt()` and the toast-driven
+ * failure path both work by aborting that same in-flight request, which is why
+ * the double honours `init.signal`.
+ *
+ * Everything here is offline: no port is opened, no `opencode` binary runs, and
+ * the spawned child is inert.
+ */
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { ChildProcess, spawn } from 'node:child_process';
+import { vi } from 'vitest';
+
+/**
+ * Provider session id `POST /session` hands back. Fixed rather than generated:
+ * the conformance floor replays every transcript and compares patch payloads,
+ * and this id reaches the wire on every later request path.
+ */
+export const OPENCODE_SESSION_ID = 'opencode-conf-session';
+
+/** Pid handed to the inert child, for the same replay-stability reason. */
+const STUB_CHILD_PID = 4343;
+
+export interface OpenCodeTransportStub {
+  /** Injected into `new OpenCodeProtocolAdapter(spawnFn)`. */
+  spawnFn: typeof spawn;
+  /** Commands spawned so far. Inspected by tests, never by the harness. */
+  spawns: Array<{ command: string; args: readonly string[] }>;
+  /**
+   * Complete the in-flight `POST /session/:id/message` with `body`, which is
+   * what ends an OpenCode turn. Waits briefly for the request to appear so a
+   * fixture step never races `sendMessage`.
+   */
+  completeMessagePost(body: unknown): Promise<void>;
+  /** Restore the real `fetch` and close any still-open SSE body. */
+  restore(): void;
+}
+
+interface PendingRequest {
+  resolve(response: Response): void;
+  reject(error: unknown): void;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function pathnameOf(input: unknown): string {
+  const raw = String(input);
+  try {
+    return new URL(raw).pathname;
+  } catch {
+    return raw;
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** The rejection undici hands a caller whose request signal aborted. */
+function abortError(signal: AbortSignal | null | undefined): unknown {
+  const reason = signal?.reason;
+  if (reason instanceof Error) return reason;
+  return new DOMException('The operation was aborted.', 'AbortError');
+}
+
+function makeInertChild(): ChildProcess {
+  return Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    pid: STUB_CHILD_PID,
+    kill: vi.fn(() => true),
+  }) as unknown as ChildProcess;
+}
+
+export function makeOpenCodeTransportStub(): OpenCodeTransportStub {
+  const spawns: Array<{ command: string; args: readonly string[] }> = [];
+  const sseClosers: Array<() => void> = [];
+  let pendingMessage: PendingRequest | null = null;
+
+  const spawnFn = ((command: string, args: readonly string[]) => {
+    spawns.push({ command, args });
+    return makeInertChild();
+  }) as unknown as typeof spawn;
+
+  /**
+   * A `/global/event` body that stays open until the adapter aborts its SSE
+   * controller on teardown. Closing (rather than erroring) the stream lets
+   * `consumeSse` unwind through its normal end-of-stream path, so teardown
+   * emits no spurious `chat:error`.
+   */
+  const sseResponse = (signal: AbortSignal | null | undefined): Response => {
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let closed = false;
+    const close = (): void => {
+      if (closed) return;
+      closed = true;
+      try {
+        controller?.close();
+      } catch {
+        /* already closed by the consumer */
+      }
+    };
+    const body = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController;
+        if (signal?.aborted) close();
+      },
+    });
+    signal?.addEventListener('abort', close, { once: true });
+    sseClosers.push(close);
+    return new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+  };
+
+  const messagePost = (
+    signal: AbortSignal | null | undefined
+  ): Promise<Response> =>
+    new Promise<Response>((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(abortError(signal));
+        return;
+      }
+      const entry: PendingRequest = { resolve, reject };
+      pendingMessage = entry;
+      signal?.addEventListener(
+        'abort',
+        () => {
+          if (pendingMessage === entry) pendingMessage = null;
+          reject(abortError(signal));
+        },
+        { once: true }
+      );
+    });
+
+  const messagePath = `/session/${OPENCODE_SESSION_ID}/message`;
+  const abortPath = `/session/${OPENCODE_SESSION_ID}/abort`;
+  const permissionPrefix = `/session/${OPENCODE_SESSION_ID}/permissions/`;
+
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (
+    input: unknown,
+    init?: RequestInit
+  ): Promise<Response> => {
+    const path = pathnameOf(input);
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const signal = init?.signal;
+
+    if (path === '/global/health') return jsonResponse({});
+    if (path === '/global/event') return sseResponse(signal);
+    if (path === '/session' && method === 'POST') {
+      return jsonResponse({
+        id: OPENCODE_SESSION_ID,
+        title: 'Relay conformance',
+      });
+    }
+    if (path === messagePath && method === 'POST') return messagePost(signal);
+    if (path === abortPath && method === 'POST') return jsonResponse(true);
+    if (path.startsWith(permissionPrefix) && method === 'POST') {
+      return jsonResponse(true);
+    }
+    // Loud on purpose: an unscripted request means the adapter grew a call
+    // the conformance transcript does not model.
+    throw new Error(
+      `opencode conformance stub: unscripted request ${method} ${path}`
+    );
+  }) as unknown as typeof fetch);
+
+  return {
+    spawnFn,
+    spawns,
+    completeMessagePost: async (body) => {
+      const deadline = Date.now() + 1_000;
+      while (!pendingMessage && Date.now() < deadline) await sleep(1);
+      const entry = pendingMessage;
+      if (!entry) {
+        throw new Error(
+          'opencode conformance stub: no message POST is in flight to complete'
+        );
+      }
+      pendingMessage = null;
+      entry.resolve(jsonResponse(body));
+    },
+    restore: () => {
+      for (const close of sseClosers.splice(0)) close();
+      fetchSpy.mockRestore();
+    },
+  };
+}

--- a/test/server/protocol-adapters/conformance/stubs/pi.stub.ts
+++ b/test/server/protocol-adapters/conformance/stubs/pi.stub.ts
@@ -1,0 +1,96 @@
+/**
+ * Offline `PiAgentRpcClient` double for the pi conformance fixture.
+ *
+ * `PiAgentProtocolAdapter` takes a client factory in its constructor — the same
+ * seam `pi-agent-adapter.test.ts` uses — so the conformance rig needs no
+ * production change and never spawns a `pi --mode rpc` child: `start`, `call`,
+ * and `stop` are spied, and scripted native frames arrive as `emit('event', …)`,
+ * exactly how the real JSONL reader delivers them.
+ *
+ * Everything here is transport plumbing. The event grammar itself lives in
+ * `fixtures/pi.fixture.ts`, per the quirk-vs-choreography rule in
+ * `server/protocol-adapters/AGENTS.md`.
+ */
+import { vi } from 'vitest';
+import {
+  PiAgentRpcClient,
+  type PiAgentRpcClientOptions,
+  type PiAgentRpcMessage,
+} from '../../../../../server/pi-agent-rpc-client.js';
+
+/**
+ * Fixed provider session identity. Pi reports these from the `get_state`
+ * response `start()` resolves with, and the adapter publishes them on its
+ * session snapshot — so they must be pinned for invariant (d) to hold.
+ */
+export const PI_SESSION_ID = 'pi-conf-1';
+export const PI_SESSION_FILE = '/tmp/pi-conf-1.jsonl';
+
+export interface PiRpcCall {
+  type: string;
+  fields: Record<string, unknown>;
+}
+
+export interface PiRpcClientDouble {
+  /** The single client every `clientFactory` invocation hands back. */
+  client: PiAgentRpcClient;
+  factory: (options: PiAgentRpcClientOptions) => PiAgentRpcClient;
+  /** Options the adapter built per factory call (command, args, cwd, env). */
+  factoryOptions: PiAgentRpcClientOptions[];
+  /** Ordered RPC the adapter sent: `prompt`, `abort`, `steer`, `compact`, … */
+  calls: PiRpcCall[];
+  /** Deliver one native Pi RPC frame, as the JSONL reader would. */
+  emit(event: PiAgentRpcMessage): void;
+  stopped(): boolean;
+}
+
+/**
+ * A double whose `start()` resolves with the real `get_state` response shape
+ * (`sessionId` / `sessionFile` / `isStreaming`) captured in
+ * `pi-agent-adapter.test.ts`, and whose `call()` acknowledges every RPC
+ * successfully. A conformance transcript drives failure through native events,
+ * never through a rigged transport error — the transport-failure paths are
+ * deep-tested next door.
+ */
+export function makePiRpcClientDouble(): PiRpcClientDouble {
+  const client = new PiAgentRpcClient();
+  const calls: PiRpcCall[] = [];
+  const factoryOptions: PiAgentRpcClientOptions[] = [];
+  let stopped = false;
+
+  vi.spyOn(client, 'start').mockResolvedValue({
+    type: 'response',
+    command: 'get_state',
+    success: true,
+    data: {
+      sessionId: PI_SESSION_ID,
+      sessionFile: PI_SESSION_FILE,
+      isStreaming: false,
+    },
+  });
+
+  vi.spyOn(client, 'call').mockImplementation(
+    async (type: string, fields: Record<string, unknown> = {}) => {
+      calls.push({ type, fields });
+      return { type: 'response', command: type, success: true };
+    }
+  );
+
+  vi.spyOn(client, 'stop').mockImplementation(async () => {
+    stopped = true;
+  });
+
+  return {
+    client,
+    factory: (options) => {
+      factoryOptions.push(options);
+      return client;
+    },
+    factoryOptions,
+    calls,
+    emit: (event) => {
+      client.emit('event', event);
+    },
+    stopped: () => stopped,
+  };
+}

--- a/test/server/protocol-adapters/conformance/stubs/prime-agent.stub.ts
+++ b/test/server/protocol-adapters/conformance/stubs/prime-agent.stub.ts
@@ -1,0 +1,125 @@
+/**
+ * Offline Prime Agent RPC transport double for the conformance suite.
+ *
+ * `PrimeAgentProtocolAdapter` takes a `ClientFactory` seam in its constructor,
+ * so no production code changes to run it offline: the factory hands back a
+ * real `PrimeAgentRpcClient` whose three process-touching methods
+ * (`start`/`call`/`stop`) are stubbed. Everything else — the EventEmitter it
+ * extends, the `'event'` channel the adapter subscribes to — stays real, so the
+ * transcript exercises the adapter's actual listener wiring.
+ *
+ * The stubbed payloads are transcribed from the captured Prime RPC responses in
+ * `test/server/protocol-adapters/prime-agent-adapter.test.ts` (`harness()`,
+ * lines 22-110): the `get_state` readiness payload `start()` resolves with, and
+ * the `get_available_models` / `get_state` control-lane responses.
+ *
+ * Every value here is fixed — no clocks, no counters, no randomness — because
+ * the conformance floor replays the same transcript twice and diffs the patch
+ * streams byte for byte.
+ */
+import { vi } from 'vitest';
+import {
+  PrimeAgentRpcClient,
+  type PrimeAgentRpcClientOptions,
+  type PrimeAgentRpcMessage,
+} from '../../../../../server/prime-agent-rpc-client.js';
+
+/** Pinned provider session identity echoed into `providerSession` patches. */
+export const PRIME_CONFORMANCE_SESSION_ID = 'prime-conf-1';
+export const PRIME_CONFORMANCE_SESSION_FILE = '/tmp/prime-conf-1.jsonl';
+
+/**
+ * The single catalog entry `get_available_models` returns. One model keeps the
+ * discovered `/model` and `/thinking` control catalog (and therefore the
+ * `agent-session-updated-v2` payload) deterministic across replays.
+ */
+const PRIME_CONFORMANCE_MODEL: Record<string, unknown> = {
+  id: 'gpt-prime',
+  name: 'GPT Prime',
+  provider: 'prime-inference',
+  reasoning: true,
+  thinkingLevelMap: { xhigh: 'xhigh' },
+};
+
+function model(): Record<string, unknown> {
+  return { ...PRIME_CONFORMANCE_MODEL };
+}
+
+function stateData(): Record<string, unknown> {
+  return {
+    sessionId: PRIME_CONFORMANCE_SESSION_ID,
+    sessionFile: PRIME_CONFORMANCE_SESSION_FILE,
+    thinkingLevel: 'medium',
+    model: model(),
+  };
+}
+
+export interface PrimeAgentTransportDouble {
+  /** The one client every `clientFactory()` call hands back. */
+  client: PrimeAgentRpcClient;
+  clientFactory: (options: PrimeAgentRpcClientOptions) => PrimeAgentRpcClient;
+  /** Launch options the adapter passed per client construction. */
+  factoryOptions: PrimeAgentRpcClientOptions[];
+  /** `[method, fields]` for every RPC the adapter issued. */
+  calls: Array<[string, Record<string, unknown>]>;
+  /** Deliver one native Prime event on the channel the adapter listens to. */
+  feed(event: unknown): void;
+}
+
+export function makePrimeAgentTransportDouble(): PrimeAgentTransportDouble {
+  const client = new PrimeAgentRpcClient();
+  const factoryOptions: PrimeAgentRpcClientOptions[] = [];
+  const calls: Array<[string, Record<string, unknown>]> = [];
+
+  // `start()` resolves with the readiness `get_state` response, exactly as the
+  // real client does after its handshake barrier.
+  vi.spyOn(client, 'start').mockResolvedValue({
+    type: 'response',
+    command: 'get_state',
+    success: true,
+    data: { ...stateData(), isStreaming: false },
+  });
+
+  vi.spyOn(client, 'call').mockImplementation(
+    async (
+      type: string,
+      fields: Record<string, unknown> = {}
+    ): Promise<PrimeAgentRpcMessage> => {
+      calls.push([type, fields]);
+      if (type === 'get_available_models') {
+        return {
+          type: 'response',
+          command: type,
+          success: true,
+          data: { models: [model()] },
+        };
+      }
+      if (type === 'get_state') {
+        return {
+          type: 'response',
+          command: type,
+          success: true,
+          data: stateData(),
+        };
+      }
+      // `prompt` and `abort` acknowledge with a bare success envelope; the
+      // user-visible consequence arrives on the event channel.
+      return { type: 'response', command: type, success: true };
+    }
+  );
+
+  vi.spyOn(client, 'stop').mockResolvedValue();
+
+  return {
+    client,
+    factoryOptions,
+    calls,
+    clientFactory: (options) => {
+      factoryOptions.push(options);
+      return client;
+    },
+    feed: (event) => {
+      client.emit('event', event);
+    },
+  };
+}

--- a/test/server/protocol-adapters/support/claude-child-double.ts
+++ b/test/server/protocol-adapters/support/claude-child-double.ts
@@ -1,0 +1,148 @@
+/**
+ * Fake `claude` child process + spawn harness shared by the Claude deep tests
+ * and the adapter conformance suite.
+ *
+ * Lifted verbatim from `claude-adapter.test.ts` (import swap only) with one
+ * behavior change the conformance suite requires: pids are assigned from a
+ * deterministic per-harness counter instead of `Math.random()`, so a replayed
+ * transcript produces byte-identical patches.
+ */
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { ChildProcess } from 'node:child_process';
+import { vi } from 'vitest';
+import type { ClaudeSpawnFn } from '../../../../server/claude-stream-client.js';
+
+/** First pid handed out by a harness; later children increment from here. */
+export const DEFAULT_BASE_PID = 4242;
+
+export interface MockChild extends EventEmitter {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+  pid: number;
+  closed: boolean;
+  serverWrite(obj: unknown): void;
+  emitClose(code: number | null, signal?: NodeJS.Signals | null): void;
+  emitStderr(text: string): void;
+  frames(): Record<string, unknown>[];
+  waitForFrames(
+    count: number,
+    timeoutMs?: number
+  ): Promise<Record<string, unknown>[]>;
+}
+
+export interface MockChildOptions {
+  closeOnStdinEnd?: boolean;
+  pid?: number;
+}
+
+export function makeMockChild(options?: MockChildOptions): MockChild {
+  const child = new EventEmitter() as MockChild;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.pid = options?.pid ?? DEFAULT_BASE_PID;
+  child.closed = false;
+
+  const frames: Record<string, unknown>[] = [];
+  const waiters: Array<{
+    count: number;
+    resolve: (f: Record<string, unknown>[]) => void;
+  }> = [];
+  let buf = '';
+  child.stdin.on('data', (chunk: Buffer) => {
+    buf += chunk.toString();
+    let idx: number;
+    while ((idx = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, idx).trim();
+      buf = buf.slice(idx + 1);
+      if (!line) continue;
+      try {
+        frames.push(JSON.parse(line) as Record<string, unknown>);
+      } catch {
+        frames.push({ __raw: line });
+      }
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        if (frames.length >= waiters[i]!.count) {
+          waiters.splice(i, 1)[0]!.resolve([...frames]);
+        }
+      }
+    }
+  });
+
+  child.emitClose = (code, signal = null) => {
+    if (child.closed) return;
+    child.closed = true;
+    child.emit('close', code, signal);
+    child.stdout.push(null);
+  };
+  child.kill = vi.fn((_signal?: string) => true);
+  if (options?.closeOnStdinEnd !== false) {
+    child.stdin.on('finish', () =>
+      setImmediate(() => child.emitClose(0, null))
+    );
+  }
+  child.serverWrite = (obj) => child.stdout.push(JSON.stringify(obj) + '\n');
+  child.emitStderr = (text) =>
+    child.stderr.push(text.endsWith('\n') ? text : text + '\n');
+  child.frames = () => [...frames];
+  child.waitForFrames = (count, timeoutMs = 1000) => {
+    if (frames.length >= count) return Promise.resolve([...frames]);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () =>
+          reject(new Error(`timeout: ${frames.length}/${count} stdin frames`)),
+        timeoutMs
+      );
+      waiters.push({
+        count,
+        resolve: (f) => {
+          clearTimeout(timer);
+          resolve(f);
+        },
+      });
+    });
+  };
+  return child;
+}
+
+export interface SpawnRecord {
+  command: string;
+  args: string[];
+  options: { cwd: string; env: Record<string, string>; stdio: 'pipe' };
+  child: MockChild;
+}
+
+export interface ClaudeChildHarness {
+  spawnFn: ClaudeSpawnFn;
+  spawns: SpawnRecord[];
+  latest(): SpawnRecord;
+  setNextChildOptions(o: { closeOnStdinEnd?: boolean }): void;
+}
+
+export function makeHarness(options?: {
+  basePid?: number;
+}): ClaudeChildHarness {
+  const basePid = options?.basePid ?? DEFAULT_BASE_PID;
+  const spawns: SpawnRecord[] = [];
+  let nextOpts: { closeOnStdinEnd?: boolean } | undefined;
+  const spawnFn: ClaudeSpawnFn = (command, args, opts) => {
+    const child = makeMockChild({ ...nextOpts, pid: basePid + spawns.length });
+    nextOpts = undefined;
+    spawns.push({ command, args, options: opts, child });
+    return child as unknown as ChildProcess;
+  };
+  return {
+    spawnFn,
+    spawns,
+    latest: (): SpawnRecord => spawns[spawns.length - 1]!,
+    setNextChildOptions: (o: { closeOnStdinEnd?: boolean }) => {
+      nextOpts = o;
+    },
+  };
+}
+
+/** Conformance alias — the suite reads this name in fixture files. */
+export const makeClaudeChildHarness = makeHarness;


### PR DESCRIPTION
## Summary

Ladder slice 1 of the harness-integration surface work (follows #1405). Adds `test/server/protocol-adapters/conformance/`: every key of `v2Adapters` runs through one shared lifecycle harness against scripted native-event fixtures derived from the real captured event shapes in the per-adapter tests.

**Invariants enforced per adapter:** exactly one terminal turn-completed per turn (normal, interrupted, and error turns), stable approval ids with no orphans after teardown, no silently dropped native events, deterministic replay (same transcript → same patch sequence), and declared-vs-observed capability reconciliation — UNKNOWN never establishes drift, and skipping an invariant requires a real GitHub issue citation (validated format, `TODO` won't pass).

**Self-extending:** the discovery test iterates `Object.keys(v2Adapters)` and fails for any registered adapter with no fixture — adapter N+1 cannot land without conformance coverage.

**Day-one catches — three real defects surfaced and filed:**
- #1407 adapters leave a tool approval pending forever on mid-approval disconnect
- #1411 failed turns on legacy-bridged adapters have no single owner of the terminal patch
- #1412 opencode-attached never emits a terminal turn patch

Their invariants run as issue-cited skips (11 total) until fixed; everything else runs hard.

Adversarial review pass: 1 P0 (suite red on the #1412 defect — converted to gap-conditional tolerance so only the cited gap is tolerated), 3 P2 (vacuous-pass holes in missing-fixture guard, abandoned-approval probe, capability reconciliation — all closed with self-tests), 4 P3. All 8 applied.

No user-visible change — test infrastructure only.

Adapter generality: choreography — the lifecycle harness and fixture contract are shared; each fixture carries only its adapter's quirk surface (event vocabulary, transport stub).

## Verification

- `npm run check` exit 0
- `npx vitest run test/server/protocol-adapters/` — 11 files, 336 passed, 11 issue-cited skips, 0 failures (re-run post-rebase onto nightly)
- Suite confirmed inside the default `vitest run` glob (`vitest list` evidence in workflow log)
- Harness self-tests pin the failure shapes so the #1407/#1411/#1412 fixers flip assertions rather than delete them

🤖 Generated with [Claude Code](https://claude.com/claude-code)