### PR TITLE
refactor(adapters): collapse provider scatter sites into guarded per-provider descriptors

### DIFF
--- a/.chalk/skills/add-provider/SKILL.md
+++ b/.chalk/skills/add-provider/SKILL.md
@@ -26,7 +26,8 @@ provider to Relay's channel-first product.
 4. Preserve stable native ids; use deterministic fallback ids only when needed.
 5. Declare exact capabilities for resume, queue, approvals, questions, images,
    and runtime environment refresh.
-6. Register the adapter in `server/protocol-adapters/index.ts`.
+6. Register the adapter AND its `ProviderDescriptor` row in
+   `server/protocol-adapters/index.ts` (one without the other will not compile).
 7. Map common output to canonical detail cards.
 8. Add a bounded provider extension only when canonical items are insufficient.
 9. Prove mention → private runtime → durable channel row through binder/bridge
@@ -61,9 +62,13 @@ before it is a code change.
    wording, which the shared helper takes as a parameter; pi-agent and
    prime-agent fold `providerSessionId` into config first — that is a
    config-transform hook, not a reason to duplicate.
-4. Renaming or adding a provider also touches sites outside this directory: the
-   resume-id ladder in `server/channel-agent-runtime.ts` and the launch
-   contracts plus capability sets in `server/protocol-adapters/index.ts`.
+4. Everything a provider's name means outside this directory — launch contract,
+   capability transcription, resume-state key, image lane, channel-lane
+   advertisement, allowlists, controls, process match, auth paths, yolo
+   permission mode — is ONE row in `PROVIDER_DESCRIPTORS`
+   (`server/protocol-adapters/index.ts`). Registering an adapter without that row
+   is a compile error; `test/provider-registry-drift.test.ts` holds each
+   consuming seam to it. Never re-derive a provider fact in the consumer.
 5. Every PR touching `server/protocol-adapters/**` starts a PR-body line with
    `Adapter generality:` stating the classification and its reason. CI requires
    the line (or the `adapter-generality-reviewed` label); the `adapter-review`

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -36,6 +36,13 @@ test/git-watcher.test.ts
 test/workspace-divergence-api.test.ts
 "
 
+# Git exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE into hook processes.
+# Tests that validate arbitrary repo paths (e.g. workspace-groups
+# terminal cwd) then resolve against THIS repo instead of their temp
+# repos and fail — only inside hooks, never standalone (#1416). Scrub
+# them so vitest sees the same env as a normal `npm test`.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 PREPUSH_VITEST_EXCLUDES=""
 for file in $PREPUSH_EXCLUDE_FILES; do
   PREPUSH_VITEST_EXCLUDES="$PREPUSH_VITEST_EXCLUDES --exclude $file"

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -316,7 +316,10 @@ npm run build
 
 1. Inspect one real native event stream and redact a structural fixture.
 2. Implement or update the `ProtocolAdapterV2` adapter.
-3. Register it in `server/protocol-adapters/index.ts`.
+3. Register it in `server/protocol-adapters/index.ts` — the adapter factory AND
+   its `PROVIDER_DESCRIPTORS` row, which is where every provider fact the rest of
+   the server reads by name lives. An adapter without a descriptor (or the
+   reverse) is a compile error.
 4. Declare exact capabilities.
 5. Add mapping, lifecycle, resume, and error tests.
 6. Prove the channel binder/bridge path.

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -31,6 +31,10 @@ import type {
 } from './channel-agent-runtime.js';
 import { providerResumeId } from './channel-agent-runtime.js';
 import {
+  DEFAULT_ORCHESTRATOR_PROVIDER_ID,
+  providerDescriptor,
+} from './protocol-adapters/index.js';
+import {
   relayControlCatalogForProvider,
   relayControlInputGuardCatalogForProvider,
 } from '../shared/agent-command-catalog.js';
@@ -107,8 +111,24 @@ const logger = createLogger('channel-agent-binder');
  * approval ever arrives.
  */
 export const CHANNEL_BINDING_YOLO_DEFAULT = true;
-/** Permission mode that maps to yolo for channel adapters (claude → --dangerously-skip-permissions). */
-const YOLO_PERMISSION_MODE = 'bypassPermissions';
+
+/**
+ * Yolo is Relay's decision; the WORD for it belongs to the provider.
+ *
+ * Each descriptor names the permission mode its own adapter understands, or
+ * `null` for none (`server/protocol-adapters/index.ts`). `bypassPermissions` is
+ * Claude's vocabulary and used to be sent to every provider from one constant
+ * here, even though `claude-adapter.ts` is the only adapter that reads
+ * `config.permissionMode`.
+ */
+function yoloPermissionModeConfig(
+  providerId: string,
+  yolo: boolean
+): { permissionMode?: string } {
+  if (!yolo) return {};
+  const mode = providerDescriptor(providerId)?.yoloPermissionMode;
+  return mode ? { permissionMode: mode } : {};
+}
 
 /** Per-binding FIFO turn queue cap; overflow → system row, message dropped. */
 const QUEUE_CAP = 8;
@@ -1813,7 +1833,7 @@ export function createChannelAgentBinder(
         ...(effectiveRole ? { role: effectiveRole } : {}),
         ...(routing.repoPath ? { repoPath: routing.repoPath } : {}),
         ...(routing.worktreePath ? { worktreePath: routing.worktreePath } : {}),
-        ...(yolo ? { permissionMode: YOLO_PERMISSION_MODE } : {}),
+        ...yoloPermissionModeConfig(framework, yolo),
         ...(profile.model !== undefined ? { model: profile.model } : {}),
         ...(profile.envVars !== undefined
           ? { processEnv: profile.envVars }
@@ -1982,7 +2002,7 @@ export function createChannelAgentBinder(
 
   async function ensureOrchestrator(
     channelId: string,
-    framework = 'claude',
+    framework = DEFAULT_ORCHESTRATOR_PROVIDER_ID,
     profileActorId?: string
   ): Promise<LiveBinding> {
     const profile = profileActorId

--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -22,6 +22,7 @@ import type { AdapterConfig } from './protocol-adapter.js';
 import type { ProtocolAdapterV2 } from './protocol-adapter-v2.js';
 import {
   createAdapterV2,
+  providerDescriptor,
   sanitizeChannelAdapterProcessEnv,
 } from './protocol-adapters/index.js';
 import { createLogger } from './logger.js';
@@ -141,26 +142,23 @@ export function configureChannelAgentRuntimes(input: {
  * key in the blob — Relay's own `lastDeliveredSeq`, an adapter's private
  * bookkeeping — is inert at spawn time. Exported so callers that must know
  * whether a respawned runtime still holds its prior conversation ask THIS
- * question rather than "is the blob non-empty" (#1408): a persisted key this
- * map does not name replays nothing.
+ * question rather than "is the blob non-empty" (#1408): a persisted key the
+ * descriptor does not name replays nothing.
+ *
+ * The key comes from `ProviderDescriptor.resumeStateKey`
+ * (`server/protocol-adapters/index.ts`), keyed by registry provider id and NOT by
+ * `adapter.agentType` — the bridged `opencode-attached` adapter reports
+ * `agentType: 'opencode'`, while resume state is per registered provider. This
+ * used to be a hand-maintained ladder here, and a provider missing from it failed
+ * SILENTLY: it connected, then never resumed, with no error, no type error, and
+ * no test.
  */
 export function providerResumeId(
   providerId: string,
   state: Record<string, unknown> | undefined
 ): string | undefined {
   if (!state) return undefined;
-  const key =
-    providerId === 'claude'
-      ? 'claudeSessionId'
-      : providerId === 'codex'
-        ? 'threadId'
-        : providerId === 'hermes'
-          ? 'hermesResponseId'
-          : providerId === 'prime-agent'
-            ? 'primeAgentSessionId'
-            : providerId === 'pi'
-              ? 'piSessionId'
-              : undefined;
+  const key = providerDescriptor(providerId)?.resumeStateKey;
   if (!key) return undefined;
   const value = state[key];
   return typeof value === 'string' && value.length > 0 ? value : undefined;

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -64,17 +64,25 @@ import {
   type ChannelSenderRef,
 } from '../shared/channel-chat-protocol.js';
 
+import {
+  DEFAULT_ORCHESTRATOR_PROVIDER_ID,
+  defaultMentionableProviderIds,
+} from './protocol-adapters/index.js';
+
 const CONTEXT_READ = 'context:read';
 const CONTEXT_WRITE = 'context:write';
 
-const DEFAULT_KNOWN_PROVIDER_IDS = [
-  'claude',
-  'codex',
-  'opencode',
-  'hermes',
-  'prime-agent',
-  'pi',
-];
+/**
+ * Fallback mention roster for a router built without `deps.knownProviderIds`.
+ *
+ * The hub always passes `Object.keys(v2Adapters)` (`server/index.ts`), so this is
+ * the test/embedding default only. Derived from
+ * `ProviderDescriptor.mentionableByDefault` rather than hand-listed here: a
+ * provider missing from the old literal list was unmentionable on any surface
+ * that took the default, with nothing to say so.
+ */
+export const DEFAULT_KNOWN_PROVIDER_IDS: readonly string[] =
+  defaultMentionableProviderIds();
 
 /**
  * Byte budget for one REST history response. Rows are row-bounded (max 200) but
@@ -2220,7 +2228,7 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     const framework =
       typeof requested === 'string' && requested.length > 0
         ? requested
-        : 'claude';
+        : DEFAULT_ORCHESTRATOR_PROVIDER_ID;
     binder
       .ensureOrchestrator(topic.id, framework)
       .then((binding) =>

--- a/server/channel-context-packet.ts
+++ b/server/channel-context-packet.ts
@@ -7,6 +7,10 @@ import {
 } from '../shared/channel-chat-protocol.js';
 import type { ChannelAttachmentStore } from './channel-attachments.js';
 import type { Attachment } from './protocol-adapter-v2.js';
+import {
+  GENERAL_IMAGE_RAW_BYTE_BUDGET,
+  providerDescriptor,
+} from './protocol-adapters/index.js';
 
 // Pure context-packet builder for @-mention routing (#1167, slice 4). No I/O:
 // store rows in, prompt string out — fully unit-testable. The binder fetches the
@@ -22,25 +26,34 @@ export const PACKET_ROW_MAX_CHARS = 2000;
 export const PACKET_MAX_BYTES = 16 * 1024;
 /** Provider turns receive at most four images, regardless of retained row count. */
 export const PACKET_IMAGE_MAX_COUNT = 4;
-/** General raw-image ceiling bounds synchronous adapter encoding work. */
-export const PACKET_IMAGE_MAX_RAW_BYTES = 10 * 1024 * 1024;
-/**
- * Claude frames images as base64 inside one JSONL stdin frame. Six raw MiB
- * expands to eight MiB, leaving over a MiB below its 9.5MB line ceiling for
- * packet text, JSON syntax, and per-block metadata.
- */
-export const CLAUDE_PACKET_IMAGE_MAX_RAW_BYTES = 6 * 1024 * 1024;
 /** Transient callback-only metadata; never persisted by the image bridge. */
 export const PACKET_IMAGE_DEGRADATION_META_KEY = '__relayImageDegradationNotes';
-/** Adapter audit: only these framework lanes consume local image attachments. */
-export const PACKET_FRAMEWORK_IMAGE_SUPPORT: Readonly<Record<string, boolean>> =
-  Object.freeze({
-    claude: true,
-    codex: true,
-    hermes: true,
-    mock: true,
-    opencode: false,
-  });
+/**
+ * Image delivery is a per-provider fact declared once, beside the adapter.
+ *
+ * `deliversImages` and `imageRawByteBudget` come from `ProviderDescriptor`
+ * (`server/protocol-adapters/index.ts`). This module used to hold its own
+ * framework table, and a provider absent from it silently inherited "cannot
+ * receive images"; the descriptor is total over the adapter roster, so the
+ * question has to be answered before an adapter can register.
+ *
+ * The lookup is lower-cased because `packet.framework` is a persisted string.
+ * An unregistered framework keeps the pre-descriptor fallbacks: no images, and
+ * the general raw-byte ceiling. (Before the descriptor, an exactly-`'claude'`
+ * framework got Claude's smaller budget while `'Claude'` got the general one;
+ * both now resolve to the same descriptor.)
+ */
+function frameworkImageLane(framework: string): {
+  deliversImages: boolean;
+  rawByteBudget: number;
+} {
+  const descriptor = providerDescriptor(framework.toLowerCase());
+  return {
+    deliversImages: descriptor?.deliversImages === true,
+    rawByteBudget:
+      descriptor?.imageRawByteBudget ?? GENERAL_IMAGE_RAW_BYTE_BUDGET,
+  };
+}
 
 const OMITTED_MARKER = '[…earlier messages omitted]';
 const ROW_TRUNCATED_SUFFIX = '…[truncated]';
@@ -464,10 +477,8 @@ export function resolveMentionContextPacket(
 ): ResolvedMentionContextPacket {
   const attachments: Attachment[] = [];
   const notes: string[] = [];
-  const rawByteLimit =
-    packet.framework === 'claude'
-      ? CLAUDE_PACKET_IMAGE_MAX_RAW_BYTES
-      : PACKET_IMAGE_MAX_RAW_BYTES;
+  const imageLane = frameworkImageLane(packet.framework);
+  const rawByteLimit = imageLane.rawByteBudget;
   let rawBytes = 0;
   const seenAttachmentIds = new Set<string>();
   for (const image of packet.images) {
@@ -477,9 +488,7 @@ export function resolveMentionContextPacket(
     // occurrence in packet priority order wins.
     if (seenAttachmentIds.has(part.id)) continue;
     seenAttachmentIds.add(part.id);
-    if (
-      PACKET_FRAMEWORK_IMAGE_SUPPORT[packet.framework.toLowerCase()] !== true
-    ) {
+    if (!imageLane.deliversImages) {
       notes.push(
         `[image attachment not deliverable to ${packet.framework}: ${part.alt?.trim() || part.id}, ${part.w}x${part.h}]`
       );

--- a/server/frameworks.ts
+++ b/server/frameworks.ts
@@ -9,8 +9,13 @@ import {
 } from './types.js';
 import {
   channelAdapterLaunchRequirement,
+  providerDescriptor,
+  providerSupportsChannelAgents,
   type ChannelGatewayProbe,
 } from './protocol-adapters/index.js';
+import { createLogger } from './logger.js';
+
+const log = createLogger('frameworks');
 
 export interface FrameworkAvailability {
   installed: boolean;
@@ -92,9 +97,41 @@ export function getFrameworkAvailability(
   };
 }
 
+/** Framework ids already warned about, so a roster poll cannot spam the log. */
+const warnedChannelLaneOverrides = new Set<string>();
+
+/**
+ * `config.frameworks.<id>.capabilities.supportsChannelAgents` no longer decides
+ * anything, in EITHER direction: it cannot claim a channel lane for a framework
+ * with no registered adapter (it never legitimately could — the roster then
+ * failed at the launch-contract lookup), and it can no longer de-advertise a
+ * lane that a registered adapter serves. Both answers now come from the provider
+ * descriptor, which is the same registry that decides whether an adapter exists
+ * at all — one gate instead of two that could disagree.
+ *
+ * The disable direction did work before, undocumented and untested, so warn
+ * rather than ignore silently: a self-hoster who set it deserves to learn why it
+ * stopped taking effect.
+ */
+function warnOnIgnoredChannelLaneOverride(
+  frameworkId: string,
+  override: Partial<AgentFramework>
+): void {
+  if (override.capabilities?.supportsChannelAgents === undefined) return;
+  if (warnedChannelLaneOverrides.has(frameworkId)) return;
+  warnedChannelLaneOverrides.add(frameworkId);
+  log.warn(
+    `config frameworks.${frameworkId}.capabilities.supportsChannelAgents is ignored; ` +
+      `the channel lane is declared by that provider's descriptor in ` +
+      `server/protocol-adapters/index.ts.`
+  );
+}
+
 export function listConfiguredFrameworks(
   frameworkOverrides?: Record<string, Partial<AgentFramework>>
 ): AgentFramework[] {
+  for (const [id, override] of Object.entries(frameworkOverrides ?? {}))
+    warnOnIgnoredChannelLaneOverride(id, override);
   const ids = new Set([
     ...Object.keys(BUILTIN_FRAMEWORKS),
     ...Object.keys(frameworkOverrides ?? {}),
@@ -107,6 +144,27 @@ export function listConfiguredFrameworks(
   );
 }
 
+/**
+ * Framework capabilities with the channel lane answered by the provider
+ * descriptor rather than by the terminal framework catalog.
+ *
+ * `supportsChannelAgents` used to be a hand-written boolean per catalog entry AND
+ * a registered adapter with a launch contract — two registries that could
+ * disagree, one of them silent. `ProviderDescriptor.supportsChannelAgents`
+ * (`server/protocol-adapters/index.ts`) is now the only declaration; this
+ * projects it so the client payload shape is unchanged. A configured framework
+ * override can no longer claim — or de-advertise — a channel lane; see
+ * `warnOnIgnoredChannelLaneOverride` above for that deliberate delta.
+ */
+export function frameworkCapabilitiesWithChannelLane(
+  framework: AgentFramework
+): AgentFramework['capabilities'] {
+  return {
+    ...framework.capabilities,
+    supportsChannelAgents: providerSupportsChannelAgents(framework.id),
+  };
+}
+
 export function getFrameworkClientInfo(
   frameworkOverrides?: Record<string, Partial<AgentFramework>>,
   env: NodeJS.ProcessEnv = process.env
@@ -115,7 +173,7 @@ export function getFrameworkClientInfo(
     id: framework.id,
     displayName: framework.displayName,
     command: framework.command,
-    capabilities: framework.capabilities,
+    capabilities: frameworkCapabilitiesWithChannelLane(framework),
     eventSource: framework.eventSource,
     availability: getFrameworkAvailability(framework, env),
   }));
@@ -152,7 +210,21 @@ export async function getFrameworkChannelAvailability(
   env: NodeJS.ProcessEnv = process.env,
   options: FrameworkChannelAvailabilityOptions = {}
 ): Promise<FrameworkChannelAvailability> {
-  if (!framework.capabilities.supportsChannelAgents) {
+  // One gate, not two: a registered channel adapter is what makes a framework a
+  // channel lane, and its descriptor says whether that lane is offered. The
+  // terminal framework catalog no longer holds a second, independently-editable
+  // `supportsChannelAgents` boolean that could disagree with the registry — so a
+  // config framework override cannot toggle this lane in either direction
+  // (`warnOnIgnoredChannelLaneOverride`). A framework with no descriptor, custom
+  // or otherwise, fails closed here.
+  const descriptor = providerDescriptor(framework.id);
+  if (!descriptor) {
+    return {
+      available: false,
+      reason: `${framework.displayName} has no registered channel runtime.`,
+    };
+  }
+  if (!descriptor.supportsChannelAgents) {
     return {
       available: false,
       reason:
@@ -161,13 +233,7 @@ export async function getFrameworkChannelAvailability(
     };
   }
 
-  const requirement = channelAdapterLaunchRequirement(framework.id);
-  if (!requirement) {
-    return {
-      available: false,
-      reason: `${framework.displayName} has no registered channel runtime.`,
-    };
-  }
+  const requirement = descriptor.launch.requirement;
 
   if (requirement.kind === 'gateway') {
     const gatewayProbe =

--- a/server/node-manifest-build.ts
+++ b/server/node-manifest-build.ts
@@ -15,6 +15,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { FILE_RPC_OPERATIONS } from '../shared/file-rpc.js';
+import { providerDescriptor } from './protocol-adapters/index.js';
 import type {
   NodeCapabilityProbe,
   NodeCapabilityStatus,
@@ -169,51 +170,37 @@ export interface AgentAuthProbeDeps {
 /**
  * Probe auth status for an agent CLI.
  *
- * Strategy (best-effort, no secrets in output):
- * - claude: checks for the presence of ~/.claude/.credentials.json or
- *   ~/.config/claude/credentials.json. File presence → 'authed'. This is a
- *   heuristic — the file could be expired, but it's non-destructive and fast.
- * - All others: 'unknown'.
+ * Strategy (best-effort, no secrets in output): a provider that declares
+ * `authCredentialPaths` in its descriptor (`server/protocol-adapters/index.ts`)
+ * reports 'authed' when any one of those home-relative files is readable, and
+ * 'unauthed' otherwise. This is a heuristic — a present file could be expired —
+ * but it is non-destructive and fast. A provider that declares none, and any
+ * custom agent, reports 'unknown'.
  *
- * Never logs token values. Only reports the three-state enum.
+ * The paths used to be `if (agentId === …)` branches here, so a new provider had
+ * no way to answer the question without editing this module.
+ *
+ * Never reads or logs token values. Only reports the three-state enum.
  */
 export function probeAgentAuthStatus(
   agentId: string,
   deps: AgentAuthProbeDeps & { homeDir?: string } = {}
 ): NodeAgentAuthStatus {
   const homeDir = deps.homeDir ?? os.homedir();
+  const credentialPaths =
+    providerDescriptor(agentId)?.authCredentialPaths ?? [];
+  if (credentialPaths.length === 0) return 'unknown';
 
-  if (agentId === 'claude') {
-    // Check common credential file locations for Claude
-    const candidates = [
-      path.join(homeDir, '.claude', '.credentials.json'),
-      path.join(homeDir, '.config', 'claude', 'credentials.json'),
-    ];
-    for (const candidate of candidates) {
-      try {
-        fs.accessSync(candidate, fs.constants.R_OK);
-        return 'authed';
-      } catch {
-        // file absent or unreadable, try next
-      }
-    }
-    // No credential file found — likely unauthenticated
-    return 'unauthed';
-  }
-
-  if (agentId === 'codex') {
-    // Codex stores auth state in ~/.codex/auth.json
-    const codexAuthFile = path.join(homeDir, '.codex', 'auth.json');
+  for (const segments of credentialPaths) {
     try {
-      fs.accessSync(codexAuthFile, fs.constants.R_OK);
+      fs.accessSync(path.join(homeDir, ...segments), fs.constants.R_OK);
       return 'authed';
     } catch {
-      return 'unauthed';
+      // File absent or unreadable — try the next declared location.
     }
   }
-
-  // opencode, hermes, and custom agents: no reliable heuristic
-  return 'unknown';
+  // No credential file found — likely unauthenticated.
+  return 'unauthed';
 }
 
 /**

--- a/server/process-tree.ts
+++ b/server/process-tree.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 
+import { providerDescriptors } from './protocol-adapters/index.js';
+
 export type LanguageServerKind =
   | 'tsserver'
   | 'typescript-language-server'
@@ -331,6 +333,67 @@ export function scheduleRelayProcessTreeReap(
   return summary;
 }
 
+/** Relay's own entrypoints. Provider CLI names come from the descriptors. */
+const RELAY_ENTRYPOINT_COMMAND_LINE_PATTERN = /relay-ide|relayctl/i;
+
+interface RelayOwnershipPatterns {
+  commandLine: RegExp;
+  commandBasename: RegExp | null;
+}
+
+let relayOwnershipPatterns: RelayOwnershipPatterns | null = null;
+
+/**
+ * Built on first use, not at module load: `claude-adapter.ts` and
+ * `codex-native-adapter.ts` import THIS module, so reading the adapter registry
+ * at module scope would be a temporal-dead-zone crash whenever the registry
+ * happens to load first. By call time both modules are initialized.
+ */
+function ownershipPatterns(): RelayOwnershipPatterns {
+  if (relayOwnershipPatterns) return relayOwnershipPatterns;
+  const substrings = [
+    RELAY_ENTRYPOINT_COMMAND_LINE_PATTERN.source,
+    ...providerDescriptors().flatMap((descriptor) =>
+      descriptor.processMatch.commandLineSubstrings.map(escapeForRegExp)
+    ),
+  ];
+  const basenames = providerDescriptors().flatMap((descriptor) =>
+    descriptor.processMatch.commandBasenames.map(escapeForRegExp)
+  );
+  relayOwnershipPatterns = {
+    commandLine: new RegExp(substrings.join('|'), 'i'),
+    commandBasename: basenames.length
+      ? new RegExp(`(?:^|/)(?:${basenames.join('|')})$`, 'i')
+      : null,
+  };
+  return relayOwnershipPatterns;
+}
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Heuristic: does this process look like Relay or one of its agent CLIs?
+ *
+ * The provider names come from `ProviderDescriptor.processMatch`
+ * (`server/protocol-adapters/index.ts`), so a new provider's CLI is recognized as
+ * soon as it registers. This used to be a hand-maintained regex, and a provider
+ * missing from it had its language-server children silently attributed to nobody.
+ * Command-line matching is substring-based on purpose (paths, wrappers, args);
+ * names too short for that — `pi` — match the command basename instead.
+ */
+export function isRelayOwnedAgentProcess(candidate: {
+  command: string;
+  commandLine: string;
+}): boolean {
+  const patterns = ownershipPatterns();
+  return (
+    patterns.commandLine.test(candidate.commandLine) ||
+    patterns.commandBasename?.test(candidate.command) === true
+  );
+}
+
 export function collectLanguageServerDiagnostics(
   options: ProcessTableOptions = {}
 ): LanguageServerDiagnostics {
@@ -340,13 +403,9 @@ export function collectLanguageServerDiagnostics(
     .filter((proc) => proc.languageServerKind)
     .map((proc) => {
       const ancestors = ancestorsOf(proc, byPid);
-      const relayOwnedLikely = [proc, ...ancestors].some((candidate) => {
-        return (
-          /relay-ide|relayctl|claude|codex|opencode|hermes|prime-agent/i.test(
-            candidate.commandLine
-          ) || /(?:^|\/)pi$/i.test(candidate.command)
-        );
-      });
+      const relayOwnedLikely = [proc, ...ancestors].some((candidate) =>
+        isRelayOwnedAgentProcess(candidate)
+      );
       return {
         pid: proc.pid,
         ppid: proc.ppid,

--- a/server/protocol-adapters/AGENTS.md
+++ b/server/protocol-adapters/AGENTS.md
@@ -33,16 +33,16 @@ fold `providerSessionId` into config — a config-transform hook, not a copy.
 - Capability flags are honest. A flag whose patch cannot render stays `false` —
   see the `telemetry: false` note on `hermes` in `index.ts`.
 
-## Scatter sites a new or renamed provider must also touch
+## One descriptor, no scatter sites
 
-- `server/channel-agent-runtime.ts` `providerResumeId` — the resume-state ladder
-  maps `providerId` to a resume key. **Missing it fails silently**: the provider
-  connects, then loses resume with no error.
-- `index.ts` — launch contract (`command` / `gateway` / `embedded`) and, for
-  bridged adapters, the hand-transcribed capability set.
-- `server/utils.ts` `cleanEnv` plus `index.ts` `sanitizeChannelAdapterProcessEnv`
-  own env stripping. Provider-specific keys go in the contract's
-  `processEnvDenylist`, never at spawn sites.
+`index.ts` `PROVIDER_DESCRIPTORS` is the single home for every provider fact code
+outside this directory needs by name: fill in a row, never re-derive a fact in
+the consumer. An adapter without a descriptor — or a descriptor without an
+adapter — is a COMPILE error, and `test/provider-registry-drift.test.ts` holds
+each consuming seam to the record. Claude-flavored defaults are NAMED fields
+(`yoloPermissionMode`, `isDefaultOrchestratorProvider`) with a value per
+provider; provider env keys go in `launch.processEnvDenylist`, never at spawn
+sites (`server/utils.ts` `cleanEnv` + `sanitizeChannelAdapterProcessEnv`).
 
 ## Sequencing
 

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -61,7 +61,9 @@ const CLAUDE_CAPABILITIES: AgentCapabilitySetV2 = {
   telemetry: true,
   rateLimits: true,
   streaming: true,
-};
+  // `Required<...>`: a new protocol capability must be answered here rather than
+  // read as false by omission. See `Fidelity invariants` in AGENTS.md.
+} satisfies Required<AgentCapabilitySetV2>;
 
 // Claude stream-json has no mapped runtime-control transport. Keep its catalog
 // provider-native until an executable control contract exists; advertising a

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -130,7 +130,9 @@ const CODEX_CAPABILITIES: AgentCapabilitySetV2 = {
   telemetry: true,
   rateLimits: true,
   streaming: true,
-};
+  // `Required<...>`: a new protocol capability must be answered here rather than
+  // read as false by omission. See `Fidelity invariants` in AGENTS.md.
+} satisfies Required<AgentCapabilitySetV2>;
 
 // ── Relay-owned bake-ins ───────────────────────────────────────────────────
 

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -1,4 +1,11 @@
 import type { ProtocolAdapterV2 } from '../protocol-adapter-v2.js';
+import type { AgentCapabilitySetV2 } from '../../shared/agent-chat-protocol-v2.js';
+import {
+  EMPTY_RELAY_CONTROL_CATALOG,
+  RELAY_CONTROL_CATALOGS,
+  type RelayControlCatalog,
+} from '../../shared/agent-command-catalog.js';
+import type { BuiltinFrameworkId } from '../types.js';
 import { MockProtocolAdapterV2 } from './mock-v2-adapter.js';
 import { ClaudeProtocolAdapter } from './claude-adapter.js';
 import { LegacyProtocolAdapterV2Bridge } from './legacy-v2-bridge.js';
@@ -49,26 +56,302 @@ export interface ChannelAdapterLaunchContract {
   processEnvDenylist: readonly string[];
 }
 
-export const v2Adapters = {
-  mock: () => new MockProtocolAdapterV2(),
-  claude: () => new ClaudeProtocolAdapter(),
-  codex: () => new CodexNativeProtocolAdapter(),
-  'prime-agent': () => new PrimeAgentProtocolAdapter(),
-  pi: () => new PiAgentProtocolAdapter(),
-  opencode: () =>
-    new LegacyProtocolAdapterV2Bridge(new OpenCodeProtocolAdapter(), {
+/**
+ * How Relay recognizes this provider's operating-system processes.
+ *
+ * Two lanes because one regex cannot serve both: long CLI names are matched as
+ * substrings of a whole command line (paths, wrappers, and args all count),
+ * while a name as short as `pi` would match almost anything that way and is
+ * therefore matched against the command basename only.
+ */
+export interface ProviderProcessMatch {
+  readonly commandLineSubstrings: readonly string[];
+  readonly commandBasenames: readonly string[];
+}
+
+/**
+ * Home-relative credential paths the node manifest's auth probe checks.
+ *
+ * Presence of any one file means `authed`; declaring none means this provider has
+ * no non-destructive heuristic and reports `unknown`. Paths only — the probe
+ * never reads or reports a token value.
+ */
+export type ProviderAuthCredentialPaths = readonly (readonly string[])[];
+
+/**
+ * Everything outside this directory that has to know a provider by NAME.
+ *
+ * Before this record, each fact below was a hand-maintained table in the module
+ * that consumed it, and a new provider silently inherited whatever an absent key
+ * meant there. The worst case was resume: a provider missing from the old
+ * `providerResumeId` ladder connected, then never resumed, with no error and no
+ * failing test. Those tables are now lookups into this one, and
+ * `v2Adapters satisfies Record<RegisteredChannelProviderId, …>` makes a provider
+ * with an adapter but no descriptor — or a descriptor with no adapter — a
+ * COMPILE error.
+ *
+ * This is DATA consumed by seams that already exist. It is not a new branching
+ * axis: the channel binder still gates on declared capabilities and adapter
+ * method presence, never on a provider id.
+ *
+ * Two facts stay in `shared/` because the frontend reads them and `shared/` must
+ * not import `server/`: the Relay control catalog (referenced by value in
+ * `relayControls`) and the topic-routing allowlist (`BUILTIN_PROVIDER_IDS` in
+ * `shared/workspace-topics.ts`, mirrored by `allowedAsTopicRoutingDefault`).
+ * `test/provider-registry-drift.test.ts` binds both to this record.
+ */
+export interface ProviderDescriptor {
+  /** Registry id. MUST equal this entry's key in `PROVIDER_DESCRIPTORS`. */
+  readonly id: string;
+  /**
+   * `adapter.agentType` — the provider identity on the wire and in legacy v1
+   * chat events. NOT always the registry id: the bridged `opencode-attached`
+   * adapter reports its inner adapter's `'opencode'`.
+   */
+  readonly agentType: string;
+  /**
+   * Terminal framework catalog entry (`server/types.ts` `BUILTIN_FRAMEWORKS`),
+   * or `null` for a channel-only lane with no PTY surface.
+   */
+  readonly terminalFrameworkId: BuiltinFrameworkId | null;
+  /** How the channel adapter starts, and what env a profile may not reintroduce. */
+  readonly launch: ChannelAdapterLaunchContract;
+  /**
+   * Capability set for a provider served through `LegacyProtocolAdapterV2Bridge`;
+   * `null` for a native V2 adapter that declares its own.
+   *
+   * `Required<AgentCapabilitySetV2>` is the drift guard: every flag on the
+   * protocol must be stated, so a new protocol capability is a COMPILE error at
+   * each transcription site instead of an omission that silently reads false.
+   * Stating a flag `false` is not a new claim — an omitted flag was already read
+   * as false everywhere (`declared[capability] === true`); it is the honest
+   * record that this bridge was audited against the flag and cannot back it.
+   */
+  readonly bridgedCapabilities: Required<AgentCapabilitySetV2> | null;
+  /**
+   * Advertised as a channel lane on the framework roster. This is the ONLY home
+   * for that answer: `server/frameworks.ts` projects it onto
+   * `AgentFramework.capabilities.supportsChannelAgents` instead of the framework
+   * catalog declaring a second, independently-editable boolean.
+   */
+  readonly supportsChannelAgents: boolean;
+  /** Mentionable when the host does not pass an explicit known-provider roster. */
+  readonly mentionableByDefault: boolean;
+  /**
+   * Legal as a topic `routingDefaults.providerId` without the `custom:` prefix.
+   * Mirrors `BUILTIN_PROVIDER_IDS` in `shared/workspace-topics.ts`.
+   */
+  readonly allowedAsTopicRoutingDefault: boolean;
+  /**
+   * The ONE persisted provider-session key a resume replays from.
+   *
+   * `null` is a decision, not a hole: it says this provider has no resume key, so
+   * a respawn legitimately starts a fresh provider conversation. Disagreement
+   * with `capabilities.resume` ships only with a written exemption in
+   * `test/provider-registry-drift.test.ts`.
+   */
+  readonly resumeStateKey: string | null;
+  /** Consumes local image attachments delivered in a context packet. */
+  readonly deliversImages: boolean;
+  /** Raw-image byte budget for one packet turn (bounds synchronous encoding). */
+  readonly imageRawByteBudget: number;
+  /** Relay control membership, by reference into the shared catalog. */
+  readonly relayControls: RelayControlCatalog;
+  /** How Relay recognizes this provider's OS processes. */
+  readonly processMatch: ProviderProcessMatch;
+  /** Credential paths for the node manifest auth probe; empty = no heuristic. */
+  readonly authCredentialPaths: ProviderAuthCredentialPaths;
+  /**
+   * The permission-mode word THIS provider's adapter understands for yolo /
+   * permission-bypass spawns, or `null` when it has no such vocabulary.
+   *
+   * `bypassPermissions` is Claude's word. It used to be sent to every provider
+   * because the binder held one constant; audited here, `config.permissionMode`
+   * is read by `claude-adapter.ts` alone, so the other providers declare `null`
+   * rather than inherit a flag they ignore.
+   */
+  readonly yoloPermissionMode: string | null;
+  /**
+   * The provider a channel gets when an orchestrator is designated with no
+   * framework named. Exactly one descriptor may declare it (asserted at load).
+   */
+  readonly isDefaultOrchestratorProvider: boolean;
+}
+
+/**
+ * General raw-image ceiling; bounds synchronous adapter encoding work. Also the
+ * fallback for a framework name no descriptor claims.
+ */
+export const GENERAL_IMAGE_RAW_BYTE_BUDGET = 10 * 1024 * 1024;
+/**
+ * Claude frames images as base64 inside one JSONL stdin frame. Six raw MiB
+ * expands to eight MiB, leaving over a MiB below its 9.5MB line ceiling for
+ * packet text, JSON syntax, and per-block metadata.
+ */
+const CLAUDE_IMAGE_RAW_BYTE_BUDGET = 6 * 1024 * 1024;
+
+export const PROVIDER_DESCRIPTORS = {
+  mock: {
+    id: 'mock',
+    agentType: 'mock',
+    terminalFrameworkId: null,
+    launch: { requirement: { kind: 'embedded' }, processEnvDenylist: [] },
+    bridgedCapabilities: null,
+    // No framework catalog entry, so the double is never rostered; the flag
+    // answers "may this provider serve a channel", which it can and does in the
+    // binder and runtime suites.
+    supportsChannelAgents: true,
+    mentionableByDefault: false,
+    allowedAsTopicRoutingDefault: false,
+    // The fixture double persists `mockSessionId`, but Relay has never resumed
+    // from it and `test/channel-agent-binder.test.ts` pins that key as inert
+    // (#1408). Kept `null` so the record describes behavior instead of changing
+    // it; the disagreement with `capabilities.resume` carries a written
+    // exemption in the drift test.
+    resumeStateKey: null,
+    deliversImages: true,
+    imageRawByteBudget: GENERAL_IMAGE_RAW_BYTE_BUDGET,
+    relayControls: EMPTY_RELAY_CONTROL_CATALOG,
+    processMatch: { commandLineSubstrings: [], commandBasenames: [] },
+    authCredentialPaths: [],
+    // The double exists to exercise Relay's own plumbing, and the binder's yolo
+    // lane is part of that plumbing (test/channel-agent-binder.test.ts).
+    yoloPermissionMode: 'bypassPermissions',
+    isDefaultOrchestratorProvider: false,
+  },
+  claude: {
+    id: 'claude',
+    agentType: 'claude',
+    terminalFrameworkId: 'claude',
+    launch: {
+      requirement: { kind: 'command', command: CLAUDE_CHANNEL_COMMAND },
+      processEnvDenylist: ['CLAUDECODE', 'CLAUDE_CODE_ENTRYPOINT'],
+    },
+    bridgedCapabilities: null,
+    // Channel agents run the persistent-subprocess adapter over stream-json
+    // (claude-adapter.ts + server/claude-stream-client.ts). Re-enabled by #1168
+    // (closes #300): no Agent SDK, real assistant-text streaming, a
+    // fixture-replayed end-to-end round trip, and one live hello-world proof.
+    supportsChannelAgents: true,
+    mentionableByDefault: true,
+    allowedAsTopicRoutingDefault: true,
+    resumeStateKey: 'claudeSessionId',
+    deliversImages: true,
+    imageRawByteBudget: CLAUDE_IMAGE_RAW_BYTE_BUDGET,
+    relayControls: EMPTY_RELAY_CONTROL_CATALOG,
+    processMatch: { commandLineSubstrings: ['claude'], commandBasenames: [] },
+    authCredentialPaths: [
+      ['.claude', '.credentials.json'],
+      ['.config', 'claude', 'credentials.json'],
+    ],
+    yoloPermissionMode: 'bypassPermissions',
+    isDefaultOrchestratorProvider: true,
+  },
+  codex: {
+    id: 'codex',
+    agentType: 'codex',
+    terminalFrameworkId: 'codex',
+    launch: {
+      requirement: { kind: 'command', command: CODEX_CHANNEL_COMMAND },
+      processEnvDenylist: ['CLAUDECODE'],
+    },
+    bridgedCapabilities: null,
+    // Channel agents run the native `codex app-server` JSON-RPC adapter
+    // (codex-native-adapter.ts + server/codex-app-server-client.ts).
+    // Re-advertised by #1169 (closes #301): the adapter maps assistant text
+    // end-to-end, the fake-app-server unit suite asserts the prompt → text-delta
+    // → completion round trip, and one live hello-world proof drove a real
+    // thread. The old `chat:text-delta` gap belonged to the retired hook adapter.
+    supportsChannelAgents: true,
+    mentionableByDefault: true,
+    allowedAsTopicRoutingDefault: true,
+    resumeStateKey: 'threadId',
+    deliversImages: true,
+    imageRawByteBudget: GENERAL_IMAGE_RAW_BYTE_BUDGET,
+    relayControls: RELAY_CONTROL_CATALOGS.codex,
+    processMatch: { commandLineSubstrings: ['codex'], commandBasenames: [] },
+    authCredentialPaths: [['.codex', 'auth.json']],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+  },
+  'prime-agent': {
+    id: 'prime-agent',
+    agentType: 'prime-agent',
+    terminalFrameworkId: 'prime-agent',
+    launch: {
+      requirement: { kind: 'command', command: PRIME_AGENT_CHANNEL_COMMAND },
+      processEnvDenylist: ['CLAUDECODE'],
+    },
+    bridgedCapabilities: null,
+    supportsChannelAgents: true,
+    mentionableByDefault: true,
+    allowedAsTopicRoutingDefault: true,
+    resumeStateKey: 'primeAgentSessionId',
+    deliversImages: false,
+    imageRawByteBudget: GENERAL_IMAGE_RAW_BYTE_BUDGET,
+    relayControls: RELAY_CONTROL_CATALOGS['prime-agent'],
+    processMatch: {
+      commandLineSubstrings: ['prime-agent'],
+      commandBasenames: [],
+    },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+  },
+  pi: {
+    id: 'pi',
+    agentType: 'pi',
+    terminalFrameworkId: 'pi',
+    launch: {
+      requirement: { kind: 'command', command: PI_AGENT_CHANNEL_COMMAND },
+      processEnvDenylist: ['CLAUDECODE'],
+    },
+    bridgedCapabilities: null,
+    supportsChannelAgents: true,
+    mentionableByDefault: true,
+    allowedAsTopicRoutingDefault: true,
+    resumeStateKey: 'piSessionId',
+    deliversImages: false,
+    imageRawByteBudget: GENERAL_IMAGE_RAW_BYTE_BUDGET,
+    relayControls: EMPTY_RELAY_CONTROL_CATALOG,
+    // `pi` is too short to match as a command-line substring.
+    processMatch: { commandLineSubstrings: [], commandBasenames: ['pi'] },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+  },
+  opencode: {
+    id: 'opencode',
+    agentType: 'opencode',
+    terminalFrameworkId: 'opencode',
+    launch: {
+      requirement: { kind: 'command', command: OPENCODE_CHANNEL_COMMAND },
+      processEnvDenylist: [
+        'CLAUDECODE',
+        'OPENCODE_SERVER_PASSWORD',
+        'OPENCODE_SERVER_USERNAME',
+      ],
+    },
+    bridgedCapabilities: {
       text: true,
       reasoning: true,
       tools: true,
       commandExecution: true,
       fileChanges: true,
       approvals: true,
+      questions: false,
+      plans: false,
       slashCommands: false,
       queue: false,
+      steer: false,
       interrupt: true,
       cancelQueued: false,
       resume: false,
+      fork: false,
+      rollback: false,
+      compact: false,
       telemetry: true,
+      rateLimits: false,
       // `OpenCodeProtocolAdapter.handleMessagePartUpdated` fires
       // `chat:text-delta` per `message.part.updated`, and
       // `mapChatEventToAgentPatchV2` DOES have a case for it, so the bridge
@@ -76,39 +359,104 @@ export const v2Adapters = {
       // hermes `telemetry` gap below, the compat mapping exists — the flag was
       // just never set.
       streaming: true,
-    }),
-  'opencode-attached': () =>
-    new LegacyProtocolAdapterV2Bridge(new OpenCodeAttachedAdapter(), {
+    },
+    supportsChannelAgents: true,
+    mentionableByDefault: true,
+    allowedAsTopicRoutingDefault: true,
+    resumeStateKey: null,
+    deliversImages: false,
+    imageRawByteBudget: GENERAL_IMAGE_RAW_BYTE_BUDGET,
+    relayControls: EMPTY_RELAY_CONTROL_CATALOG,
+    processMatch: { commandLineSubstrings: ['opencode'], commandBasenames: [] },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+  },
+  'opencode-attached': {
+    id: 'opencode-attached',
+    // The bridge inherits the inner adapter's identity: attached and spawned
+    // OpenCode are one provider on the wire, two registry lanes.
+    agentType: 'opencode',
+    terminalFrameworkId: null,
+    launch: {
+      requirement: {
+        kind: 'gateway',
+        gateway: 'opencode-attached',
+        probe: probeOpenCodeAttachedApi,
+      },
+      processEnvDenylist: [],
+    },
+    bridgedCapabilities: {
       text: true,
       reasoning: true,
       tools: true,
       commandExecution: true,
       fileChanges: true,
       approvals: true,
+      questions: false,
+      plans: false,
       slashCommands: false,
       queue: false,
+      steer: false,
       interrupt: true,
       cancelQueued: false,
       resume: false,
+      fork: false,
+      rollback: false,
+      compact: false,
       telemetry: true,
+      rateLimits: false,
       // Same as `opencode`: the attached adapter's `message.part.updated`
       // handler fires `chat:text-delta` whenever the event carries a string
       // delta.
       streaming: true,
-    }),
-  hermes: () =>
-    new LegacyProtocolAdapterV2Bridge(new HermesProtocolAdapter(), {
+    },
+    // Reachable by explicit provider id; not rostered, because attached OpenCode
+    // has no framework catalog entry of its own (`terminalFrameworkId: null`).
+    supportsChannelAgents: true,
+    mentionableByDefault: false,
+    allowedAsTopicRoutingDefault: false,
+    resumeStateKey: null,
+    deliversImages: false,
+    imageRawByteBudget: GENERAL_IMAGE_RAW_BYTE_BUDGET,
+    relayControls: EMPTY_RELAY_CONTROL_CATALOG,
+    // Attached sessions reach an already-running server; Relay spawns nothing.
+    processMatch: { commandLineSubstrings: [], commandBasenames: [] },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+  },
+  hermes: {
+    id: 'hermes',
+    agentType: 'hermes',
+    terminalFrameworkId: 'hermes',
+    // Hermes channel sessions attach to the HTTP gateway and spawn no local CLI.
+    launch: {
+      requirement: {
+        kind: 'gateway',
+        gateway: 'hermes',
+        probe: probeHermesGatewayApi,
+      },
+      processEnvDenylist: [],
+    },
+    bridgedCapabilities: {
       text: true,
       reasoning: true,
       tools: true,
       commandExecution: true,
       fileChanges: true,
       approvals: true,
+      questions: false,
+      plans: false,
       slashCommands: false,
       queue: false,
+      steer: false,
       interrupt: true,
       cancelQueued: false,
       resume: true,
+      fork: false,
+      rollback: false,
+      compact: false,
       // `HermesProtocolAdapter` emits `chat:telemetry`, but
       // `mapChatEventToAgentPatchV2` has no case for it yet, so
       // `LegacyProtocolAdapterV2Bridge` silently drops it before it reaches the
@@ -116,69 +464,163 @@ export const v2Adapters = {
       // above). Keep this `false` until that compat mapping exists so the
       // capability bit doesn't advertise a feature that can't render.
       telemetry: false,
-    }),
-} satisfies Record<string, () => ProtocolAdapterV2>;
+      rateLimits: false,
+      // Left unset until the gateway emits `response.output_text.delta`
+      // (#1305); now stated explicitly because the transcription must be total.
+      streaming: false,
+    },
+    supportsChannelAgents: true,
+    mentionableByDefault: true,
+    allowedAsTopicRoutingDefault: true,
+    resumeStateKey: 'hermesResponseId',
+    deliversImages: true,
+    imageRawByteBudget: GENERAL_IMAGE_RAW_BYTE_BUDGET,
+    relayControls: EMPTY_RELAY_CONTROL_CATALOG,
+    processMatch: { commandLineSubstrings: ['hermes'], commandBasenames: [] },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+  },
+} satisfies Record<string, ProviderDescriptor>;
 
 /**
- * Kept exhaustive against the adapter factory keys. Adding a registered adapter
- * without declaring how it launches is therefore a type error rather than a
- * silently unavailable roster entry.
+ * The registered channel-provider roster: exactly the keys of
+ * `PROVIDER_DESCRIPTORS`, which `v2Adapters` is held to below.
+ *
+ * Scatter sites outside this directory key their lookups on this so a new or
+ * renamed provider is a compile error there rather than a silent omission.
  */
-export const CHANNEL_ADAPTER_LAUNCH_CONTRACTS = {
-  mock: { requirement: { kind: 'embedded' }, processEnvDenylist: [] },
-  claude: {
-    requirement: { kind: 'command', command: CLAUDE_CHANNEL_COMMAND },
-    processEnvDenylist: ['CLAUDECODE', 'CLAUDE_CODE_ENTRYPOINT'],
-  },
-  codex: {
-    requirement: { kind: 'command', command: CODEX_CHANNEL_COMMAND },
-    processEnvDenylist: ['CLAUDECODE'],
-  },
-  'prime-agent': {
-    requirement: { kind: 'command', command: PRIME_AGENT_CHANNEL_COMMAND },
-    processEnvDenylist: ['CLAUDECODE'],
-  },
-  pi: {
-    requirement: { kind: 'command', command: PI_AGENT_CHANNEL_COMMAND },
-    processEnvDenylist: ['CLAUDECODE'],
-  },
-  opencode: {
-    requirement: { kind: 'command', command: OPENCODE_CHANNEL_COMMAND },
-    processEnvDenylist: [
-      'CLAUDECODE',
-      'OPENCODE_SERVER_PASSWORD',
-      'OPENCODE_SERVER_USERNAME',
-    ],
-  },
-  'opencode-attached': {
-    requirement: {
-      kind: 'gateway',
-      gateway: 'opencode-attached',
-      probe: probeOpenCodeAttachedApi,
-    },
-    processEnvDenylist: [],
-  },
-  // Hermes channel sessions attach to the HTTP gateway and spawn no local CLI.
-  hermes: {
-    requirement: {
-      kind: 'gateway',
-      gateway: 'hermes',
-      probe: probeHermesGatewayApi,
-    },
-    processEnvDenylist: [],
-  },
-} satisfies Record<keyof typeof v2Adapters, ChannelAdapterLaunchContract>;
+export type RegisteredChannelProviderId = keyof typeof PROVIDER_DESCRIPTORS;
+
+/**
+ * `satisfies Record<RegisteredChannelProviderId, …>` is the two-way gate:
+ * a registered adapter with no descriptor is an excess-property error, and a
+ * descriptor with no adapter is a missing-property error. Bridged adapters read
+ * their capability transcription straight out of the descriptor so capability
+ * truth has one home.
+ */
+export const v2Adapters = {
+  mock: () => new MockProtocolAdapterV2(),
+  claude: () => new ClaudeProtocolAdapter(),
+  codex: () => new CodexNativeProtocolAdapter(),
+  'prime-agent': () => new PrimeAgentProtocolAdapter(),
+  pi: () => new PiAgentProtocolAdapter(),
+  opencode: () =>
+    new LegacyProtocolAdapterV2Bridge(
+      new OpenCodeProtocolAdapter(),
+      PROVIDER_DESCRIPTORS.opencode.bridgedCapabilities
+    ),
+  'opencode-attached': () =>
+    new LegacyProtocolAdapterV2Bridge(
+      new OpenCodeAttachedAdapter(),
+      PROVIDER_DESCRIPTORS['opencode-attached'].bridgedCapabilities
+    ),
+  hermes: () =>
+    new LegacyProtocolAdapterV2Bridge(
+      new HermesProtocolAdapter(),
+      PROVIDER_DESCRIPTORS.hermes.bridgedCapabilities
+    ),
+} satisfies Record<RegisteredChannelProviderId, () => ProtocolAdapterV2>;
+
+// The registry is read from a dozen modules; nobody may mutate it. Statements,
+// not an `Object.freeze(...)` expression, so the literal types survive.
+//
+// The freeze reaches every descriptor-owned object and array, not just the top
+// level: `bridgedCapabilities` in particular is now ONE object handed to every
+// `LegacyProtocolAdapterV2Bridge` instance of a provider as its public
+// `adapter.capabilities`, so a single mutation there would poison every other
+// live instance and the registry with it. (`relayControls` is a reference into
+// `shared/agent-command-catalog.ts`, which owns its own immutability; readers
+// there clone.)
+for (const descriptor of Object.values(PROVIDER_DESCRIPTORS)) {
+  Object.freeze(descriptor.launch.requirement);
+  Object.freeze(descriptor.launch.processEnvDenylist);
+  Object.freeze(descriptor.launch);
+  Object.freeze(descriptor.processMatch.commandLineSubstrings);
+  Object.freeze(descriptor.processMatch.commandBasenames);
+  Object.freeze(descriptor.processMatch);
+  for (const segments of descriptor.authCredentialPaths)
+    Object.freeze(segments);
+  Object.freeze(descriptor.authCredentialPaths);
+  if (descriptor.bridgedCapabilities)
+    Object.freeze(descriptor.bridgedCapabilities);
+  Object.freeze(descriptor);
+}
+Object.freeze(PROVIDER_DESCRIPTORS);
+
+const DESCRIPTOR_BY_ID = PROVIDER_DESCRIPTORS as Record<
+  string,
+  ProviderDescriptor | undefined
+>;
+
+/** The descriptor for a registered provider, or `undefined` for a stranger. */
+export function providerDescriptor(
+  providerId: string
+): ProviderDescriptor | undefined {
+  return DESCRIPTOR_BY_ID[providerId];
+}
+
+/** Every registered provider descriptor, in registration order. */
+export function providerDescriptors(): readonly ProviderDescriptor[] {
+  return Object.values(PROVIDER_DESCRIPTORS);
+}
+
+/**
+ * Kept exhaustive against the descriptor roster, and therefore against the
+ * adapter factories. Derived rather than declared so a launch contract cannot
+ * drift from the descriptor that owns it; the shape is unchanged for callers.
+ */
+export const CHANNEL_ADAPTER_LAUNCH_CONTRACTS = Object.freeze(
+  Object.fromEntries(
+    Object.entries(PROVIDER_DESCRIPTORS).map(([providerId, descriptor]) => [
+      providerId,
+      descriptor.launch,
+    ])
+  )
+) as {
+  [K in RegisteredChannelProviderId]: (typeof PROVIDER_DESCRIPTORS)[K]['launch'];
+};
 
 export function channelAdapterLaunchRequirement(
   providerId: string
 ): ChannelAdapterLaunchRequirement | undefined {
-  return (
-    CHANNEL_ADAPTER_LAUNCH_CONTRACTS as Record<
-      string,
-      ChannelAdapterLaunchContract
-    >
-  )[providerId]?.requirement;
+  return providerDescriptor(providerId)?.launch.requirement;
 }
+
+/**
+ * Does this provider advertise a channel lane at all?
+ *
+ * `server/frameworks.ts` projects this onto
+ * `AgentFramework.capabilities.supportsChannelAgents` so channel availability is
+ * decided by the descriptor rather than by a second boolean in the terminal
+ * framework catalog that could disagree with it.
+ */
+export function providerSupportsChannelAgents(providerId: string): boolean {
+  return providerDescriptor(providerId)?.supportsChannelAgents === true;
+}
+
+/** Providers mentionable when the host passes no explicit roster. */
+export function defaultMentionableProviderIds(): readonly string[] {
+  return providerDescriptors()
+    .filter((descriptor) => descriptor.mentionableByDefault)
+    .map((descriptor) => descriptor.id);
+}
+
+/**
+ * The provider a channel gets when an orchestrator is designated without a
+ * framework. Resolved from the descriptors so the default has one home instead
+ * of a `'claude'` literal at each designation site.
+ */
+export const DEFAULT_ORCHESTRATOR_PROVIDER_ID = ((): string => {
+  const declared = providerDescriptors().filter(
+    (descriptor) => descriptor.isDefaultOrchestratorProvider
+  );
+  if (declared.length !== 1)
+    throw new Error(
+      `exactly one provider descriptor must set isDefaultOrchestratorProvider; found ${declared.length}`
+    );
+  return declared[0]!.id;
+})();
 
 export function sanitizeChannelAdapterProcessEnv(
   providerId: string,
@@ -186,13 +628,8 @@ export function sanitizeChannelAdapterProcessEnv(
   platform: NodeJS.Platform = process.platform
 ): Record<string, string> {
   const sanitized = { ...processEnv };
-  const contract = (
-    CHANNEL_ADAPTER_LAUNCH_CONTRACTS as Record<
-      string,
-      ChannelAdapterLaunchContract
-    >
-  )[providerId];
-  const denied = contract?.processEnvDenylist ?? [];
+  const denied =
+    providerDescriptor(providerId)?.launch.processEnvDenylist ?? [];
   if (platform === 'win32') {
     const foldedDenylist = new Set(denied.map((key) => key.toUpperCase()));
     for (const key of Object.keys(sanitized)) {

--- a/server/protocol-adapters/mock-v2-adapter.ts
+++ b/server/protocol-adapters/mock-v2-adapter.ts
@@ -75,6 +75,10 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     plans: true,
     slashCommands: true,
     queue: true,
+    // The fixture double has no `steerMessage`, so this stays false even though
+    // every other flag is on: a declared-true flag with no implementation is the
+    // dishonest-capability case AGENTS.md forbids.
+    steer: false,
     interrupt: true,
     cancelQueued: true,
     resume: true,
@@ -84,7 +88,9 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     telemetry: true,
     rateLimits: true,
     streaming: true,
-  };
+    // `Required<...>`: a new protocol capability must be answered here rather
+    // than read as false by omission. See `Fidelity invariants` in AGENTS.md.
+  } satisfies Required<AgentCapabilitySetV2>;
 
   private _status: AdapterStatus = 'disconnected';
   private config: AdapterConfig | null = null;

--- a/server/protocol-adapters/pi-agent-adapter.ts
+++ b/server/protocol-adapters/pi-agent-adapter.ts
@@ -36,6 +36,8 @@ const CAPABILITIES: AgentCapabilitySetV2 = {
   plans: false,
   slashCommands: false,
   queue: true,
+  // No native mid-turn injection boundary, and no `steerMessage` implementation.
+  steer: false,
   cancelQueued: false,
   interrupt: true,
   resume: true,
@@ -45,7 +47,9 @@ const CAPABILITIES: AgentCapabilitySetV2 = {
   telemetry: true,
   rateLimits: false,
   streaming: true,
-};
+  // `Required<...>`: a new protocol capability must be answered here rather than
+  // read as false by omission. See `Fidelity invariants` in AGENTS.md.
+} satisfies Required<AgentCapabilitySetV2>;
 
 type ClientFactory = (options: PiAgentRpcClientOptions) => PiAgentRpcClient;
 type RpcRecord = Record<string, unknown>;

--- a/server/protocol-adapters/prime-agent-adapter.ts
+++ b/server/protocol-adapters/prime-agent-adapter.ts
@@ -43,6 +43,8 @@ const CAPABILITIES: AgentCapabilitySetV2 = {
   plans: false,
   slashCommands: true,
   queue: true,
+  // No native mid-turn injection boundary, and no `steerMessage` implementation.
+  steer: false,
   cancelQueued: false,
   interrupt: true,
   resume: true,
@@ -52,7 +54,9 @@ const CAPABILITIES: AgentCapabilitySetV2 = {
   telemetry: true,
   rateLimits: false,
   streaming: true,
-};
+  // `Required<...>`: a new protocol capability must be answered here rather than
+  // read as false by omission. See `Fidelity invariants` in AGENTS.md.
+} satisfies Required<AgentCapabilitySetV2>;
 
 type ClientFactory = (
   options: PrimeAgentRpcClientOptions

--- a/server/types.ts
+++ b/server/types.ts
@@ -83,6 +83,15 @@ export interface AgentFramework {
     supportsYolo: boolean;
     supportsTelemetry: boolean;
     supportsAttachedRuntime: boolean;
+    /**
+     * Whether this framework is available as a channel agent lane.
+     *
+     * NOT declared here: `server/frameworks.ts` projects it from
+     * `ProviderDescriptor.supportsChannelAgents`
+     * (`server/protocol-adapters/index.ts`), which is the single home for that
+     * answer. A hand-written boolean here was a second registry that could
+     * disagree with whether an adapter is registered at all.
+     */
     supportsChannelAgents?: boolean;
   };
 }
@@ -102,12 +111,6 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: true,
-      // Channel agents run the persistent-subprocess adapter over stream-json
-      // (server/protocol-adapters/claude-adapter.ts + server/claude-stream-client.ts).
-      // Re-enabled by #1168 (closes #300): no Agent SDK, real assistant-text
-      // streaming, fixture-replayed end-to-end round-trip, and one live
-      // hello-world proof. See the #1168 PR for verification evidence.
-      supportsChannelAgents: true,
     },
   },
   codex: {
@@ -124,16 +127,6 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: false,
       supportsAttachedRuntime: false,
-      // Channel agents run the native `codex app-server` JSON-RPC adapter
-      // (server/protocol-adapters/codex-native-adapter.ts +
-      // server/codex-app-server-client.ts). Re-advertised by #1169 (closes
-      // #301): the adapter maps assistant text end-to-end
-      // (`item/agentMessage/delta` → `agent-item-delta-v2`, plus item
-      // started/completed and `turn/completed`), the fake-app-server unit suite
-      // asserts the prompt → text-delta → completion round-trip, and one live
-      // hello-world proof drove the built adapter through a real thread. The
-      // old `chat:text-delta` gap belonged to the retired hook-based adapter.
-      supportsChannelAgents: true,
     },
   },
   opencode: {
@@ -168,7 +161,6 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: true,
-      supportsChannelAgents: true,
     },
   },
   hermes: {
@@ -185,7 +177,6 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: true,
-      supportsChannelAgents: true,
     },
   },
   'prime-agent': {
@@ -204,7 +195,6 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: false,
       supportsTelemetry: true,
       supportsAttachedRuntime: false,
-      supportsChannelAgents: true,
     },
   },
   pi: {
@@ -223,7 +213,6 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: false,
       supportsTelemetry: true,
       supportsAttachedRuntime: false,
-      supportsChannelAgents: true,
     },
   },
 };

--- a/shared/agent-command-catalog.ts
+++ b/shared/agent-command-catalog.ts
@@ -166,11 +166,61 @@ const PRIME_AGENT_CONTROL_DEFINITIONS: AgentSlashCommandV2[] = [
   },
 ];
 
+/** One provider's Relay controls: what it advertises, and what it reserves. */
+export interface RelayControlCatalog {
+  /** Advertised to the composer and roster before any runtime has bound. */
+  readonly advertised: readonly AgentSlashCommandV2[];
+  /**
+   * Reserved from ordinary channel prose. Always a superset of `advertised`: a
+   * control that can be dispatched but not reserved would leak onto the
+   * ordinary-message lane.
+   */
+  readonly guarded: readonly AgentSlashCommandV2[];
+}
+
+/** A provider with no Relay controls. Shared so the empty case has one identity. */
+export const EMPTY_RELAY_CONTROL_CATALOG: RelayControlCatalog = Object.freeze({
+  advertised: Object.freeze([]),
+  guarded: Object.freeze([]),
+});
+
+/**
+ * Provider control membership, keyed by provider id.
+ *
+ * This lives in `shared/` because the frontend composer reads it directly
+ * (`frontend/src/components/chat/ChannelComposer.tsx`) and `shared/` must not
+ * import from `server/`. The channel-provider descriptor
+ * (`server/protocol-adapters/index.ts`) therefore *references* these entries by
+ * value rather than restating them, and `test/provider-registry-drift.test.ts`
+ * asserts the reference identity so the two homes can never disagree.
+ */
+export const RELAY_CONTROL_CATALOGS = {
+  codex: { advertised: CODEX_CONTROLS, guarded: CODEX_CONTROLS },
+  // Prime's controls are definitions for its connected adapter to narrow by
+  // live discovery, so nothing is advertised pre-bind — but they stay reserved.
+  'prime-agent': {
+    advertised: EMPTY_RELAY_CONTROL_CATALOG.advertised,
+    guarded: PRIME_AGENT_CONTROL_DEFINITIONS,
+  },
+} satisfies Record<string, RelayControlCatalog>;
+
+/** The catalog a provider uses, or the shared empty one. */
+export function relayControlCatalogEntryForProvider(
+  providerId: string
+): RelayControlCatalog {
+  return (
+    (RELAY_CONTROL_CATALOGS as Record<string, RelayControlCatalog | undefined>)[
+      providerId
+    ] ?? EMPTY_RELAY_CONTROL_CATALOG
+  );
+}
+
 export function relayControlCatalogForProvider(
   providerId: string
 ): AgentSlashCommandV2[] {
-  const controls = providerId === 'codex' ? CODEX_CONTROLS : [];
-  return cloneCatalog(controls);
+  return cloneCatalog(
+    relayControlCatalogEntryForProvider(providerId).advertised
+  );
 }
 
 /**
@@ -190,16 +240,12 @@ export function primeAgentControlDefinitions(): AgentSlashCommandV2[] {
 export function relayControlInputGuardCatalogForProvider(
   providerId: string
 ): AgentSlashCommandV2[] {
-  const controls =
-    providerId === 'prime-agent'
-      ? PRIME_AGENT_CONTROL_DEFINITIONS
-      : providerId === 'codex'
-        ? CODEX_CONTROLS
-        : [];
-  return cloneCatalog(controls);
+  return cloneCatalog(relayControlCatalogEntryForProvider(providerId).guarded);
 }
 
-function cloneCatalog(controls: AgentSlashCommandV2[]): AgentSlashCommandV2[] {
+function cloneCatalog(
+  controls: readonly AgentSlashCommandV2[]
+): AgentSlashCommandV2[] {
   return controls.map((command) => ({
     ...command,
     ...(command.aliases ? { aliases: [...command.aliases] } : {}),

--- a/shared/workspace-topics.ts
+++ b/shared/workspace-topics.ts
@@ -408,7 +408,18 @@ const SECRET_KEY_PATTERN =
 const SECRET_VALUE_PATTERN =
   /(bearer\s+[A-Za-z0-9._~+/=-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|relay-sac-v1\.|BEGIN [A-Z ]*PRIVATE KEY)/i;
 const CUSTOM_PROVIDER_PATTERN = /^custom:[A-Za-z0-9._-]{1,80}$/;
-const BUILTIN_PROVIDER_IDS = new Set([
+/**
+ * Provider ids a topic's `routingDefaults.providerId` may name without the
+ * `custom:` prefix. `terminal` is the non-agent routing lane, not an adapter.
+ *
+ * The declaration of record is `ProviderDescriptor.allowedAsTopicRoutingDefault`
+ * (`server/protocol-adapters/index.ts`). This set has to be restated here because
+ * `shared/` must not import from `server/` and the topic validator runs on both
+ * sides; `test/provider-registry-drift.test.ts` binds the two in both directions,
+ * so a registered provider missing here (its topic routing default REJECTED by
+ * `assertProviderId`) or a name no adapter serves fails the drift suite.
+ */
+export const BUILTIN_PROVIDER_IDS: ReadonlySet<string> = new Set([
   'claude',
   'codex',
   'opencode',

--- a/test/channel-context-packet.test.ts
+++ b/test/channel-context-packet.test.ts
@@ -6,14 +6,15 @@ import * as path from 'node:path';
 import {
   buildMentionContextPacket,
   buildMentionContextPacketEnvelope,
-  CLAUDE_PACKET_IMAGE_MAX_RAW_BYTES,
-  PACKET_FRAMEWORK_IMAGE_SUPPORT,
   PACKET_IMAGE_MAX_COUNT,
   PACKET_MAX_ROWS,
   PACKET_ROW_MAX_CHARS,
   PACKET_MAX_BYTES,
   resolveMentionContextPacket,
 } from '../server/channel-context-packet.js';
+// Image delivery and the raw-byte budget are per-provider descriptor fields
+// (`server/protocol-adapters/index.ts`), not local tables in the packet builder.
+import { providerDescriptor } from '../server/protocol-adapters/index.js';
 import type { ChannelAttachmentStore } from '../server/channel-attachments.js';
 import type {
   ChannelAttachmentId,
@@ -197,8 +198,8 @@ describe('buildMentionContextPacket', () => {
       } as ChannelAttachmentStore
     );
 
-    expect(PACKET_FRAMEWORK_IMAGE_SUPPORT.opencode).toBe(false);
-    expect(PACKET_FRAMEWORK_IMAGE_SUPPORT.mock).toBe(true);
+    expect(providerDescriptor('opencode')?.deliversImages).toBe(false);
+    expect(providerDescriptor('mock')?.deliversImages).toBe(true);
     expect(storeReads).toBe(0);
     expect(resolved.attachments).toEqual([]);
     expect(resolved.content).toBe(
@@ -369,7 +370,9 @@ describe('buildMentionContextPacket', () => {
         }),
         store
       );
-      expect(CLAUDE_PACKET_IMAGE_MAX_RAW_BYTES).toBe(6 * 1024 * 1024);
+      expect(providerDescriptor('claude')?.imageRawByteBudget).toBe(
+        6 * 1024 * 1024
+      );
       expect(
         resolved.attachments.map((item) => path.basename(item.path))
       ).toEqual(['trigger-large.png', 'context-fits.png']);

--- a/test/framework-availability.test.ts
+++ b/test/framework-availability.test.ts
@@ -3,9 +3,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  frameworkCapabilitiesWithChannelLane,
   getFrameworkAvailability,
   getFrameworkChannelAvailability,
   getFrameworkClientInfo,
+  listConfiguredFrameworks,
   resolveExecutablePath,
 } from '../server/frameworks.js';
 import type { AgentFramework } from '../server/types.js';
@@ -223,6 +225,38 @@ describe('framework CLI availability', () => {
       available: false,
       reason: 'future-agent has no registered channel runtime.',
     });
+  });
+
+  it('ignores a config override that tries to toggle the channel lane', async () => {
+    // Deliberate delta: the provider descriptor is the ONE channel-lane gate, so
+    // `config.frameworks.<id>.capabilities.supportsChannelAgents` decides nothing
+    // in either direction. The claim direction is pinned by the fail-closed test
+    // above (a custom framework with no descriptor stays unavailable); this pins
+    // the disable direction, which the old deep-merged catalog boolean honored.
+    const disabled = listConfiguredFrameworks({
+      claude: {
+        capabilities: {
+          supportsHooks: true,
+          supportsContinue: true,
+          supportsYolo: true,
+          supportsTelemetry: true,
+          supportsAttachedRuntime: true,
+          supportsChannelAgents: false,
+        },
+      },
+    }).find((framework) => framework.id === 'claude');
+
+    expect(disabled?.capabilities.supportsChannelAgents).toBe(false);
+    expect(
+      frameworkCapabilitiesWithChannelLane(disabled!).supportsChannelAgents
+    ).toBe(true);
+    await expect(
+      getFrameworkChannelAvailability(
+        disabled!,
+        { PATH: '' },
+        { probeLaunchCommand: false }
+      )
+    ).resolves.toEqual({ available: true, command: 'claude' });
   });
 
   it('includes custom future frameworks in the client list', () => {

--- a/test/framework-types.test.ts
+++ b/test/framework-types.test.ts
@@ -7,6 +7,7 @@ import {
   resolveFramework,
 } from '../server/types.js';
 import type { AgentFramework, EventSourceType } from '../server/types.js';
+import { frameworkCapabilitiesWithChannelLane } from '../server/frameworks.js';
 
 // ── BUILTIN_FRAMEWORKS structure ──
 
@@ -40,7 +41,13 @@ test('claude framework has correct values', () => {
 // round-trip, and one live hello-world proof.
 test('claude advertises the channel-agent capability (#1168)', () => {
   const claude = BUILTIN_FRAMEWORKS['claude'];
-  expect(claude.capabilities.supportsChannelAgents).toBe(true);
+  // The channel lane is declared once, on the provider descriptor
+  // (`server/protocol-adapters/index.ts`), and projected onto the framework
+  // capabilities — the catalog no longer carries its own boolean.
+  expect(claude.capabilities.supportsChannelAgents).toBeUndefined();
+  expect(
+    frameworkCapabilitiesWithChannelLane(claude).supportsChannelAgents
+  ).toBe(true);
 });
 
 test('codex framework has correct values', () => {
@@ -64,7 +71,9 @@ test('codex framework has correct values', () => {
   // #1169 (closes #301): Codex channel agents are advertised. The native
   // `codex app-server` adapter maps assistant text end-to-end and the
   // fake-app-server suite asserts prompt → text-delta → completion.
-  expect(codex.capabilities.supportsChannelAgents).toBe(true);
+  expect(
+    frameworkCapabilitiesWithChannelLane(codex).supportsChannelAgents
+  ).toBe(true);
 });
 
 test('opencode framework has correct values', () => {
@@ -96,7 +105,9 @@ test('hermes framework has correct values', () => {
   expect(hermes.capabilities.supportsYolo).toBe(true);
   expect(hermes.capabilities.supportsTelemetry).toBe(true);
   expect(hermes.capabilities.supportsAttachedRuntime).toBe(true);
-  expect(hermes.capabilities.supportsChannelAgents).toBe(true);
+  expect(
+    frameworkCapabilitiesWithChannelLane(hermes).supportsChannelAgents
+  ).toBe(true);
 });
 
 test('prime-agent framework exposes native channels and a generic PTY', () => {
@@ -114,8 +125,10 @@ test('prime-agent framework exposes native channels and a generic PTY', () => {
     supportsYolo: false,
     supportsTelemetry: true,
     supportsAttachedRuntime: false,
-    supportsChannelAgents: true,
   });
+  expect(
+    frameworkCapabilitiesWithChannelLane(prime).supportsChannelAgents
+  ).toBe(true);
 });
 
 test('pi framework exposes native channels and a generic PTY', () => {
@@ -133,8 +146,10 @@ test('pi framework exposes native channels and a generic PTY', () => {
     supportsYolo: false,
     supportsTelemetry: true,
     supportsAttachedRuntime: false,
-    supportsChannelAgents: true,
   });
+  expect(frameworkCapabilitiesWithChannelLane(pi).supportsChannelAgents).toBe(
+    true
+  );
 });
 
 test('opencode yoloEnv contains OPENCODE_CONFIG_CONTENT with permission JSON', () => {

--- a/test/mock-v2-adapter.test.ts
+++ b/test/mock-v2-adapter.test.ts
@@ -550,7 +550,7 @@ describe('MockProtocolAdapterV2', () => {
     expect(createAdapterV2('mock')).toBeInstanceOf(MockProtocolAdapterV2);
   });
 
-  it('advertises the full v2 UI capability superset', () => {
+  it('advertises every v2 UI capability it can actually back', () => {
     const adapter = new MockProtocolAdapterV2(zeroDelays);
 
     expect(adapter.capabilities).toEqual({
@@ -564,6 +564,9 @@ describe('MockProtocolAdapterV2', () => {
       plans: true,
       slashCommands: true,
       queue: true,
+      // The one exception to "everything on": there is no `steerMessage` here, so
+      // a true flag would be a capability the double cannot honor.
+      steer: false,
       interrupt: true,
       cancelQueued: true,
       resume: true,
@@ -610,7 +613,9 @@ describe('MockProtocolAdapterV2', () => {
 
     await adapter.resumeSession('mock-session-abc');
 
-    const snapshot = patches.find((p) => p.type === 'agent-session-snapshot-v2');
+    const snapshot = patches.find(
+      (p) => p.type === 'agent-session-snapshot-v2'
+    );
     expect(snapshot).toMatchObject({
       type: 'agent-session-snapshot-v2',
       session: expect.objectContaining({

--- a/test/provider-registry-drift.test.ts
+++ b/test/provider-registry-drift.test.ts
@@ -1,0 +1,832 @@
+/**
+ * Provider-registry drift guards.
+ *
+ * `server/protocol-adapters/index.ts` holds ONE record — `PROVIDER_DESCRIPTORS` —
+ * for every fact about a provider that code outside that directory needs to know
+ * by name. Each of those facts used to be a hand-maintained table in the module
+ * that consumed it, and at least one failed silently: a provider missing from the
+ * old `providerResumeId` ladder connected, then never resumed, with no error, no
+ * type error, and no test.
+ *
+ * `v2Adapters satisfies Record<RegisteredChannelProviderId, …>` is the primary
+ * gate and it is a COMPILE error in both directions (adapter without descriptor,
+ * descriptor without adapter). This file is the second half: it holds each
+ * CONSUMING SEAM to the descriptor, so collapsing the old tables into a registry
+ * cannot quietly disconnect the registry from the code that reads it. The
+ * expectation table records what the code does today — a row that looks wrong is a
+ * finding to fix in its own slice, not something to silently "generalize" here.
+ *
+ * Compile-time backpressure has to live in the source (`PROVIDER_DESCRIPTORS` and
+ * the `ProviderDescriptor` interface): this repo's `test/tsconfig.json` typechecks
+ * only `shared/**` plus one named file, so a `satisfies` clause in a test file is
+ * documentation, not a gate.
+ *
+ * Run: `npx vitest run test/provider-registry-drift.test.ts`
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  CHANNEL_ADAPTER_LAUNCH_CONTRACTS,
+  DEFAULT_ORCHESTRATOR_PROVIDER_ID,
+  PROVIDER_DESCRIPTORS,
+  providerDescriptor,
+  providerDescriptors,
+  v2Adapters,
+  type ProviderDescriptor,
+  type RegisteredChannelProviderId,
+} from '../server/protocol-adapters/index.js';
+import { LegacyProtocolAdapterV2Bridge } from '../server/protocol-adapters/legacy-v2-bridge.js';
+import type { ProtocolAdapterV2 } from '../server/protocol-adapter-v2.js';
+import type { AgentCapabilitySetV2 } from '../shared/agent-chat-protocol-v2.js';
+import { providerResumeId } from '../server/channel-agent-runtime.js';
+import { DEFAULT_KNOWN_PROVIDER_IDS } from '../server/channel-chat-router.js';
+import { BUILTIN_PROVIDER_IDS } from '../shared/workspace-topics.js';
+import { BUILTIN_FRAMEWORKS } from '../server/types.js';
+import { frameworkCapabilitiesWithChannelLane } from '../server/frameworks.js';
+import { isRelayOwnedAgentProcess } from '../server/process-tree.js';
+import { probeAgentAuthStatus } from '../server/node-manifest-build.js';
+import {
+  relayControlCatalogEntryForProvider,
+  relayControlCatalogForProvider,
+  relayControlInputGuardCatalogForProvider,
+} from '../shared/agent-command-catalog.js';
+import { isChatEvent } from '../shared/chat-events.js';
+
+/**
+ * Every flag on `AgentCapabilitySetV2`. `Record<keyof …>` requires all of them,
+ * so a new protocol capability fails to compile here until this list is updated
+ * — which is the prompt to audit each adapter's declaration for it.
+ */
+const ALL_CAPABILITY_FLAGS = {
+  text: true,
+  reasoning: true,
+  tools: true,
+  commandExecution: true,
+  fileChanges: true,
+  approvals: true,
+  questions: true,
+  plans: true,
+  slashCommands: true,
+  queue: true,
+  steer: true,
+  interrupt: true,
+  cancelQueued: true,
+  resume: true,
+  fork: true,
+  rollback: true,
+  compact: true,
+  telemetry: true,
+  rateLimits: true,
+  streaming: true,
+} satisfies Record<keyof AgentCapabilitySetV2, true>;
+
+const CAPABILITY_FLAG_NAMES = Object.keys(
+  ALL_CAPABILITY_FLAGS
+) as (keyof AgentCapabilitySetV2)[];
+
+interface ProviderDriftExpectation {
+  /**
+   * `adapter.agentType`. NOT always the registry key: the bridged
+   * `opencode-attached` adapter reports its inner adapter's `'opencode'`.
+   */
+  agentType: string;
+  /** Wrapped by `LegacyProtocolAdapterV2Bridge` (capabilities live in the descriptor). */
+  legacyBridged: boolean;
+  /** `descriptor.resumeStateKey`. `null` = this provider has no resume key. */
+  resumeKey: string | null;
+  /** `adapter.capabilities.resume`. */
+  declaresResumeCapability: boolean;
+  /**
+   * Why `declaresResumeCapability` and `resumeKey` disagree. MUST be `null` when
+   * they agree — a non-null value is an acknowledged gap, not a free pass.
+   */
+  resumeLadderExemption: string | null;
+  /** `descriptor.deliversImages` (context-packet image lane). */
+  deliversImages: boolean;
+  /** `descriptor.imageRawByteBudget`, in MiB. */
+  imageRawBudgetMiB: number;
+  /** Terminal framework catalog id, or `null` for a channel-only provider. */
+  terminalFrameworkId: keyof typeof BUILTIN_FRAMEWORKS | null;
+  /** `descriptor.supportsChannelAgents` — may this provider serve a channel. */
+  supportsChannelAgents: boolean;
+  /** `shared/workspace-topics.ts` `BUILTIN_PROVIDER_IDS` (topic routing default). */
+  inTopicProviderAllowlist: boolean;
+  /** `DEFAULT_KNOWN_PROVIDER_IDS` fallback mention roster. */
+  inRouterFallbackRoster: boolean;
+  /** `relayControlCatalogForProvider` names (advertised Relay controls). */
+  advertisedControlNames: readonly string[];
+  /** `relayControlInputGuardCatalogForProvider` names (reserved from prose). */
+  guardedControlNames: readonly string[];
+  /** Command-line substrings / basenames that mark a process as this provider's. */
+  processMatch: { commandLineSubstrings: string[]; commandBasenames: string[] };
+  /** Home-relative credential files the node auth probe accepts. */
+  authCredentialPaths: string[][];
+  /** Permission-mode word for a yolo spawn; `null` = this provider has none. */
+  yoloPermissionMode: string | null;
+  /** Chosen when an orchestrator is designated with no framework named. */
+  isDefaultOrchestratorProvider: boolean;
+  /** Legacy v1 `ChatEventSource` — only the bridged lane needs one. */
+  validLegacyChatEventSource: boolean;
+}
+
+const CODEX_CONTROL_NAMES = [
+  'new',
+  'continue',
+  'model',
+  'effort',
+  'fast',
+  'compact',
+  'rollback',
+  'archive',
+  'unarchive',
+  'goal',
+  'review',
+  'fork',
+] as const;
+
+const PRIME_AGENT_CONTROL_NAMES = ['model', 'thinking'] as const;
+
+const PROVIDER_DRIFT_EXPECTATIONS = {
+  mock: {
+    agentType: 'mock',
+    legacyBridged: false,
+    resumeKey: null,
+    declaresResumeCapability: true,
+    resumeLadderExemption:
+      'fixture double: it persists `mockSessionId`, but test/channel-agent-binder.test.ts pins that key as inert (#1408). Relay has never resumed a mock runtime.',
+    deliversImages: true,
+    imageRawBudgetMiB: 10,
+    terminalFrameworkId: null,
+    supportsChannelAgents: true,
+    inTopicProviderAllowlist: false,
+    inRouterFallbackRoster: false,
+    advertisedControlNames: [],
+    guardedControlNames: [],
+    processMatch: { commandLineSubstrings: [], commandBasenames: [] },
+    authCredentialPaths: [],
+    // The double exists to exercise Relay's plumbing, and the binder's yolo lane
+    // is part of that plumbing (test/channel-agent-binder.test.ts).
+    yoloPermissionMode: 'bypassPermissions',
+    isDefaultOrchestratorProvider: false,
+    validLegacyChatEventSource: true,
+  },
+  claude: {
+    agentType: 'claude',
+    legacyBridged: false,
+    resumeKey: 'claudeSessionId',
+    declaresResumeCapability: true,
+    resumeLadderExemption: null,
+    deliversImages: true,
+    imageRawBudgetMiB: 6,
+    terminalFrameworkId: 'claude',
+    supportsChannelAgents: true,
+    inTopicProviderAllowlist: true,
+    inRouterFallbackRoster: true,
+    advertisedControlNames: [],
+    guardedControlNames: [],
+    processMatch: { commandLineSubstrings: ['claude'], commandBasenames: [] },
+    authCredentialPaths: [
+      ['.claude', '.credentials.json'],
+      ['.config', 'claude', 'credentials.json'],
+    ],
+    yoloPermissionMode: 'bypassPermissions',
+    isDefaultOrchestratorProvider: true,
+    validLegacyChatEventSource: true,
+  },
+  codex: {
+    agentType: 'codex',
+    legacyBridged: false,
+    resumeKey: 'threadId',
+    declaresResumeCapability: true,
+    resumeLadderExemption: null,
+    deliversImages: true,
+    imageRawBudgetMiB: 10,
+    terminalFrameworkId: 'codex',
+    supportsChannelAgents: true,
+    inTopicProviderAllowlist: true,
+    inRouterFallbackRoster: true,
+    advertisedControlNames: CODEX_CONTROL_NAMES,
+    guardedControlNames: CODEX_CONTROL_NAMES,
+    processMatch: { commandLineSubstrings: ['codex'], commandBasenames: [] },
+    authCredentialPaths: [['.codex', 'auth.json']],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+    validLegacyChatEventSource: true,
+  },
+  'prime-agent': {
+    agentType: 'prime-agent',
+    legacyBridged: false,
+    resumeKey: 'primeAgentSessionId',
+    declaresResumeCapability: true,
+    resumeLadderExemption: null,
+    deliversImages: false,
+    imageRawBudgetMiB: 10,
+    terminalFrameworkId: 'prime-agent',
+    supportsChannelAgents: true,
+    inTopicProviderAllowlist: true,
+    inRouterFallbackRoster: true,
+    // Prime's controls are candidates for a CONNECTED adapter to narrow by live
+    // discovery, so nothing is advertised pre-bind — but they stay reserved.
+    advertisedControlNames: [],
+    guardedControlNames: PRIME_AGENT_CONTROL_NAMES,
+    processMatch: {
+      commandLineSubstrings: ['prime-agent'],
+      commandBasenames: [],
+    },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+    validLegacyChatEventSource: false,
+  },
+  pi: {
+    agentType: 'pi',
+    legacyBridged: false,
+    resumeKey: 'piSessionId',
+    declaresResumeCapability: true,
+    resumeLadderExemption: null,
+    deliversImages: false,
+    imageRawBudgetMiB: 10,
+    terminalFrameworkId: 'pi',
+    supportsChannelAgents: true,
+    inTopicProviderAllowlist: true,
+    inRouterFallbackRoster: true,
+    advertisedControlNames: [],
+    guardedControlNames: [],
+    // `pi` is too short to match as a command-line substring.
+    processMatch: { commandLineSubstrings: [], commandBasenames: ['pi'] },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+    validLegacyChatEventSource: false,
+  },
+  opencode: {
+    agentType: 'opencode',
+    legacyBridged: true,
+    resumeKey: null,
+    declaresResumeCapability: false,
+    resumeLadderExemption: null,
+    deliversImages: false,
+    imageRawBudgetMiB: 10,
+    terminalFrameworkId: 'opencode',
+    supportsChannelAgents: true,
+    inTopicProviderAllowlist: true,
+    inRouterFallbackRoster: true,
+    advertisedControlNames: [],
+    guardedControlNames: [],
+    processMatch: { commandLineSubstrings: ['opencode'], commandBasenames: [] },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+    validLegacyChatEventSource: true,
+  },
+  'opencode-attached': {
+    // The bridge inherits the inner adapter's identity: attached and spawned
+    // OpenCode are one provider on the wire, two registry lanes.
+    agentType: 'opencode',
+    legacyBridged: true,
+    resumeKey: null,
+    declaresResumeCapability: false,
+    resumeLadderExemption: null,
+    deliversImages: false,
+    imageRawBudgetMiB: 10,
+    terminalFrameworkId: null,
+    supportsChannelAgents: true,
+    inTopicProviderAllowlist: false,
+    inRouterFallbackRoster: false,
+    advertisedControlNames: [],
+    guardedControlNames: [],
+    // Attached sessions reach an already-running server; Relay spawns nothing.
+    processMatch: { commandLineSubstrings: [], commandBasenames: [] },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+    validLegacyChatEventSource: true,
+  },
+  hermes: {
+    agentType: 'hermes',
+    legacyBridged: true,
+    resumeKey: 'hermesResponseId',
+    declaresResumeCapability: true,
+    resumeLadderExemption: null,
+    deliversImages: true,
+    imageRawBudgetMiB: 10,
+    terminalFrameworkId: 'hermes',
+    supportsChannelAgents: true,
+    inTopicProviderAllowlist: true,
+    inRouterFallbackRoster: true,
+    advertisedControlNames: [],
+    guardedControlNames: [],
+    processMatch: { commandLineSubstrings: ['hermes'], commandBasenames: [] },
+    authCredentialPaths: [],
+    yoloPermissionMode: null,
+    isDefaultOrchestratorProvider: false,
+    validLegacyChatEventSource: true,
+  },
+} satisfies Record<RegisteredChannelProviderId, ProviderDriftExpectation>;
+
+/** Non-adapter ids that legitimately appear in provider allowlists. */
+const NON_ADAPTER_PROVIDER_IDS: Readonly<Record<string, string>> = {
+  terminal:
+    'the non-agent routing lane: a topic that opens a PTY, not a channel agent',
+};
+
+const PROVIDER_IDS = Object.keys(v2Adapters) as RegisteredChannelProviderId[];
+const MIB = 1024 * 1024;
+
+function expectationFor(
+  providerId: RegisteredChannelProviderId
+): ProviderDriftExpectation {
+  const expectation = PROVIDER_DRIFT_EXPECTATIONS[providerId] as
+    | ProviderDriftExpectation
+    | undefined;
+  if (!expectation) {
+    throw new Error(
+      `No drift expectation for registered provider '${providerId}'. Add a row to ` +
+        `PROVIDER_DRIFT_EXPECTATIONS in test/provider-registry-drift.test.ts and ` +
+        `answer every scatter site it names — each field is a seam a new provider ` +
+        `must be wired into.`
+    );
+  }
+  return expectation;
+}
+
+function descriptorFor(
+  providerId: RegisteredChannelProviderId
+): ProviderDescriptor {
+  const descriptor = providerDescriptor(providerId);
+  if (!descriptor)
+    throw new Error(`no provider descriptor registered for '${providerId}'`);
+  return descriptor;
+}
+
+function adapterFor(providerId: string): ProtocolAdapterV2 {
+  return (v2Adapters as Record<string, () => ProtocolAdapterV2>)[providerId]!();
+}
+
+function emptyHomeDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'relay-drift-home-'));
+}
+
+describe('provider registry drift guards', () => {
+  it('registers exactly one descriptor per adapter', () => {
+    // Compile-enforced by `v2Adapters satisfies Record<RegisteredChannelProviderId,
+    // …>`; asserted here too because `test/tsconfig.json` typechecks only
+    // `shared/**` plus one named file, so a test-file `satisfies` is not a gate.
+    expect(Object.keys(PROVIDER_DESCRIPTORS).sort()).toEqual(
+      [...PROVIDER_IDS].sort()
+    );
+    expect(Object.keys(PROVIDER_DRIFT_EXPECTATIONS).sort()).toEqual(
+      [...PROVIDER_IDS].sort()
+    );
+  });
+
+  it.each(PROVIDER_IDS)('keys the descriptor for %s on its own id', (id) => {
+    expect(descriptorFor(id).id).toBe(id);
+  });
+
+  it.each(PROVIDER_IDS)('declares the real adapter identity for %s', (id) => {
+    const adapter = adapterFor(id);
+    const expected = expectationFor(id);
+    const descriptor = descriptorFor(id);
+
+    expect(adapter.agentType).toBe(expected.agentType);
+    expect(descriptor.agentType).toBe(adapter.agentType);
+    expect(adapter instanceof LegacyProtocolAdapterV2Bridge).toBe(
+      expected.legacyBridged
+    );
+    // A bridged adapter has no capabilities of its own — the descriptor's
+    // transcription IS its capability set, so the two must not diverge.
+    expect(descriptor.bridgedCapabilities !== null).toBe(
+      expected.legacyBridged
+    );
+    if (descriptor.bridgedCapabilities)
+      expect(adapter.capabilities).toEqual(descriptor.bridgedCapabilities);
+  });
+
+  it.each(PROVIDER_IDS)('hands out an immutable descriptor for %s', (id) => {
+    const descriptor = descriptorFor(id);
+
+    expect(Object.isFrozen(descriptor)).toBe(true);
+    expect(Object.isFrozen(descriptor.launch)).toBe(true);
+    expect(Object.isFrozen(descriptor.launch.requirement)).toBe(true);
+    expect(Object.isFrozen(descriptor.launch.processEnvDenylist)).toBe(true);
+    expect(Object.isFrozen(descriptor.processMatch)).toBe(true);
+    expect(Object.isFrozen(descriptor.processMatch.commandLineSubstrings)).toBe(
+      true
+    );
+    expect(Object.isFrozen(descriptor.processMatch.commandBasenames)).toBe(
+      true
+    );
+    expect(Object.isFrozen(descriptor.authCredentialPaths)).toBe(true);
+    for (const segments of descriptor.authCredentialPaths)
+      expect(Object.isFrozen(segments)).toBe(true);
+
+    if (!descriptor.bridgedCapabilities) return;
+    // ONE capability object serves every bridge instance of this provider as its
+    // public `adapter.capabilities`, so an unfrozen one would let a single
+    // mutation poison every other live instance and the registry with it.
+    expect(Object.isFrozen(descriptor.bridgedCapabilities)).toBe(true);
+    const first = adapterFor(id);
+    const second = adapterFor(id);
+    expect(first.capabilities).toBe(descriptor.bridgedCapabilities);
+    expect(second.capabilities).toBe(first.capabilities);
+  });
+
+  describe('resume ladder (server/channel-agent-runtime.ts)', () => {
+    it.each(PROVIDER_IDS)('resumes %s from its declared key only', (id) => {
+      const { resumeKey } = expectationFor(id);
+      expect(descriptorFor(id).resumeStateKey).toBe(resumeKey);
+
+      if (resumeKey === null) {
+        // Every other provider's key must stay inert on this provider's blob.
+        for (const other of PROVIDER_IDS) {
+          const foreign = descriptorFor(other).resumeStateKey;
+          if (foreign === null) continue;
+          expect(
+            providerResumeId(id, { [foreign]: 'foreign' })
+          ).toBeUndefined();
+        }
+        return;
+      }
+
+      expect(providerResumeId(id, { [resumeKey]: 'session-1' })).toBe(
+        'session-1'
+      );
+      // A persisted blob that names anything else replays nothing (#1408).
+      expect(
+        providerResumeId(id, { lastDeliveredSeq: 7, unrelatedKey: 'x' })
+      ).toBeUndefined();
+      expect(providerResumeId(id, { [resumeKey]: '' })).toBeUndefined();
+      expect(providerResumeId(id, undefined)).toBeUndefined();
+    });
+
+    it.each(PROVIDER_IDS)(
+      'keeps %s resume capability and resume key consistent',
+      (id) => {
+        const expected = expectationFor(id);
+        const declared = adapterFor(id).capabilities.resume === true;
+
+        expect(declared).toBe(expected.declaresResumeCapability);
+
+        const agrees = declared === (expected.resumeKey !== null);
+        if (agrees) {
+          expect(
+            expected.resumeLadderExemption,
+            `${id} agrees, so it must not carry an exemption`
+          ).toBeNull();
+          return;
+        }
+        // Disagreement is the silent-resume bug class. It ships only with a
+        // written reason, so the next provider cannot inherit it by accident.
+        expect(
+          expected.resumeLadderExemption,
+          `${id} declares capabilities.resume=${declared} but its resume key is ` +
+            `${JSON.stringify(expected.resumeKey)}. Either set resumeStateKey on ` +
+            `its descriptor or write a resumeLadderExemption saying why resume is ` +
+            `never invoked for this provider.`
+        ).toBeTruthy();
+      }
+    );
+
+    it('has no resume key for an unregistered provider', () => {
+      expect(
+        providerResumeId('future-agent', { futureAgentSessionId: 'x' })
+      ).toBeUndefined();
+    });
+  });
+
+  describe('capability declarations', () => {
+    it.each(PROVIDER_IDS)('declares every protocol flag for %s', (id) => {
+      const declared = adapterFor(id).capabilities;
+      const missing = CAPABILITY_FLAG_NAMES.filter(
+        (flag) => !Object.hasOwn(declared, flag)
+      );
+
+      expect(
+        missing,
+        `${id} omits capability flags, which read as false without ever being ` +
+          `audited. State them explicitly (see ProviderDescriptor.bridgedCapabilities ` +
+          `in server/protocol-adapters/index.ts).`
+      ).toEqual([]);
+    });
+
+    it.each(PROVIDER_IDS)('declares no unknown flag for %s', (id) => {
+      const unknown = Object.keys(adapterFor(id).capabilities).filter(
+        (flag) => !(flag in ALL_CAPABILITY_FLAGS)
+      );
+      expect(unknown).toEqual([]);
+    });
+
+    it.each(PROVIDER_IDS)(
+      'backs a declared steer flag with a method for %s',
+      (id) => {
+        const adapter = adapterFor(id);
+        if (adapter.capabilities.steer !== true) return;
+        expect(
+          typeof adapter.steerMessage,
+          `${id} declares capabilities.steer but has no steerMessage()`
+        ).toBe('function');
+      }
+    );
+  });
+
+  describe('image delivery (server/channel-context-packet.ts)', () => {
+    it.each(PROVIDER_IDS)('matches the declared image lane for %s', (id) => {
+      const expected = expectationFor(id);
+      const descriptor = descriptorFor(id);
+      expect(descriptor.deliversImages).toBe(expected.deliversImages);
+      expect(descriptor.imageRawByteBudget).toBe(
+        expected.imageRawBudgetMiB * MIB
+      );
+    });
+  });
+
+  describe('terminal framework catalog (server/types.ts)', () => {
+    it.each(PROVIDER_IDS)('matches the declared catalog entry for %s', (id) => {
+      const expected = expectationFor(id);
+      const descriptor = descriptorFor(id);
+
+      expect(descriptor.terminalFrameworkId).toBe(expected.terminalFrameworkId);
+      expect(descriptor.supportsChannelAgents).toBe(
+        expected.supportsChannelAgents
+      );
+
+      if (!expected.terminalFrameworkId) {
+        expect(Object.hasOwn(BUILTIN_FRAMEWORKS, id)).toBe(false);
+        return;
+      }
+
+      const framework = BUILTIN_FRAMEWORKS[expected.terminalFrameworkId];
+      expect(framework, `no BUILTIN_FRAMEWORKS entry for ${id}`).toBeTruthy();
+      // The catalog is the display-identity map: a provider with no label falls
+      // back to its bare id in every sender ref and roster row.
+      expect(framework.displayName.trim().length).toBeGreaterThan(0);
+      // The catalog no longer declares the channel lane; `server/frameworks.ts`
+      // projects it from the descriptor, so the two cannot disagree.
+      expect(framework.capabilities.supportsChannelAgents).toBeUndefined();
+      expect(
+        frameworkCapabilitiesWithChannelLane(framework).supportsChannelAgents
+      ).toBe(descriptor.supportsChannelAgents);
+    });
+
+    it('backs every terminal framework catalog entry with a descriptor', () => {
+      // Two INDEPENDENT sources: the catalog keys (`server/types.ts`) and the
+      // framework ids the descriptors claim. Filtering the catalog by the
+      // projected `supportsChannelAgents` instead would be tautological — the
+      // projection is derived from descriptor existence, so a deleted descriptor
+      // would remove the framework from its own guard while the roster quietly
+      // started answering "no registered channel runtime" for it.
+      const catalogIds = Object.keys(BUILTIN_FRAMEWORKS).sort();
+
+      // `server/frameworks.ts` looks a framework up by its CATALOG id, so that
+      // is the lookup this guard performs.
+      expect(
+        catalogIds.filter(
+          (id) => providerDescriptor(id)?.terminalFrameworkId === id
+        ),
+        'a framework catalog entry has no provider descriptor keyed on its id — its roster row reports "no registered channel runtime"'
+      ).toEqual(catalogIds);
+
+      // Reverse direction: every claimed framework id exists in the catalog, and
+      // no two descriptors claim the same one.
+      expect(
+        providerDescriptors()
+          .map((descriptor) => descriptor.terminalFrameworkId)
+          .filter((id): id is NonNullable<typeof id> => id !== null)
+          .sort(),
+        'a descriptor claims a terminal framework id the catalog does not define, or two descriptors claim the same one'
+      ).toEqual(catalogIds);
+    });
+  });
+
+  describe('provider id allowlists', () => {
+    it.each(PROVIDER_IDS)('matches the topic allowlist for %s', (id) => {
+      const expected = expectationFor(id);
+      expect(descriptorFor(id).allowedAsTopicRoutingDefault).toBe(
+        expected.inTopicProviderAllowlist
+      );
+      // `shared/` cannot import `server/`, so the shared set is a restatement.
+      // This is the bind that keeps the restatement honest.
+      expect(BUILTIN_PROVIDER_IDS.has(id)).toBe(
+        descriptorFor(id).allowedAsTopicRoutingDefault
+      );
+    });
+
+    it.each(PROVIDER_IDS)('matches the router fallback roster for %s', (id) => {
+      const expected = expectationFor(id);
+      expect(descriptorFor(id).mentionableByDefault).toBe(
+        expected.inRouterFallbackRoster
+      );
+      expect(DEFAULT_KNOWN_PROVIDER_IDS.includes(id)).toBe(
+        descriptorFor(id).mentionableByDefault
+      );
+    });
+
+    it('lists no unknown id in the topic allowlist', () => {
+      const unknown = [...BUILTIN_PROVIDER_IDS].filter(
+        (id) => !(id in v2Adapters) && !(id in NON_ADAPTER_PROVIDER_IDS)
+      );
+      expect(
+        unknown,
+        'topic routing allows a provider id no adapter serves (renamed or removed?)'
+      ).toEqual([]);
+    });
+
+    it('lists no unknown id in the router fallback roster', () => {
+      const unknown = DEFAULT_KNOWN_PROVIDER_IDS.filter(
+        (id) => !(id in v2Adapters)
+      );
+      expect(
+        unknown,
+        'the fallback mention roster names a provider id no adapter serves'
+      ).toEqual([]);
+    });
+  });
+
+  describe('relay control catalog (shared/agent-command-catalog.ts)', () => {
+    it.each(PROVIDER_IDS)('advertises the declared controls for %s', (id) => {
+      expect(
+        relayControlCatalogForProvider(id).map((command) => command.name)
+      ).toEqual([...expectationFor(id).advertisedControlNames]);
+    });
+
+    it.each(PROVIDER_IDS)('guards the declared controls for %s', (id) => {
+      const guarded = relayControlInputGuardCatalogForProvider(id).map(
+        (command) => command.name
+      );
+      expect(guarded).toEqual([...expectationFor(id).guardedControlNames]);
+      // A control that can be dispatched but not reserved would leak onto the
+      // ordinary-message lane, so the guard set is always a superset.
+      for (const advertised of expectationFor(id).advertisedControlNames) {
+        expect(guarded).toContain(advertised);
+      }
+    });
+
+    it.each(PROVIDER_IDS)(
+      'points the descriptor at the same catalog entry the frontend reads for %s',
+      (id) => {
+        // The specs live in `shared/` because the composer reads them and
+        // `shared/` cannot import `server/`. Reference identity is what keeps the
+        // descriptor from becoming a second, divergent membership table.
+        expect(descriptorFor(id).relayControls).toBe(
+          relayControlCatalogEntryForProvider(id)
+        );
+      }
+    );
+  });
+
+  describe('process ownership heuristic (server/process-tree.ts)', () => {
+    it.each(PROVIDER_IDS)('declares the process match for %s', (id) => {
+      const expected = expectationFor(id);
+      const { processMatch } = descriptorFor(id);
+      expect({
+        commandLineSubstrings: [...processMatch.commandLineSubstrings],
+        commandBasenames: [...processMatch.commandBasenames],
+      }).toEqual(expected.processMatch);
+    });
+
+    it.each(PROVIDER_IDS)('recognizes the launch command for %s', (id) => {
+      const requirement = CHANNEL_ADAPTER_LAUNCH_CONTRACTS[id].requirement;
+      if (requirement.kind !== 'command') return;
+
+      const command = requirement.command;
+      expect(
+        isRelayOwnedAgentProcess({
+          command,
+          commandLine: `/usr/local/bin/${command} --relay-channel`,
+        }),
+        `${command} is not recognized as a Relay-owned process, so its language-server children are attributed to nobody`
+      ).toBe(true);
+    });
+
+    it.each(PROVIDER_IDS)('recognizes every declared pattern for %s', (id) => {
+      const { processMatch } = descriptorFor(id);
+      for (const substring of processMatch.commandLineSubstrings) {
+        expect(
+          isRelayOwnedAgentProcess({
+            command: 'node',
+            commandLine: `/opt/wrap/${substring} --serve`,
+          })
+        ).toBe(true);
+      }
+      for (const basename of processMatch.commandBasenames) {
+        expect(
+          isRelayOwnedAgentProcess({
+            command: `/usr/local/bin/${basename}`,
+            commandLine: 'unrelated command line',
+          })
+        ).toBe(true);
+      }
+    });
+
+    it('still recognizes Relay’s own entrypoints', () => {
+      expect(
+        isRelayOwnedAgentProcess({
+          command: 'node',
+          commandLine: '/usr/bin/node /opt/relay-ide/dist/server/index.js',
+        })
+      ).toBe(true);
+      expect(
+        isRelayOwnedAgentProcess({
+          command: 'relayctl',
+          commandLine: 'relayctl status',
+        })
+      ).toBe(true);
+    });
+
+    it('does not claim an unrelated process', () => {
+      expect(
+        isRelayOwnedAgentProcess({
+          command: 'python3',
+          commandLine: '/usr/bin/python3 -m http.server',
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('node manifest auth probe (server/node-manifest-build.ts)', () => {
+    it.each(PROVIDER_IDS)(
+      'matches the declared credential paths for %s',
+      (id) => {
+        const expected = expectationFor(id);
+        expect(
+          descriptorFor(id).authCredentialPaths.map((segments) => [...segments])
+        ).toEqual(expected.authCredentialPaths);
+      }
+    );
+
+    it.each(PROVIDER_IDS)('probes %s from its declared paths only', (id) => {
+      const declared = descriptorFor(id).authCredentialPaths;
+      const homeDir = emptyHomeDir();
+
+      if (declared.length === 0) {
+        expect(probeAgentAuthStatus(id, { homeDir })).toBe('unknown');
+        return;
+      }
+
+      expect(probeAgentAuthStatus(id, { homeDir })).toBe('unauthed');
+      for (const segments of declared) {
+        const authedHome = emptyHomeDir();
+        const file = path.join(authedHome, ...segments);
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, '{}');
+        expect(
+          probeAgentAuthStatus(id, { homeDir: authedHome }),
+          `${id} declares ${segments.join('/')} but the probe ignored it`
+        ).toBe('authed');
+      }
+    });
+  });
+
+  describe('claude-flavored defaults, now named', () => {
+    it.each(PROVIDER_IDS)('names the yolo permission mode for %s', (id) => {
+      expect(descriptorFor(id).yoloPermissionMode).toBe(
+        expectationFor(id).yoloPermissionMode
+      );
+    });
+
+    it('resolves the default orchestrator from exactly one descriptor', () => {
+      const declared = PROVIDER_IDS.filter(
+        (id) => descriptorFor(id).isDefaultOrchestratorProvider
+      );
+      expect(declared).toHaveLength(1);
+      expect(DEFAULT_ORCHESTRATOR_PROVIDER_ID).toBe(declared[0]);
+      expect(
+        declared.map((id) => expectationFor(id).isDefaultOrchestratorProvider)
+      ).toEqual([true]);
+    });
+  });
+
+  describe('legacy v1 chat-event source (shared/chat-events.ts)', () => {
+    it.each(PROVIDER_IDS)('matches the declared v1 source for %s', (id) => {
+      const adapter = adapterFor(id);
+      const accepted = isChatEvent({
+        sessionId: 's1',
+        timestamp: new Date(0).toISOString(),
+        type: 'chat:text-delta',
+        source: adapter.agentType,
+      });
+      expect(accepted).toBe(expectationFor(id).validLegacyChatEventSource);
+    });
+
+    it('accepts the v1 source of every bridged adapter', () => {
+      const rejected = PROVIDER_IDS.filter((id) => {
+        const adapter = adapterFor(id);
+        if (!(adapter instanceof LegacyProtocolAdapterV2Bridge)) return false;
+        return !isChatEvent({
+          sessionId: 's1',
+          timestamp: new Date(0).toISOString(),
+          type: 'chat:text-delta',
+          source: adapter.agentType,
+        });
+      });
+
+      expect(
+        rejected,
+        'a legacy-bridged adapter emits chat events whose source isChatEvent rejects — the compat layer would drop the whole stream'
+      ).toEqual([]);
+    });
+  });
+});

--- a/test/server/protocol-adapters/conformance/fixtures/hermes.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/hermes.fixture.ts
@@ -46,9 +46,11 @@ const SESSION = 'conf-hermes';
 
 /**
  * Hand-transcribed twin of the `hermes` capability block in
- * `server/protocol-adapters/index.ts` (lines 99-119), including the
+ * `PROVIDER_DESCRIPTORS.hermes.bridgedCapabilities`
+ * (`server/protocol-adapters/index.ts`), including the
  * `telemetry: false` honesty note. The suite's registry-parity test compares
- * this against the registered factory, so a drifted copy fails loudly.
+ * this against the registered factory, so a drifted copy fails loudly. The
+ * registry set is total over `AgentCapabilitySetV2`, so this twin is too.
  */
 const HERMES_CAPABILITIES = {
   text: true,
@@ -57,16 +59,26 @@ const HERMES_CAPABILITIES = {
   commandExecution: true,
   fileChanges: true,
   approvals: true,
+  questions: false,
+  plans: false,
   slashCommands: false,
   queue: false,
+  steer: false,
   interrupt: true,
   cancelQueued: false,
   resume: true,
+  fork: false,
+  rollback: false,
+  compact: false,
   // `HermesProtocolAdapter` emits `chat:telemetry`, but
   // `mapChatEventToAgentPatchV2` has no case for it, so the bridge drops it
   // before the V2 stream (#1104). The flag stays false until that mapping
   // exists; this fixture drives a real `usage` payload to keep that honest.
   telemetry: false,
+  rateLimits: false,
+  // Unset in the registry until the gateway emits `response.output_text.delta`
+  // (#1305); stated here because the transcription is total.
+  streaming: false,
 } as const;
 
 /** Captured `apply_patch` output: a created-file unified diff. */

--- a/test/server/protocol-adapters/conformance/fixtures/opencode-attached.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/opencode-attached.fixture.ts
@@ -5,7 +5,9 @@
  * Transport: no spawn. The rig builds the same two-plane twin the registry
  * builds — inner `new OpenCodeAttachedAdapter()` pointed at
  * `config.extra.endpoint`, wrapped in the bridge with the capability set
- * transcribed from `server/protocol-adapters/index.ts` lines 80-98 — and hands
+ * transcribed from
+ * `PROVIDER_DESCRIPTORS['opencode-attached'].bridgedCapabilities`
+ * (`server/protocol-adapters/index.ts`) — and hands
  * it an offline `fetch` double (`../stubs/opencode-attached.stub.ts`) serving
  * `/global/health` plus a held-open `/event` SSE stream.
  *
@@ -76,9 +78,12 @@ const NO_TERMINAL_TURN_PATCH =
   'OpenCodeAttachedAdapter never fires chat:turn-completed (its session.status handler only re-broadcasts chat:session-status, unlike OpenCodeProtocolAdapter.handleSessionStatus which closes the turn) and its chat:error carries no turnId, so the compat bridge cannot synthesize a failed terminal either. No scripted transcript can end a turn, so every invariant that reads a terminal patch is unevaluable.';
 
 /**
- * Capability set transcribed from `index.ts` lines 80-98. The registry-parity
- * test compares this against the real factory, so any registry edit that is not
- * mirrored here fails loudly instead of quietly weakening the floor.
+ * Capability set transcribed from
+ * `PROVIDER_DESCRIPTORS['opencode-attached'].bridgedCapabilities` in
+ * `server/protocol-adapters/index.ts`. The registry-parity test compares this
+ * against the real factory, so any registry edit that is not mirrored here fails
+ * loudly instead of quietly weakening the floor. The registry transcription is
+ * total over `AgentCapabilitySetV2`, so this twin is too.
  */
 const REGISTERED_CAPABILITIES = {
   text: true,
@@ -87,12 +92,19 @@ const REGISTERED_CAPABILITIES = {
   commandExecution: true,
   fileChanges: true,
   approvals: true,
+  questions: false,
+  plans: false,
   slashCommands: false,
   queue: false,
+  steer: false,
   interrupt: true,
   cancelQueued: false,
   resume: false,
+  fork: false,
+  rollback: false,
+  compact: false,
   telemetry: true,
+  rateLimits: false,
   streaming: true,
 } as const;
 

--- a/test/server/protocol-adapters/conformance/fixtures/opencode.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/opencode.fixture.ts
@@ -20,7 +20,8 @@
  * Rig shape: the registry builds `LegacyProtocolAdapterV2Bridge(new
  * OpenCodeProtocolAdapter(), <capability literal>)`, so the rig builds the same
  * pair with the spawn seam injected. The capability object is hand-copied from
- * `server/protocol-adapters/index.ts` lines 58-79 and the suite's registry
+ * `PROVIDER_DESCRIPTORS.opencode.bridgedCapabilities`
+ * (`server/protocol-adapters/index.ts`) and the suite's registry
  * parity test guards the copy against drift.
  *
  * Turn boundary quirk: an OpenCode turn is bounded by the message POST, not by
@@ -42,10 +43,12 @@ import type {
 } from '../fixture-types.js';
 
 /**
- * Hand-copied from `v2Adapters.opencode` in `server/protocol-adapters/index.ts`
- * (lines 58-79). The suite's `registry parity` test asserts this equals the
- * registered set, so a registry edit that skips this file fails there rather
- * than silently reconciling against a stale literal.
+ * Hand-copied from `PROVIDER_DESCRIPTORS.opencode.bridgedCapabilities` in
+ * `server/protocol-adapters/index.ts`.
+ * The suite's `registry parity` test asserts this equals the registered set, so
+ * a registry edit that skips this file fails there rather than silently
+ * reconciling against a stale literal. The registry transcription is total over
+ * `AgentCapabilitySetV2`, so this twin is too.
  */
 const OPENCODE_BRIDGE_CAPABILITIES: AgentCapabilitySetV2 = {
   text: true,
@@ -54,12 +57,19 @@ const OPENCODE_BRIDGE_CAPABILITIES: AgentCapabilitySetV2 = {
   commandExecution: true,
   fileChanges: true,
   approvals: true,
+  questions: false,
+  plans: false,
   slashCommands: false,
   queue: false,
+  steer: false,
   interrupt: true,
   cancelQueued: false,
   resume: false,
+  fork: false,
+  rollback: false,
+  compact: false,
   telemetry: true,
+  rateLimits: false,
   streaming: true,
 };
 


### PR DESCRIPTION
## Summary

Adapter ladder slice 2 (follows #1405/#1413). Two stages plus a hook fix the slice surfaced:

**Stage 1 — drift guards.** Every provider-name table outside the adapters directory is now total over the `v2Adapters` roster, guarded by compile-time `satisfies` in source plus `test/provider-registry-drift.test.ts` at runtime. This closes the silent resume-ladder failure (a new provider missing the `channel-agent-runtime` two-line edit got resume silently never invoked) and fixed `PACKET_FRAMEWORK_IMAGE_SUPPORT` already missing pi/prime-agent/opencode-attached — new providers silently inherited "cannot receive images". Guards live in source because `test/tsconfig.json` doesn't typecheck test files — a `satisfies` in a test is documentation, not a gate (proved by negative control; documented in the test header).

**Stage 2 — one `ProviderDescriptor` per adapter**, registered beside the factory, `satisfies`-checked against the roster: resume key, image support, identity, process-match patterns, launch contract, channel-lane support, and the previously hand-transcribed bridge capability sets. Scatter sites became descriptor lookups; the dual `supportsChannelAgents` registry gate now reads the descriptor. Descriptors deep-frozen with an immutability test over every nested structure.

**Declared behavior deltas (deliberate):** a `config.frameworks` override can no longer toggle channel-lane availability (logged once when attempted; roster and availability can no longer disagree — override-merge still works and is test-pinned); a custom framework's channel-unavailability reason reads "has no registered channel runtime" instead of "is not currently available in channels". All per-provider values are bit-identical to the tables they replace.

**Hook fix:** `pre-push` now unsets `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` before running vitest — git exports these into hooks and they poisoned repo-path validation in `workspace-groups` (fails on clean nightly with `GIT_DIR` set, 31/31 green without; #1416 tracks the product-code angle).

Adversarial review: 5 findings, all applied with falsification evidence — the rewritten registry guard was proven able to fire by mutation (phantom framework added → new guard fails, old guard passed), and the freeze guard proven by removing a freeze.

No user-visible change — registry/data-model refactor and contributor tooling.

Adapter generality: choreography — registry data model; no quirk copied between siblings, no quirk generalized; per-provider values untouched.

## Verification

- `npm run check` exit 0
- Targeted suites: 18 files, 659 passed, 11 issue-cited conformance skips
- Pre-push changed-set run: 189 files, 2845 passed
- Full-suite sole red is `hermes-image-input` live-gateway hang, proven pre-existing on clean nightly (#1415)

🤖 Generated with [Claude Code](https://claude.com/claude-code)