### PR TITLE
fix(adapters): deliver system prompts, repair resume continuity, own terminal patches once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,25 @@ workflow.
 
 #### Fixed
 
+- Codex and Hermes agents now receive the profile system prompt and Relay's
+  collaboration contract, so a channel agent behaves the same whichever harness
+  runs it. Hermes sends that prompt as one byte-stable block on every turn;
+  OpenCode profiles still cannot be given one on this transport, and Relay no
+  longer implies otherwise (#1409)
+- Interrupting a Hermes agent no longer wipes the conversation: the next message
+  continues from the last completed response instead of starting a
+  context-free one (#1409)
+- OpenCode channels no longer claim to resume after a restart. A restarted
+  OpenCode session reports the truth up front rather than silently answering
+  from an empty history (#1409)
+- A failed turn now ends exactly once on Hermes, OpenCode, and attached
+  OpenCode, carrying its error text, instead of leaving a turn that never
+  visibly finishes or finishes twice (#1411, #1412)
+- Tool approvals no longer stay actionable forever when an agent session
+  disconnects while one is outstanding. Every provider now cancels the
+  outstanding request on its own wire and marks the approval card cancelled with
+  the reason, so a reopened channel never shows live-looking Allow/Deny controls
+  for a session that is gone (#1407)
 - Reap owned agent process trees after channel-runtime failure or replacement,
   report aggregate runtime resource health, and let operators explicitly release
   idle channel agents (#1019)

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -3160,10 +3160,15 @@ export function createChannelAgentBinder(
         {
           const activeTurnId = binding.activeTurnId;
           if (activeTurnId !== null && patch.turnId === undefined) {
-            // Legacy chat:error dispatches its paired turn-0 completion only
-            // after this handler returns. The queued successor can bare-idle
-            // synchronously while finishTurn pumps it, so mark the anonymous
-            // namespace unsafe before that successor starts.
+            // The completion paired with a legacy chat:error no longer rides
+            // the mapper: since #1411 it is owned by
+            // LegacyProtocolAdapterV2Bridge, which arms it one microtask later
+            // and fires it only when the adapter did not end the errored turn
+            // itself — so it lands after this handler returns, or not at all.
+            // The queued successor can bare-idle synchronously while finishTurn
+            // pumps it, so mark the anonymous namespace unsafe before that
+            // successor starts; a window that is wider than strictly needed is
+            // the safe direction here.
             binding.turnZeroFallbackUnsafe = true;
           }
           const terminalTurnId = patch.turnId ?? binding.activeTurnId;

--- a/server/protocol-adapters/AGENTS.md
+++ b/server/protocol-adapters/AGENTS.md
@@ -20,10 +20,12 @@ must audit the sibling adapters for the same concern before landing it:
   (`adapter-utils.ts`, `../utils.ts`), never a third hand-written copy.
 
 Default posture is quirk containment. Propagating a fix into a sibling needs
-proof of the same underlying behavior, not the same-looking code. `reconnect()`
-matches across claude, codex-native, hermes, and opencode apart from the
-not-connected wording the shared helper parameterizes; pi-agent and prime-agent
-fold `providerSessionId` into config — a config-transform hook, not a copy.
+proof of the same behavior, not the same-looking code. `reconnect()` matches
+across claude, codex-native, hermes, and opencode apart from the not-connected
+wording the shared helper parameterizes; pi-agent and prime-agent fold
+`providerSessionId` into config — a config-transform hook, not a copy. Two lanes
+onto ONE provider share that provider's wire vocabulary from a provider-scoped
+module (`opencode-shared.ts`), never a second copy, never `adapter-utils.ts`.
 
 ## Fidelity invariants
 

--- a/server/protocol-adapters/adapter-utils.ts
+++ b/server/protocol-adapters/adapter-utils.ts
@@ -8,10 +8,16 @@
  *   hand-duplicated into a third adapter.
  *
  * This module is the seed of that layer. Broad extraction is sequenced behind
- * an adapter conformance suite; add here only what is already identical.
+ * the adapter conformance suite (`test/server/protocol-adapters/conformance/`),
+ * which is now the floor a shared rewrite is accountable to; add here only what
+ * is already identical, or what the suite proves must be identical.
  */
 
 import type { AdapterConfig } from '../protocol-adapter-v2.js';
+import type {
+  AgentApprovalItemV2,
+  AgentPatchV2,
+} from '../../shared/agent-chat-protocol-v2.js';
 
 export interface ReconnectWithStoredConfigOptions {
   /** Config captured by the last successful connect; null before one. */
@@ -49,4 +55,120 @@ export async function reconnectWithStoredConfig(
     : config;
   await options.disconnect();
   await options.connect(nextConfig);
+}
+
+// ── Abandoned approvals (#1407) ──────────────────────────────────────────────
+
+/**
+ * Reason a stranded approval card carries out when the session goes away
+ * underneath it. Exported and constant on purpose: the string reaches a durable
+ * transcript, so two identical teardowns must read identically rather than
+ * drifting per adapter.
+ */
+export const ABANDONED_APPROVAL_REASON =
+  'Approval cancelled: the agent session disconnected before it was answered.';
+
+/** Same shape, for the turn that dies with an approval still on screen. */
+export const TURN_ENDED_APPROVAL_REASON =
+  'Approval cancelled: the turn ended before it was answered.';
+
+/**
+ * The approval card exactly as its adapter last published it, minus everything
+ * that describes how it ENDED. Those fields are the shared choreography's to
+ * write; the rest — kind, description, target, provider details, supported
+ * scopes — is harness vocabulary the helper only copies through.
+ */
+export type AbandonedApprovalCardV2 = Omit<
+  AgentApprovalItemV2,
+  | 'type'
+  | 'requestId'
+  | 'status'
+  | 'decision'
+  | 'respondedBy'
+  | 'completedAt'
+  | 'error'
+  | 'card'
+>;
+
+/** One approval that was still awaiting a human when the session went away. */
+export interface AbandonedApprovalV2 {
+  /** The id the provider knows this request by (its wire identity). */
+  requestId: string;
+  /** Turn the approval card lives in, so the patch lands on the right turn. */
+  turnId: string;
+  card: AbandonedApprovalCardV2;
+}
+
+export interface ResolveAbandonedApprovalsOptions {
+  sessionId: string;
+  approvals: Iterable<AbandonedApprovalV2>;
+  emitPatch: (patch: AgentPatchV2) => void;
+  /**
+   * QUIRK hook — how this harness answers the outstanding request on its own
+   * wire (claude writes a `deny` control_response, codex answers the
+   * `respondToServerRequest`, the legacy bridge POSTs `deny` through the inner
+   * adapter). Runs BEFORE the card is published so the provider is released
+   * first and the transcript never claims a resolution the wire refused to
+   * carry. Callers that have no live wire left simply omit it.
+   */
+  denyOnWire?: (approval: AbandonedApprovalV2) => void;
+  /** Defaults to `ABANDONED_APPROVAL_REASON`. */
+  reason?: string;
+  /** Seam for deterministic timestamps in tests. */
+  now?: () => string;
+}
+
+/**
+ * CHOREOGRAPHY (#1407). Teardown with an approval still outstanding used to
+ * leave a permanently actionable Allow/Deny card in the reduced session: the
+ * wire got its deny but the patch stream got nothing, so every consumer replayed
+ * a live-looking approval for a session that no longer exists.
+ *
+ * The dance is identical for every harness and is stated once, here:
+ *  1. release the provider on its own wire (the one per-adapter quirk),
+ *  2. publish a terminal `agent-item-updated-v2` for each card — `cancelled`,
+ *     `respondedBy: 'timeout'`, carrying a stable reason,
+ *  3. drain `live.activeRequestIds` / `waitingOn` exactly once, and only when
+ *     there was something to drain.
+ *
+ * Emitting is synchronous by contract: `BaseProtocolAdapterV2.disconnect()`
+ * clears its handler set as soon as `onDisconnect()` resolves, so a resolution
+ * deferred to a later microtask reaches nobody.
+ */
+export function resolveAbandonedApprovals(
+  options: ResolveAbandonedApprovalsOptions
+): void {
+  const now = options.now ?? (() => new Date().toISOString());
+  const reason = options.reason ?? ABANDONED_APPROVAL_REASON;
+  let resolved = 0;
+
+  for (const approval of options.approvals) {
+    options.denyOnWire?.(approval);
+    resolved += 1;
+    options.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: options.sessionId,
+      timestamp: now(),
+      turnId: approval.turnId,
+      item: {
+        ...approval.card,
+        type: 'approval',
+        requestId: approval.requestId,
+        decision: { kind: 'cancel' },
+        respondedBy: 'timeout',
+        status: 'cancelled',
+        error: reason,
+        completedAt: now(),
+      },
+    });
+  }
+
+  if (resolved === 0) return;
+
+  options.emitPatch({
+    type: 'agent-live-state-updated-v2',
+    sessionId: options.sessionId,
+    timestamp: now(),
+    live: { waitingOn: null, activeRequestIds: [] },
+  });
 }

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -1,5 +1,11 @@
 import { CLAUDE_CHANNEL_COMMAND } from './launch-commands.js';
-import { reconnectWithStoredConfig } from './adapter-utils.js';
+import {
+  ABANDONED_APPROVAL_REASON,
+  TURN_ENDED_APPROVAL_REASON,
+  reconnectWithStoredConfig,
+  resolveAbandonedApprovals,
+  type AbandonedApprovalV2,
+} from './adapter-utils.js';
 import * as fs from 'node:fs';
 import { spawn as nodeSpawn } from 'node:child_process';
 import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
@@ -833,13 +839,22 @@ export class ClaudeProtocolAdapter
       new Error('Claude adapter disconnected during runtime env refresh')
     );
 
-    // Auto-deny outstanding approvals before the child is killed (§7.4).
-    for (const requestId of [...this.pendingApprovals.keys()]) {
-      this.writeControlResponse(requestId, {
-        behavior: 'deny',
-        message: 'Denied (session closing)',
-      });
-    }
+    // Auto-deny outstanding approvals before the child is killed (§7.4) AND
+    // resolve their cards in the patch stream — the wire deny alone left a
+    // permanently actionable approval in every consumer's reduced session
+    // (#1407). Synchronous: `disconnect()` drops its handlers the moment this
+    // returns.
+    resolveAbandonedApprovals({
+      sessionId: this.sessionId,
+      approvals: this.abandonedApprovals(),
+      emitPatch: (patch) => this.emitPatch(patch),
+      reason: ABANDONED_APPROVAL_REASON,
+      denyOnWire: ({ requestId }) =>
+        this.writeControlResponse(requestId, {
+          behavior: 'deny',
+          message: 'Denied (session closing)',
+        }),
+    });
     this.clearPendingApprovals();
     this.approvalWaitStartedMs = null;
     this.suppressInterruptedTail = false;
@@ -2452,36 +2467,42 @@ export class ClaudeProtocolAdapter
   }
 
   /**
+   * QUIRK: the claude vocabulary for an outstanding approval card. The terminal
+   * state it wears on the way out is choreography and lives in `adapter-utils`.
+   */
+  private abandonedApprovals(): AbandonedApprovalV2[] {
+    return [...this.pendingApprovals].map(([requestId, pending]) => ({
+      requestId,
+      turnId: pending.turnId,
+      card: {
+        id: `approval-${requestId}`,
+        kind: 'permission',
+        description: `Claude wants to use ${pending.toolName}`,
+        target: pending.target,
+        ...(pending.detail ? { detail: pending.detail } : {}),
+        supported: CLAUDE_APPROVAL_SUPPORT,
+      },
+    }));
+  }
+
+  /**
    * Resolve any approval cards still outstanding when a turn ends abnormally
    * (crash / timeout / interrupt). Without this the started `approval` item stays
    * `status:'pending'` forever, showing live-looking Allow/Deny controls inside a
    * dead turn whose respondToApproval would no-op (§7). Emits a terminal update
    * per item before the pending map is cleared; a no-op on a clean completion
    * (approvals always resolve before a successful `result`).
+   *
+   * No `denyOnWire` here: the turn is already over and the child that owned the
+   * control_request is dead or dying. Only teardown speaks on the wire.
    */
   private cancelPendingApprovalItems(): void {
-    for (const [requestId, pending] of this.pendingApprovals) {
-      this.emitPatch({
-        type: 'agent-item-updated-v2',
-        sessionId: this.sessionId,
-        timestamp: nowIso(),
-        turnId: pending.turnId,
-        item: {
-          type: 'approval',
-          id: `approval-${requestId}`,
-          requestId,
-          kind: 'permission',
-          description: `Claude wants to use ${pending.toolName}`,
-          target: pending.target,
-          ...(pending.detail ? { detail: pending.detail } : {}),
-          supported: CLAUDE_APPROVAL_SUPPORT,
-          decision: { kind: 'decline' },
-          respondedBy: 'timeout',
-          status: 'cancelled',
-          completedAt: nowIso(),
-        },
-      });
-    }
+    resolveAbandonedApprovals({
+      sessionId: this.sessionId,
+      approvals: this.abandonedApprovals(),
+      emitPatch: (patch) => this.emitPatch(patch),
+      reason: TURN_ENDED_APPROVAL_REASON,
+    });
   }
 
   // ── Turn completion / queue ────────────────────────────────────────────────

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -1,4 +1,8 @@
-import { reconnectWithStoredConfig } from './adapter-utils.js';
+import {
+  reconnectWithStoredConfig,
+  resolveAbandonedApprovals,
+  type AbandonedApprovalCardV2,
+} from './adapter-utils.js';
 import {
   AgentSteerRejectedError,
   BaseProtocolAdapterV2,
@@ -470,6 +474,25 @@ function codexPermissionsResponse(
   return { scope, permissions: originalPermissions };
 }
 
+/**
+ * The decline envelope for an approval nobody will ever answer (#1407). Each
+ * kind has its own response shape, so the mapping is a codex QUIRK even though
+ * the "release the provider on teardown" rule it serves is shared.
+ */
+function codexDeclineResponse(meta: PendingApproval): Record<string, unknown> {
+  const declined: AgentApprovalDecisionV2 = { kind: 'decline' };
+  switch (meta.kind) {
+    case 'command':
+      return codexCommandDecisionResponse(declined);
+    case 'patch':
+      return codexFileDecisionResponse(declined);
+    case 'permissions':
+      return codexPermissionsResponse(declined, meta.permissions ?? []);
+    case 'elicitation':
+      return { action: 'decline' };
+  }
+}
+
 // ── Queued message ────────────────────────────────────────────────────────
 
 interface QueuedCodexMessage {
@@ -486,6 +509,10 @@ interface PendingApproval {
   kind: ApprovalKind;
   nativeRequestId: number | string;
   permissions?: string[];
+  /** Turn the card lives in, so teardown can address it (#1407). */
+  turnId: string;
+  /** The card as published, minus how it ends — see `adapter-utils`. */
+  card: AbandonedApprovalCardV2;
 }
 
 // ── Pending input request ─────────────────────────────────────────────────
@@ -634,6 +661,43 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
+  /**
+   * Relay's system-prompt appendix, in the one app-server channel that carries
+   * it as a system region rather than as conversation.
+   *
+   * Codex QUIRK — the wire vocabulary is codex's own, and the choice between
+   * its two instruction slots is a correctness decision, not a style one:
+   *
+   * - `baseInstructions` REPLACES codex's built-in operating prompt. It is the
+   *   model's base prompt template (the app-server errors with "` is missing
+   *   both `base_instructions` and `model_messages.instructions_template`" when
+   *   a model definition supplies neither, and rollout `SessionMeta` persists
+   *   it as thread identity). Writing Relay's appendix there would delete the
+   *   harness's own instructions.
+   * - `developerInstructions` is the additive layer codex itself uses for
+   *   personas: it is a `config.toml` key, and the bundled agent-role files
+   *   (`awaiter.toml`, `explorer.toml`) define a role purely as
+   *   `developer_instructions="""You are an awaiter. ..."""`. Same shape as a
+   *   Relay profile prompt plus collaboration contract.
+   *
+   * Prefix-cache invariant: this is a thread-scoped field. `ThreadStartParams`
+   * and `ThreadResumeParams` accept it; `TurnStartParams` and `TurnSteerParams`
+   * do NOT (verified against `codex app-server generate-ts --experimental`,
+   * codex-cli 0.147.0). So it is sent exactly once per client generation, from
+   * the same stored `config`, and the system region is byte-stable across every
+   * turn of one runtime — a resume or reconnect replays the identical string.
+   *
+   * An older app-server that predates the field ignores it: serde skips unknown
+   * params, which the adapter already relies on for `persistExtendedHistory`
+   * (absent from the 0.147.0 schema and accepted in practice).
+   */
+  private threadInstructionParams(
+    config: AdapterConfig
+  ): { developerInstructions: string } | Record<string, never> {
+    const appendix = config.systemPromptAppendix?.trim();
+    return appendix ? { developerInstructions: appendix } : {};
+  }
+
   async connect(config: AdapterConfig): Promise<void> {
     const catalogGeneration = ++this.catalogGeneration;
     this.config = config;
@@ -656,11 +720,15 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       ? await client.call<{ thread: { id: string } }>('thread/resume', {
           threadId: config.resumeSessionId,
           excludeTurns: false,
+          // Replayed, not re-derived: the resumed thread keeps the same profile
+          // prompt and collaboration contract the original thread/start sent.
+          ...this.threadInstructionParams(config),
         })
       : await client.call<{ thread: { id: string } }>('thread/start', {
           cwd: config.cwd,
           experimentalRawEvents: false,
           persistExtendedHistory: false,
+          ...this.threadInstructionParams(config),
           ...(config.model || this.pendingModelOverride
             ? { model: this.pendingModelOverride ?? config.model }
             : {}),
@@ -1199,6 +1267,36 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     ++this.catalogGeneration;
     this.modelCatalogReady = Promise.resolve();
     this.rejectQueued(new Error('Codex adapter disconnecting'));
+
+    // #1407: answer every outstanding approval on the app-server wire and
+    // publish its terminal card BEFORE the client goes away. Clearing the maps
+    // alone left `handleCommandApprovalRequest` awaiting a promise nobody would
+    // ever settle, so no decision reached the provider and no patch resolved
+    // the card. Synchronous by contract — `disconnect()` drops its patch
+    // handlers as soon as `onDisconnect()` resolves.
+    const liveClient = this.client;
+    resolveAbandonedApprovals({
+      sessionId: this.sessionId,
+      approvals: [...this.approvalMeta].map(([requestId, meta]) => ({
+        requestId,
+        turnId: meta.turnId,
+        card: meta.card,
+      })),
+      emitPatch: (patch) => this.emitPatch(patch),
+      // QUIRK: codex answers a JSON-RPC server request, and each approval kind
+      // has its own decline envelope.
+      denyOnWire: ({ requestId }) => {
+        const meta = this.approvalMeta.get(requestId);
+        if (!liveClient || !meta) return;
+        liveClient.respondToServerRequest(
+          meta.nativeRequestId,
+          codexDeclineResponse(meta)
+        );
+      },
+    });
+    // Settle the awaiting handlers so their promises cannot leak; each one
+    // returns early now that `this.client` is about to be null.
+    const abandonedResolvers = [...this.pendingApprovals.values()];
     this.pendingApprovals.clear();
     this.pendingInputRequests.clear();
     this.approvalMeta.clear();
@@ -1220,6 +1318,10 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
     const client = this.client;
     this.client = null;
+    // Ordering matters: the resolvers run their continuations in a microtask,
+    // by which point `this.client` is null and each handler bails out instead
+    // of re-answering a wire that is already closed (#1407).
+    for (const resolve of abandonedResolvers) resolve({ kind: 'cancel' });
     if (client) {
       try {
         await this.stopOwnedClient(client, 'adapter teardown');
@@ -2303,11 +2405,25 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.approvalMeta.set(requestId, {
       kind: 'command',
       nativeRequestId,
+      turnId,
+      card: {
+        id: itemId,
+        kind: 'command',
+        description: `Run command: ${command}`,
+        target: command,
+        details: { kind: 'command', command, cwd, commandActions },
+        supported: CODEX_COMMAND_APPROVAL_SUPPORT,
+      },
     });
 
     const decision = await new Promise<AgentApprovalDecisionV2>((resolve) => {
       this.pendingApprovals.set(requestId, resolve);
     });
+
+    // Teardown settles this promise too, after it has already answered the wire
+    // and published the cancelled card (#1407). The client is gone by then, so
+    // the resolution path below must not run a second time.
+    if (!this.client) return;
 
     const nativeResponse = codexCommandDecisionResponse(decision);
     this.client.respondToServerRequest(nativeRequestId, nativeResponse);
@@ -2381,11 +2497,26 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       queueLength: this.queue.length,
     });
 
-    this.approvalMeta.set(requestId, { kind: 'patch', nativeRequestId });
+    this.approvalMeta.set(requestId, {
+      kind: 'patch',
+      nativeRequestId,
+      turnId,
+      card: {
+        id: itemId,
+        kind: 'patch',
+        description: `Apply file changes (${changes.length} file${changes.length !== 1 ? 's' : ''})`,
+        target: changes.map((c) => c.path).join(', ') || 'unknown',
+        details: { kind: 'patch', changes },
+        supported: CODEX_PATCH_APPROVAL_SUPPORT,
+      },
+    });
 
     const decision = await new Promise<AgentApprovalDecisionV2>((resolve) => {
       this.pendingApprovals.set(requestId, resolve);
     });
+
+    // See handleCommandApprovalRequest — teardown already resolved this card.
+    if (!this.client) return;
 
     const nativeResponse = codexFileDecisionResponse(decision);
     this.client.respondToServerRequest(nativeRequestId, nativeResponse);
@@ -2463,11 +2594,23 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       kind: 'permissions',
       nativeRequestId,
       permissions,
+      turnId,
+      card: {
+        id: itemId,
+        kind: 'permissionsGrant',
+        description: `Grant permissions: ${permissions.join(', ')}`,
+        target: permissions.join(', ') || 'unknown',
+        details: { kind: 'permissionsGrant', permissions },
+        supported: CODEX_PERMISSIONS_APPROVAL_SUPPORT,
+      },
     });
 
     const decision = await new Promise<AgentApprovalDecisionV2>((resolve) => {
       this.pendingApprovals.set(requestId, resolve);
     });
+
+    // See handleCommandApprovalRequest — teardown already resolved this card.
+    if (!this.client) return;
 
     const response = codexPermissionsResponse(decision, permissions);
     this.client.respondToServerRequest(nativeRequestId, response);
@@ -2641,11 +2784,32 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       queueLength: this.queue.length,
     });
 
-    this.approvalMeta.set(requestId, { kind: 'elicitation', nativeRequestId });
+    this.approvalMeta.set(requestId, {
+      kind: 'elicitation',
+      nativeRequestId,
+      turnId,
+      card: {
+        id: itemId,
+        kind: 'elicitation',
+        description: `MCP elicitation from ${serverName}: ${message}`,
+        target: serverName,
+        details: {
+          kind: 'elicitation',
+          serverName,
+          mode,
+          message,
+          requestedSchema,
+        },
+        supported: CODEX_ELICITATION_APPROVAL_SUPPORT,
+      },
+    });
 
     const decision = await new Promise<AgentApprovalDecisionV2>((resolve) => {
       this.pendingApprovals.set(requestId, resolve);
     });
+
+    // See handleCommandApprovalRequest — teardown already resolved this card.
+    if (!this.client) return;
 
     // Elicitation response: { action: 'accept'|'decline', content? }
     const elicitAction = decision.kind === 'accept' ? 'accept' : 'decline';

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -652,6 +652,50 @@ export function buildRelayHermesSessionInstructions(input: {
   ].join('\n');
 }
 
+/**
+ * Compose the persistent system region one Hermes runtime sends on every
+ * `/v1/responses` call, in Relay's authority order:
+ *
+ * 1. Relay session context (inert labels: session id, cwd, workspace anchors).
+ * 2. Channel `promptDefaults` (`extra.instructions`, #1090).
+ * 3. `config.systemPromptAppendix` — the profile system prompt plus Relay's
+ *    collaboration contract (`server/channel-agent-runtime.ts`), LAST so
+ *    channel-authored material cannot redefine Relay's runtime boundary.
+ *
+ * Hermes QUIRK: the gateway has no separate system-prompt slot, and the
+ * Responses API's `instructions` field IS the system region — so #1409's
+ * "deliver the appendix" is a fold into this block, not a new request field.
+ * Pure and total over its input, so `connect()` composes it once and every turn
+ * replays the identical bytes: the prefix-cache invariant holds by construction
+ * rather than by every caller re-deriving the same string. Returns null when
+ * there is nothing to send.
+ */
+export function composeHermesPersistentInstructions(input: {
+  sessionId?: string | null | undefined;
+  cwd?: string | null | undefined;
+  metadata?: Record<string, string> | undefined;
+  channelInstructions?: unknown;
+  systemPromptAppendix?: string | null | undefined;
+}): string | null {
+  const parts: string[] = [];
+  const relayContext = buildRelayHermesSessionInstructions({
+    sessionId: input.sessionId,
+    cwd: input.cwd,
+    metadata: input.metadata,
+  });
+  if (relayContext) parts.push(relayContext);
+  if (
+    typeof input.channelInstructions === 'string' &&
+    input.channelInstructions.trim()
+  ) {
+    parts.push(input.channelInstructions.trim());
+  }
+  if (input.systemPromptAppendix?.trim()) {
+    parts.push(input.systemPromptAppendix.trim());
+  }
+  return parts.length > 0 ? parts.join('\n\n') : null;
+}
+
 const MIME_BY_EXTENSION: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -740,6 +784,34 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
   private _currentTurnId: string | null = null;
   private _apiKey: string | null = null;
   private _lastResponseId: string | null = null;
+  /**
+   * The last response id the gateway actually FINISHED — `response.completed`
+   * (the one persisted as `hermesResponseId`), the `response.incomplete` the
+   * adapter already treats as chainable, or an id restored by `resumeSession`.
+   *
+   * Distinct from `_lastResponseId`, which `response.created` advances to the
+   * in-flight id the moment a turn starts. An interrupted turn's in-flight
+   * response was never finished upstream, so it is not a legal
+   * `previous_response_id` and must never be resurrected — but the last
+   * finished one still is. Dropping the chain to null on abort (pre-#1409) made
+   * every turn after a user interrupt start a fresh, context-free conversation.
+   */
+  private _lastChainableResponseId: string | null = null;
+  /**
+   * The Hermes system region for this runtime, composed ONCE in `connect()` by
+   * `composeHermesPersistentInstructions` and replayed verbatim on every
+   * `/v1/responses` call. Prefix-cache invariant (#1409): the instructions
+   * prefix must be byte-stable across every turn of one runtime, so it is built
+   * from the immutable `AdapterConfig` at connect instead of being recomposed
+   * per turn. The one-shot ticket kickoff below is the single deliberate
+   * exception and is appended after this block, on the first turn only.
+   */
+  private _persistentInstructions: string | null = null;
+  /**
+   * `metadata` for every `/v1/responses` call, sanitized once at connect from
+   * the same immutable config — same reason as `_persistentInstructions`.
+   */
+  private _responsesMetadata: Record<string, string> | null = null;
   // One-shot delivery for `extra.initialInstructions` (e.g. a ticket-launch
   // kickoff prompt, #1062): unlike `extra.instructions` (channel promptDefaults,
   // resent every turn — #1090), this is folded into `instructions` for the
@@ -778,11 +850,25 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     this._messageAbortController = null;
     this._currentTurnId = null;
     this._lastResponseId = null;
+    this._lastChainableResponseId = null;
     this._turnCounter = 0;
     this._initialInstructionsSent = false;
     this._pendingToolCalls.clear();
     this._reasoningBuffer = '';
     this._assistantEmittedThisTurn = false;
+
+    // Compose the system region and metadata once per runtime, from the config
+    // this connect generation was handed. Every turn below replays these exact
+    // bytes (prefix-cache invariant, #1409).
+    this._responsesMetadata =
+      sanitizeResponsesMetadata(config.extra?.['metadata']) ?? null;
+    this._persistentInstructions = composeHermesPersistentInstructions({
+      sessionId: config.sessionId,
+      cwd: config.cwd,
+      ...(this._responsesMetadata ? { metadata: this._responsesMetadata } : {}),
+      channelInstructions: config.extra?.['instructions'],
+      systemPromptAppendix: config.systemPromptAppendix,
+    });
 
     const settings = resolveHermesGatewaySettings(config.extra);
     this._endpoint = settings.endpoint;
@@ -805,6 +891,9 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     this._messageAbortController = null;
     this._currentTurnId = null;
     this._lastResponseId = null;
+    this._lastChainableResponseId = null;
+    this._persistentInstructions = null;
+    this._responsesMetadata = null;
     this._pendingToolCalls.clear();
     this._reasoningBuffer = '';
     this._assistantEmittedThisTurn = false;
@@ -859,34 +948,20 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     if (this._lastResponseId) {
       body['previous_response_id'] = this._lastResponseId;
     }
-    const metadata = sanitizeResponsesMetadata(
-      this._config?.extra?.['metadata']
-    );
-    if (metadata) {
-      body['metadata'] = metadata;
+    if (this._responsesMetadata) {
+      body['metadata'] = this._responsesMetadata;
     }
-    // `instructions` (channel promptDefaults, #1090) is persistent system
-    // framing resent on every turn. `initialInstructions` (ticket-launch
-    // kickoff, #1062) is one-shot: fold it in only for the first turn of this
-    // adapter instance, then drop it, so it doesn't linger as system framing
-    // and cause the model to re-anchor on a one-time kickoff instruction
-    // mid-conversation.
-    const persistentInstructions = this._config?.extra?.['instructions'];
+    // `_persistentInstructions` (Relay session context + channel promptDefaults
+    // #1090 + `systemPromptAppendix` #1409) is the byte-stable system region,
+    // composed at connect and resent unchanged on every turn.
+    // `initialInstructions` (ticket-launch kickoff, #1062) is one-shot: fold it
+    // in only for the first turn of this adapter instance, then drop it, so it
+    // doesn't linger as system framing and cause the model to re-anchor on a
+    // one-time kickoff instruction mid-conversation.
     const oneShotInstructions = this._config?.extra?.['initialInstructions'];
-    const relayContextInstructions = buildRelayHermesSessionInstructions({
-      sessionId,
-      cwd: this._config?.cwd,
-      metadata,
-    });
     const instructionParts: string[] = [];
-    if (relayContextInstructions) {
-      instructionParts.push(relayContextInstructions);
-    }
-    if (
-      typeof persistentInstructions === 'string' &&
-      persistentInstructions.trim()
-    ) {
-      instructionParts.push(persistentInstructions.trim());
+    if (this._persistentInstructions) {
+      instructionParts.push(this._persistentInstructions);
     }
     if (
       !this._initialInstructionsSent &&
@@ -932,7 +1007,12 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     } catch (err) {
       const isAbort = err instanceof Error && err.name === 'AbortError';
       if (isAbort) {
-        this._lastResponseId = null;
+        // Re-anchor, do not drop (#1409). The interrupted response was never
+        // finished upstream, so `response.created`'s in-flight id is not a
+        // legal `previous_response_id` — but the last response the gateway DID
+        // finish still is, and it is what the next turn must chain from.
+        // Nulling here broke conversation continuity on every user interrupt.
+        this._lastResponseId = this._lastChainableResponseId;
         this.fire({
           type: 'chat:turn-completed',
           turnId,
@@ -1030,6 +1110,10 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     // only reinstate the chaining anchor here.
     if (providerSessionId) {
       this._lastResponseId = providerSessionId;
+      // A persisted `hermesResponseId` is by construction a COMPLETED response,
+      // so it is also the fallback anchor if the first turn after resume is
+      // interrupted (#1409).
+      this._lastChainableResponseId = providerSessionId;
     }
   }
 
@@ -1378,6 +1462,9 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     const responseId = response?.['id'];
     if (typeof responseId === 'string') {
       this._lastResponseId = responseId;
+      // The gateway finished this response, so it is the anchor an interrupted
+      // or failed later turn falls back to (#1409).
+      this._lastChainableResponseId = responseId;
       // Persist the completed response id so a resumed session (after a
       // Relay restart) can continue the conversation via
       // `previous_response_id`. Only completed responses are chainable.
@@ -1438,7 +1525,9 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
       | Record<string, unknown>
       | undefined;
     const error = response?.['error'] as Record<string, unknown> | undefined;
-    this._lastResponseId = null;
+    // Same re-anchor as the abort path (#1409): a failed response is not
+    // chainable, but the conversation before it still is.
+    this._lastResponseId = this._lastChainableResponseId;
     this.failCurrentTurn(
       String(error?.['message'] ?? 'Hermes response failed'),
       'failed'
@@ -1447,7 +1536,9 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
 
   private handleResponseError(event: SseEvent): void {
     const message = event.data['message'];
-    this._lastResponseId = null;
+    // Same re-anchor as the abort path (#1409): an errored response is not
+    // chainable, but the conversation before it still is.
+    this._lastResponseId = this._lastChainableResponseId;
     this.failCurrentTurn(
       typeof message === 'string' ? message : 'Hermes response error',
       'failed'
@@ -1461,8 +1552,11 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     const responseId = response?.['id'];
     if (typeof responseId === 'string') {
       // Incomplete responses are still chainable via `previous_response_id`,
-      // so keep the anchor for the next turn.
+      // so keep the anchor for the next turn — and for a later interrupt to
+      // fall back to (#1409); the gateway did finish this response, it just
+      // ran out of room.
       this._lastResponseId = responseId;
+      this._lastChainableResponseId = responseId;
     }
     const details = response?.['incomplete_details'] as
       | Record<string, unknown>

--- a/server/protocol-adapters/legacy-v2-bridge.ts
+++ b/server/protocol-adapters/legacy-v2-bridge.ts
@@ -11,8 +11,42 @@ import type {
 import type {
   AgentApprovalDecisionV2,
   AgentCapabilitySetV2,
+  AgentPatchV2,
 } from '../../shared/agent-chat-protocol-v2.js';
+import type { ChatEvent } from '../../shared/chat-events.js';
 import { mapChatEventToAgentPatchV2 } from '../../shared/agent-chat-v1-compat.js';
+import { createLogger } from '../logger.js';
+import {
+  resolveAbandonedApprovals,
+  type AbandonedApprovalV2,
+} from './adapter-utils.js';
+
+const logger = createLogger('legacy-v2-bridge');
+
+/**
+ * Turn ids retained by the terminal ledger. Bounded so a long-lived bridged
+ * session cannot grow the map without limit; eviction is oldest-first and only
+ * ever reaches turns that ended many turns ago.
+ *
+ * The bound is also the limit of the exactly-once guarantee, and that is
+ * deliberate: a duplicate terminal for a turn already evicted (an adapter
+ * firing a second `chat:turn-completed` more than 256 turns later) finds no
+ * record, opens a fresh one, and passes through. Memory is the harder
+ * constraint — an unbounded ledger on a session that never disconnects is a
+ * real leak, a terminal replayed 256 turns late is not a shape any adapter
+ * here produces. See `openTurn` for the second, related escape.
+ */
+const MAX_TRACKED_TURNS = 256;
+
+/** One turn's terminal state, as seen by the bridge. */
+interface TurnTerminalRecord {
+  /** A terminal `agent-turn-completed-v2` has already been emitted. */
+  terminated: boolean;
+  /** Last `chat:error` message seen for this turn, if any. */
+  error?: string;
+  /** A deferred fallback completion is already armed for this turn. */
+  fallbackArmed: boolean;
+}
 
 /**
  * Translate a V2 decision back to the v1 binary form expected by legacy adapters.
@@ -47,6 +81,55 @@ export class LegacyProtocolAdapterV2Bridge extends BaseProtocolAdapterV2 {
 
   private unlisten: (() => void) | null = null;
 
+  /**
+   * #1411 — the bridge is the single owner of the terminal turn patch.
+   *
+   * CHOREOGRAPHY, not a quirk: "a turn ends exactly once" is the V2 turn
+   * lifecycle contract, identical for every legacy harness, and this bridge is
+   * the one seam all of them pass through. Fixing it per adapter would mean
+   * three hand-written copies of the same rule — exactly what
+   * `AGENTS.md` forbids — and `mapChatEventToAgentPatchV2` cannot own it
+   * because a pure event->patches function holds no turn state.
+   *
+   * The rule, stated once:
+   *  - The adapter's own `chat:turn-completed` is authoritative; it carries the
+   *    honest completion `reason`, which a synthesized patch can only flatten
+   *    to `failed`.
+   *  - A second completion for a turn that already ended is dropped (hermes
+   *    fires `chat:error` + `chat:turn-completed` from every failure path;
+   *    opencode can complete a turn from both the SSE idle and the message POST
+   *    resolution).
+   *  - A `chat:error` carrying a turnId arms a fallback completion. If the
+   *    adapter does not end the turn in the same synchronous emit chain, the
+   *    bridge ends it (opencode's `tui.toast.show` path fires the error and
+   *    never completes). The deferral is one microtask — legacy adapters fire
+   *    their paired events synchronously, so no wall clock is involved and the
+   *    patch order stays deterministic.
+   *  - A `chat:error` with NO turnId is not a turn signal and synthesizes
+   *    nothing: guessing would pin a session-level failure on whatever turn
+   *    happened to be running. (#1412 fixed opencode-attached by making its
+   *    `session.error` carry the turnId, which is where that belongs.)
+   */
+  private readonly turnLedger = new Map<string, TurnTerminalRecord>();
+  /** Bumped on connect/disconnect so armed fallbacks from a dead generation no-op. */
+  private ledgerGeneration = 0;
+
+  /**
+   * #1407 — approvals still awaiting a human, keyed by request id.
+   *
+   * CHOREOGRAPHY, for the same reason the turn ledger is: "teardown never
+   * leaves an actionable approval card behind" is a V2 lifecycle rule, and this
+   * bridge is the one seam opencode, opencode-attached, and hermes all pass
+   * through. Fixing it inside each legacy adapter would be three hand-written
+   * copies. The ledger is fed by the patches the bridge itself publishes, so it
+   * needs no per-adapter vocabulary: an approval item that reads pending is
+   * pending, whatever native event produced it.
+   */
+  private readonly pendingApprovals = new Map<
+    string,
+    AbandonedApprovalV2 & { sessionId: string }
+  >();
+
   constructor(
     private readonly inner: ProtocolAdapter,
     readonly capabilities: AgentCapabilitySetV2
@@ -60,39 +143,242 @@ export class LegacyProtocolAdapterV2Bridge extends BaseProtocolAdapterV2 {
     return this.inner.status;
   }
 
-  private subscribePatches(): void {
+  /**
+   * Drop the inner patch subscription. Idempotent, and the first move of every
+   * teardown path: nothing the inner adapter emits after this reaches a
+   * consumer, which is what `cancelAbandonedApprovals` relies on.
+   */
+  private dropInnerSubscription(): void {
     this.unlisten?.();
+    this.unlisten = null;
+  }
+
+  private subscribePatches(): void {
+    this.dropInnerSubscription();
     this.unlisten = this.inner.on((event) => {
       for (const patch of mapChatEventToAgentPatchV2(event)) {
-        this.emitPatch(patch);
+        this.emitTurnOwnedPatch(patch);
       }
+      this.armTerminalFallback(event);
+    });
+  }
+
+  /** Forget every turn and disarm anything the previous generation scheduled. */
+  private resetTurnLedger(): void {
+    this.ledgerGeneration += 1;
+    this.turnLedger.clear();
+  }
+
+  /**
+   * Start (or restart) a turn's record, re-inserted at the tail so eviction
+   * stays oldest-first.
+   *
+   * The record is reset unconditionally, which is the second bound on the
+   * dedupe: a repeated `agent-turn-started-v2` for an id that already
+   * terminated re-arms that id for another terminal. Preserving `terminated`
+   * instead would be worse — an adapter that reuses a turn id is announcing a
+   * genuinely new turn, and a preserved record would silently swallow its real
+   * terminal, turning a duplicate into a missing one. The dedupe is therefore
+   * "one terminal per turn-started", not "one terminal per id, forever".
+   */
+  private openTurn(turnId: string): TurnTerminalRecord {
+    const record: TurnTerminalRecord = {
+      terminated: false,
+      fallbackArmed: false,
+    };
+    this.turnLedger.delete(turnId);
+    this.turnLedger.set(turnId, record);
+    while (this.turnLedger.size > MAX_TRACKED_TURNS) {
+      const oldest = this.turnLedger.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.turnLedger.delete(oldest);
+    }
+    return record;
+  }
+
+  /**
+   * Emit a mapped patch, enforcing exactly-one-terminal ownership on the way
+   * out. Every non-turn-lifecycle patch passes straight through.
+   */
+  private emitTurnOwnedPatch(patch: AgentPatchV2): void {
+    this.trackApproval(patch);
+    if (patch.type === 'agent-turn-started-v2') {
+      this.openTurn(patch.turn.id);
+      this.emitPatch(patch);
+      return;
+    }
+    if (patch.type !== 'agent-turn-completed-v2') {
+      this.emitPatch(patch);
+      return;
+    }
+
+    const known = this.turnLedger.get(patch.turnId);
+    if (known?.terminated) {
+      // Not silence: a duplicate terminal is a logged gap, per the fidelity
+      // invariants in AGENTS.md. Dropping it is the whole point of #1411.
+      logger.debug(
+        `[${this.agentType}] dropped a duplicate agent-turn-completed-v2 for turn ${patch.turnId} (status ${patch.status})`
+      );
+      return;
+    }
+
+    const record = known ?? this.openTurn(patch.turnId);
+    record.terminated = true;
+    // The error text used to ride the synthesized patch. Now that the adapter's
+    // own completion wins, carry the message onto it so a failed turn still
+    // says why it failed.
+    const enriched =
+      patch.status === 'failed' && !patch.error && record.error
+        ? { ...patch, error: record.error }
+        : patch;
+    this.emitPatch(enriched);
+  }
+
+  /**
+   * Keep the approval ledger in step with the cards the bridge publishes: an
+   * item that reads `pending`/`running` is outstanding, anything else has been
+   * answered. Reading the patch stream rather than the native events is what
+   * keeps this provider-agnostic.
+   */
+  private trackApproval(patch: AgentPatchV2): void {
+    if (
+      patch.type !== 'agent-item-started-v2' &&
+      patch.type !== 'agent-item-updated-v2'
+    ) {
+      return;
+    }
+    const item = patch.item;
+    if (item.type !== 'approval') return;
+    const status = item.status ?? 'pending';
+    if (status !== 'pending' && status !== 'running') {
+      this.pendingApprovals.delete(item.requestId);
+      return;
+    }
+    this.pendingApprovals.set(item.requestId, {
+      sessionId: patch.sessionId,
+      requestId: item.requestId,
+      turnId: patch.turnId,
+      card: {
+        id: item.id,
+        kind: item.kind,
+        description: item.description,
+        target: item.target,
+        ...(item.detail !== undefined ? { detail: item.detail } : {}),
+        ...(item.details !== undefined ? { details: item.details } : {}),
+        ...(item.supported !== undefined ? { supported: item.supported } : {}),
+        ...(item.startedAt !== undefined ? { startedAt: item.startedAt } : {}),
+        ...(item.metadata !== undefined ? { metadata: item.metadata } : {}),
+      },
+    });
+  }
+
+  /**
+   * Teardown half of #1407. Every caller MUST drop the inner subscription
+   * first, and both do (`onDisconnect`, `reconnect`). That ordering is what
+   * makes the cancelled cards this publishes the only resolution the transcript
+   * sees: the wire deny below is fire-and-forget, and both OpenCode adapters
+   * fire a `chat:approval-response` on a 2xx, so with the subscription still
+   * attached a deny that lands before the session dies would emit a
+   * `completed` / `respondedBy: 'user'` update AFTER the cancelled card and
+   * overwrite it — a transcript claiming the operator denied an approval they
+   * never saw.
+   */
+  private cancelAbandonedApprovals(): void {
+    const abandoned = [...this.pendingApprovals.values()];
+    this.pendingApprovals.clear();
+    const sessionId = abandoned[0]?.sessionId;
+    if (sessionId === undefined) return;
+    resolveAbandonedApprovals({
+      sessionId,
+      approvals: abandoned,
+      emitPatch: (patch) => this.emitPatch(patch),
+      // QUIRK, delegated: every legacy adapter already knows how to say "deny"
+      // on its own transport. Best-effort and unawaited — teardown must not
+      // block on a provider round-trip that may never answer.
+      denyOnWire: ({ requestId }) => {
+        void this.inner.respondToApproval(requestId, 'deny').catch((err) => {
+          logger.debug(
+            `[${this.agentType}] teardown deny for approval ${requestId} did not land:`,
+            err
+          );
+        });
+      },
+    });
+  }
+
+  /**
+   * A `chat:error` bound to a turn arms the fallback completion the mapper used
+   * to synthesize unconditionally. It fires only if the adapter did not end the
+   * turn itself in the same synchronous emit chain.
+   */
+  private armTerminalFallback(event: ChatEvent): void {
+    if (event.type !== 'chat:error') return;
+    const turnId = event.turnId;
+    if (!turnId) return;
+
+    const known = this.turnLedger.get(turnId);
+    if (known?.terminated) return;
+    const record = known ?? this.openTurn(turnId);
+    record.error = event.message;
+    if (record.fallbackArmed) return;
+    record.fallbackArmed = true;
+
+    const generation = this.ledgerGeneration;
+    const { sessionId, timestamp } = event;
+    queueMicrotask(() => {
+      if (generation !== this.ledgerGeneration) return;
+      const current = this.turnLedger.get(turnId);
+      if (!current || current.terminated) return;
+      current.terminated = true;
+      logger.debug(
+        `[${this.agentType}] completing turn ${turnId} from chat:error — the adapter never did`
+      );
+      this.emitPatch({
+        type: 'agent-turn-completed-v2',
+        sessionId,
+        timestamp,
+        turnId,
+        status: 'failed',
+        completedAt: timestamp,
+        ...(current.error ? { error: current.error } : {}),
+      });
     });
   }
 
   async connect(config: AdapterConfig): Promise<void> {
+    this.resetTurnLedger();
+    this.pendingApprovals.clear();
     this.subscribePatches();
     try {
       await this.inner.connect(config);
     } catch (error) {
-      this.unlisten?.();
-      this.unlisten = null;
+      this.dropInnerSubscription();
+      this.resetTurnLedger();
       throw error;
     }
   }
 
   protected async onDisconnect(): Promise<void> {
-    this.unlisten?.();
-    this.unlisten = null;
+    this.dropInnerSubscription();
+    this.resetTurnLedger();
+    this.cancelAbandonedApprovals();
     await this.inner.disconnect();
   }
 
   async reconnect(): Promise<void> {
+    // Drop the inner subscription BEFORE cancelling, exactly as `onDisconnect`
+    // does: the wire deny is unawaited and answers with a
+    // `chat:approval-response`, which would otherwise overwrite the cancelled
+    // card with a `user`-decided one. `subscribePatches()` re-attaches below.
+    this.dropInnerSubscription();
+    // A reconnect replaces the session the outstanding approvals belonged to,
+    // so they are as abandoned as they are on a plain disconnect (#1407).
+    this.cancelAbandonedApprovals();
     try {
       await this.inner.reconnect();
       this.subscribePatches();
     } catch (error) {
-      this.unlisten?.();
-      this.unlisten = null;
+      this.dropInnerSubscription();
       throw error;
     }
   }

--- a/server/protocol-adapters/mock-v2-adapter.ts
+++ b/server/protocol-adapters/mock-v2-adapter.ts
@@ -15,6 +15,11 @@ import type {
   AgentTurnV2,
 } from '../../shared/agent-chat-protocol-v2.js';
 import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
+import {
+  TURN_ENDED_APPROVAL_REASON,
+  resolveAbandonedApprovals,
+  type AbandonedApprovalV2,
+} from './adapter-utils.js';
 
 export interface MockProtocolAdapterV2Delays {
   connectMs: number;
@@ -101,6 +106,8 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     string,
     (decision: AgentApprovalDecisionV2) => void
   >();
+  /** Cards still awaiting a human, so teardown can resolve them (#1407). */
+  private readonly approvalCards = new Map<string, AbandonedApprovalV2>();
   private readonly delays: MockProtocolAdapterV2Delays;
   private connectGeneration = 0;
   /**
@@ -153,6 +160,16 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   protected async onDisconnect(): Promise<void> {
     this.connectGeneration++;
     this.rejectQueuedMessages();
+    // #1407: emit the resolution HERE rather than leaning on the aborted turn
+    // to do it. `runTurn`'s abort path fires a microtask later, by which point
+    // `disconnect()` has already dropped every patch handler — the resolution
+    // was real and unobservable, which is the worst of both.
+    resolveAbandonedApprovals({
+      sessionId: this.sessionId,
+      approvals: [...this.approvalCards.values()],
+      emitPatch: (patch) => this.emitPatch(patch),
+    });
+    this.approvalCards.clear();
     this.activeController?.abort();
     this.pendingApprovals.clear();
     this.activeTurnId = null;
@@ -250,6 +267,7 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     }
 
     this.pendingApprovals.delete(input.requestId);
+    this.approvalCards.delete(input.requestId);
     resolver(input.decision);
   }
 
@@ -497,6 +515,19 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     const approvalId = `approval-${scope}`;
     const toolId = `tool-${scope}`;
 
+    this.approvalCards.set(approvalId, {
+      requestId: approvalId,
+      turnId,
+      card: {
+        id: approvalId,
+        kind: 'command',
+        description: 'Run mock command',
+        target: 'npm test',
+        detail: 'Mock v2 approval scenario',
+        metadata: { toolId },
+      },
+    });
+
     this.emitItemStarted(turnId, {
       type: 'approval',
       id: approvalId,
@@ -560,6 +591,16 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
         'abort',
         () => {
           this.pendingApprovals.delete(requestId);
+          // An interrupt kills the turn under the card too. Teardown clears
+          // `approvalCards` before it aborts, so this never double-resolves.
+          const abandoned = this.approvalCards.get(requestId);
+          this.approvalCards.delete(requestId);
+          resolveAbandonedApprovals({
+            sessionId: this.sessionId,
+            approvals: abandoned ? [abandoned] : [],
+            emitPatch: (patch) => this.emitPatch(patch),
+            reason: TURN_ENDED_APPROVAL_REASON,
+          });
           reject(new DOMException('aborted', 'AbortError'));
         },
         { once: true }

--- a/server/protocol-adapters/opencode-adapter.ts
+++ b/server/protocol-adapters/opencode-adapter.ts
@@ -1,5 +1,6 @@
 import { OPENCODE_CHANNEL_COMMAND } from './launch-commands.js';
 import { reconnectWithStoredConfig } from './adapter-utils.js';
+import { openCodeStatusType } from './opencode-shared.js';
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import crypto from 'node:crypto';
@@ -436,8 +437,30 @@ export class OpenCodeProtocolAdapter extends BaseProtocolAdapter {
     return this._config?.sessionId ?? crypto.randomBytes(8).toString('hex');
   }
 
-  async resumeSession(_sessionId: string): Promise<void> {
-    // no-op; the OpenCode REST session is created on connect.
+  /**
+   * Resume honesty (#1409). This used to be a silent no-op, which reads as
+   * "the prior conversation is restored" to every caller. It never was: the
+   * OpenCode REST session is created in `connect()` via `createOpenCodeSession`
+   * (`POST /session`), and the surface this adapter speaks —
+   * `/session/<id>/message`, `/session/<id>/abort`,
+   * `/session/<id>/permissions/<id>`, `/question/<id>/reply`, `/global/health`,
+   * `/global/event` — has no route to rebind a session id from a previous
+   * process. A resumed runtime is therefore amnesiac.
+   *
+   * That is why `PROVIDER_DESCRIPTORS.opencode.resumeStateKey` is `null` and
+   * `bridgedCapabilities.resume` is `false`. Because `providerResumeId()` reads
+   * that same key, `channel-agent-binder` classifies a respawned opencode
+   * runtime as holding nothing and re-orients it from cursor 0 — the bounded
+   * root-plus-window packet from #1408, never a history dump — instead of
+   * withholding rows a fresh session was assumed to remember.
+   *
+   * Failing loudly keeps the ladder honest: reaching here means a caller
+   * bypassed the capability flag, and a silent success would hide the bypass.
+   */
+  async resumeSession(sessionId: string): Promise<void> {
+    throw new Error(
+      `opencode cannot resume session ${sessionId}: the REST transport creates a fresh session in connect() and exposes no rebind route (capabilities.resume is false).`
+    );
   }
 
   async forkSession(_sessionId: string): Promise<string> {
@@ -478,6 +501,19 @@ export class OpenCodeProtocolAdapter extends BaseProtocolAdapter {
     throw new Error(`OpenCode server did not become ready within 10s`);
   }
 
+  /**
+   * `config.systemPromptAppendix` is NOT delivered to OpenCode, and cannot be
+   * on this transport (#1409, documented impossibility). The two routes that
+   * could carry it take neither an instructions nor a system field: session
+   * create is `POST /session { title }`, and a prompt is
+   * `POST /session/<id>/message { parts, model? }` where every part is a user
+   * part. OpenCode takes its agent instructions from `AGENTS.md` and its own
+   * config files in the working directory, which Relay must not write into a
+   * user's repo. Folding the appendix into `parts` would move Relay's runtime
+   * contract into the operator's message on every turn — outside the system
+   * region the prefix-cache invariant is stated over, and misattributed.
+   * Delivering it needs a system/instructions field on one of those two routes.
+   */
   private async createOpenCodeSession(): Promise<string> {
     const title = this._config?.sessionId
       ? `Relay ${this._config.sessionId}`
@@ -644,7 +680,7 @@ export class OpenCodeProtocolAdapter extends BaseProtocolAdapter {
   }
 
   private handleSessionStatus(event: OpenCodeEvent): void {
-    const status = this.statusType(event.properties?.['status']);
+    const status = openCodeStatusType(event.properties?.['status']);
     if (status === 'active' || status === 'busy') {
       this.fire({ type: 'chat:session-status', status: 'active' });
       return;
@@ -694,15 +730,6 @@ export class OpenCodeProtocolAdapter extends BaseProtocolAdapter {
       this._currentTurnId = null;
     }
     this.fire({ type: 'chat:session-status', status: 'idle' });
-  }
-
-  private statusType(status: unknown): string | undefined {
-    if (typeof status === 'string') return status;
-    if (status && typeof status === 'object') {
-      const type = (status as Record<string, unknown>)['type'];
-      return typeof type === 'string' ? type : undefined;
-    }
-    return undefined;
   }
 
   private handleMessageUpdated(event: OpenCodeEvent): void {

--- a/server/protocol-adapters/opencode-attached-adapter.ts
+++ b/server/protocol-adapters/opencode-attached-adapter.ts
@@ -1,5 +1,6 @@
 import { AttachedRuntimeAdapter } from './attached-runtime-adapter.js';
 import type { AdapterConfig, Attachment } from '../protocol-adapter.js';
+import { openCodeStatusType } from './opencode-shared.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('opencode-attached');
@@ -54,11 +55,34 @@ interface OpenCodeEvent {
   properties?: Record<string, unknown>;
 }
 
+/** Why the active turn stopped, in this adapter's own vocabulary. */
+type OpenCodeTurnEndReason = 'completed' | 'failed' | 'interrupted';
+
 /**
  * Attached runtime adapter for OpenCode.
  *
  * Connects to a running `opencode serve` or `opencode web` instance via HTTP
  * and consumes the SSE `/event` stream for real-time updates.
+ *
+ * Turn lifecycle (#1412). This adapter used to start turns and never end them:
+ * no handler fired `chat:turn-completed`, so `agent-turn-completed-v2` was
+ * unreachable in `completed`, `failed`, and `interrupted` form alike and the
+ * channel binder had to finalize every turn from a bare idle live-state — a
+ * compensation it deliberately skips while an approval is outstanding. The turn
+ * now ends from three places, all of them local QUIRK (this harness's own event
+ * vocabulary and abort semantics):
+ *
+ *  - `session.status` idle/error — the server told us the run stopped.
+ *  - `session.error` — carried on the `chat:error` as a turnId so the failure
+ *    binds to the turn instead of floating at session level.
+ *  - `interrupt()` — `prompt_async` returns immediately, so unlike the spawned
+ *    `OpenCodeProtocolAdapter` there is no in-flight POST whose `AbortError`
+ *    could signal the stop; a SUCCESSFUL abort ack is the evidence, and an
+ *    abort the server refused ends nothing.
+ *
+ * "Exactly one terminal per turn" is CHOREOGRAPHY and stays where #1411 put it,
+ * in `LegacyProtocolAdapterV2Bridge`: this adapter only has to end the turn
+ * honestly, and a redundant completion is deduped one layer up.
  */
 export class OpenCodeAttachedAdapter extends AttachedRuntimeAdapter {
   readonly agentType = 'opencode';
@@ -68,9 +92,30 @@ export class OpenCodeAttachedAdapter extends AttachedRuntimeAdapter {
   private _messageAbortController: AbortController | null = null;
   private _turnCounter = 0;
   private _currentTurnId: string | null = null;
+  /**
+   * Turn the operator asked to abort. Read when the server settles back to
+   * idle, so a stop is reported as `interrupted` rather than `completed` even
+   * when the idle beats the abort POST's own ack.
+   */
+  private _interruptedTurnId: string | null = null;
+  /**
+   * Turn each outstanding approval was asked in, keyed by the provider's
+   * request id. Recorded when the request arrives rather than read back at
+   * response time: now that idle closes the turn and clears `_currentTurnId`
+   * (#1412), an approval answered after that idle would otherwise bind its
+   * response to the fabricated `turn-0` while its card lives in the real turn,
+   * leaving the card pending forever in the reduced session.
+   */
+  private readonly _approvalTurnIds = new Map<string, string>();
 
   protected async onConnect(config: AdapterConfig): Promise<void> {
     this._endpoint = resolveOpenCodeAttachedEndpoint(config.extra);
+    // A re-attach starts from no turn: leaving a stale id here would let the
+    // first `session.status` of the new stream close a turn that is gone.
+    this._currentTurnId = null;
+    this._interruptedTurnId = null;
+    // Approvals belong to the session that asked them; a re-attach replaces it.
+    this._approvalTurnIds.clear();
 
     // Verify the server is reachable
     const healthRes = await fetch(`${this._endpoint}/global/health`).catch(
@@ -147,6 +192,18 @@ export class OpenCodeAttachedAdapter extends AttachedRuntimeAdapter {
     }
   }
 
+  /**
+   * `config.systemPromptAppendix` is NOT delivered here, and cannot be on this
+   * transport (#1409, documented impossibility). The attached adapter owns no
+   * session: `opencode serve` / `opencode web` created it, with whatever agent
+   * instructions that process was started with, and the only route this adapter
+   * has into it is `POST /session/<id>/prompt_async { text }` — a user turn,
+   * not a system region. Folding the appendix into `text` would put Relay's
+   * runtime contract in the operator's message on every turn, which is both a
+   * lie about who said it and outside the system region the prefix-cache
+   * invariant is stated over. Delivering it would need an instructions field on
+   * the prompt route or a session-create route this adapter never calls.
+   */
   async sendMessage(
     turnId: string,
     content: string,
@@ -182,13 +239,37 @@ export class OpenCodeAttachedAdapter extends AttachedRuntimeAdapter {
     const sessionId = this._config?.sessionId;
     if (!sessionId) return;
 
+    // Record the intent before the await: the server may emit `session.status`
+    // idle while the abort POST is still in flight, and that idle must close
+    // the turn as `interrupted`, not `completed`.
+    this._interruptedTurnId = this._currentTurnId;
+
     const url = `${this._endpoint}/session/${encodeURIComponent(sessionId)}/abort`;
-    await fetch(url, {
+    const res = await fetch(url, {
       method: 'POST',
       ...(this._messageAbortController
         ? { signal: this._messageAbortController.signal }
         : {}),
-    }).catch(() => {});
+    }).catch(() => null);
+
+    // `prompt_async` left no in-flight request to abort, so the ack is the only
+    // synchronous evidence the run stopped — and it has to be a real ack. An
+    // abort the server refused or never received leaves the run going, so
+    // completing here would close a live turn and strand every later
+    // `message.part.updated` on a finished one. The intent recorded above still
+    // stands: whenever the server does settle, that idle reports `interrupted`.
+    if (!res || !res.ok) {
+      logger.warn(
+        `OpenCode abort for session ${sessionId} was not accepted${
+          res ? `: HTTP ${res.status}` : ''
+        }; leaving the turn for the server's own idle or error to end`
+      );
+      return;
+    }
+
+    // If the idle already closed the turn this is a no-op; if the server never
+    // idles, the turn still ends here on the ack.
+    this.completeCurrentTurn('interrupted');
   }
 
   async respondToApproval(
@@ -197,12 +278,59 @@ export class OpenCodeAttachedAdapter extends AttachedRuntimeAdapter {
   ): Promise<void> {
     const allow = decision === 'allow' || decision === 'allow-always';
     const url = `${this._endpoint}/permission/${encodeURIComponent(requestId)}/${allow ? 'allow' : 'deny'}`;
-    await fetch(url, {
+    const res = await fetch(url, {
       method: 'POST',
       ...(this._messageAbortController
         ? { signal: this._messageAbortController.signal }
         : {}),
-    }).catch(() => {});
+    }).catch(() => null);
+
+    // Only claim the approval resolved when the server accepted the decision;
+    // announcing it on a failed POST would strand the UI on a lie. On success
+    // the response patch is what moves the approval item out of `pending` and
+    // drains `live.activeRequestIds` (#1412).
+    if (!res || !res.ok) {
+      logger.warn(
+        `OpenCode permission ${decision} for ${requestId} was not accepted${
+          res ? `: HTTP ${res.status}` : ''
+        }`
+      );
+      return;
+    }
+    // The turn the request was ASKED in, not whatever turn is live now: the
+    // approval may well be answered after the idle that closed its turn, and
+    // the response has to land on the same turn as the card it resolves.
+    const turnId =
+      this._approvalTurnIds.get(requestId) ?? this._currentTurnId ?? 'turn-0';
+    this._approvalTurnIds.delete(requestId);
+    this.fire({
+      type: 'chat:approval-response',
+      requestId,
+      decision,
+      respondedBy: 'user',
+      turnId,
+    });
+  }
+
+  /**
+   * Resume honesty (#1409). The base attached adapter treats `resumeSession`
+   * as a silent success, which reads as "the conversation is restored" to every
+   * caller. It is not: this adapter addresses the external server's session by
+   * `config.sessionId`, handed to it at connect, and Relay never learns an
+   * OpenCode-side conversation id it could rebind to later. That is why
+   * `PROVIDER_DESCRIPTORS['opencode-attached'].resumeStateKey` is `null` and
+   * `bridgedCapabilities.resume` is `false` — and why `providerResumeId()`
+   * returns nothing for this provider, so `channel-agent-binder` re-orients a
+   * respawned runtime from its bounded context window (#1408) instead of
+   * assuming provider memory it does not have.
+   *
+   * Failing loudly keeps that ladder honest: a caller that reaches here has
+   * bypassed the capability flag, and a silent no-op would hide the bypass.
+   */
+  override async resumeSession(sessionId: string): Promise<void> {
+    throw new Error(
+      `opencode-attached cannot resume session ${sessionId}: the attached session id comes from connect() and the server exposes no route to rebind a prior conversation (capabilities.resume is false).`
+    );
   }
 
   async respondToInput(
@@ -232,18 +360,51 @@ export class OpenCodeAttachedAdapter extends AttachedRuntimeAdapter {
     }
   }
 
+  /**
+   * End the active turn, once. Clearing `_currentTurnId` first makes every
+   * caller idempotent, so the abort ack and a racing idle cannot both fire.
+   */
+  private completeCurrentTurn(reason: OpenCodeTurnEndReason): void {
+    const turnId = this._currentTurnId;
+    this._currentTurnId = null;
+    this._interruptedTurnId = null;
+    if (!turnId) return;
+    this.fire({
+      type: 'chat:turn-completed',
+      turnId,
+      reason,
+      durationMs: 0,
+      toolCallCount: 0,
+      messageCount: 0,
+    });
+  }
+
   private readonly _eventHandlers: Record<
     string,
     ((event: OpenCodeEvent) => void) | undefined
   > = {
     'session.status': (event) => {
-      const status = event.properties?.['status'];
-      if (status === 'idle') {
-        this.fire({ type: 'chat:session-status', status: 'idle' });
-      } else if (status === 'active') {
+      // Decoded by the shared OpenCode helper, not a local copy: both lanes read
+      // the same server's `{ type: 'idle' }` / bare-string encoding, and the
+      // #1412 defect was this lane's copy drifting from it.
+      const status = openCodeStatusType(event.properties?.['status']);
+      if (status === 'active' || status === 'busy') {
         this.fire({ type: 'chat:session-status', status: 'active' });
-      } else if (status === 'error') {
+        return;
+      }
+      if (status === 'error') {
+        this.completeCurrentTurn('failed');
         this.fire({ type: 'chat:session-status', status: 'error' });
+        return;
+      }
+      if (status === 'idle') {
+        // A stop the operator asked for reports as `interrupted`; anything else
+        // reaching idle ran to the end.
+        const interrupted =
+          this._currentTurnId !== null &&
+          this._interruptedTurnId === this._currentTurnId;
+        this.completeCurrentTurn(interrupted ? 'interrupted' : 'completed');
+        this.fire({ type: 'chat:session-status', status: 'idle' });
       }
     },
 
@@ -262,10 +423,15 @@ export class OpenCodeAttachedAdapter extends AttachedRuntimeAdapter {
 
     'permission.asked': (event) => {
       const props = event.properties ?? {};
+      const requestId = String(props['requestID'] ?? 'req-0');
+      const turnId = this._currentTurnId ?? 'turn-0';
+      // Remember which turn owns this card, so the eventual response binds to
+      // the same turn even if the turn has closed by then.
+      this._approvalTurnIds.set(requestId, turnId);
       this.fire({
         type: 'chat:approval-request',
-        turnId: this._currentTurnId ?? 'turn-0',
-        requestId: String(props['requestID'] ?? 'req-0'),
+        turnId,
+        requestId,
         kind: 'permission',
         toolName: String(props['toolName'] ?? 'unknown'),
         description: String(props['description'] ?? ''),
@@ -326,12 +492,18 @@ export class OpenCodeAttachedAdapter extends AttachedRuntimeAdapter {
 
     'session.error': (event) => {
       const error = event.properties?.['error'];
+      const turnId = this._currentTurnId;
       this.fire({
         type: 'chat:error',
         kind: 'unknown',
         message: String(error ?? 'Unknown error'),
         retryable: true,
+        // Bind the failure to the turn it killed. Without this the bridge sees
+        // a session-level error it cannot attribute, and the failed terminal
+        // below would carry no message (#1412).
+        ...(turnId ? { turnId } : {}),
       });
+      this.completeCurrentTurn('failed');
     },
   };
 }

--- a/server/protocol-adapters/opencode-shared.ts
+++ b/server/protocol-adapters/opencode-shared.ts
@@ -1,0 +1,37 @@
+/**
+ * Wire vocabulary shared by the two OpenCode lanes, and by nothing else.
+ *
+ * Classification: QUIRK, deduplicated — not promoted to choreography. Nothing
+ * here is provider-agnostic, so `adapter-utils.ts` is the wrong home: putting an
+ * OpenCode encoding in the shared choreography layer would hand every other
+ * harness a rule that is only true of this one, which is the "generalized quirk"
+ * `AGENTS.md` rejects. But `OpenCodeProtocolAdapter` (Relay spawns
+ * `opencode serve`) and `OpenCodeAttachedAdapter` (an operator's own
+ * `opencode serve` / `opencode web`) consume the SAME server's SSE stream, so a
+ * second hand-written copy of its decoding is drift waiting to happen — which is
+ * exactly the #1412 defect: the attached lane compared `status === 'idle'` as a
+ * bare string while the real server sends `{ type: 'idle' }`, so its turns never
+ * ended at all.
+ *
+ * One provider, one decoder, two lanes. Anything a lane does NOT share — the
+ * spawned adapter's `retry` message extraction, the attached adapter's
+ * interrupt bookkeeping — stays in that adapter.
+ */
+
+/**
+ * Decode `session.status` into its status name.
+ *
+ * The status rides the wire in two encodings: a bare string, and the nested
+ * `{ type: 'idle' }` object the real server sends (see
+ * `test/fixtures/opencode-serve-stub.cjs` `emitTurn()`). Both are accepted;
+ * anything else decodes to `undefined` so the caller can log a gap instead of
+ * guessing a lifecycle transition.
+ */
+export function openCodeStatusType(status: unknown): string | undefined {
+  if (typeof status === 'string') return status;
+  if (status && typeof status === 'object') {
+    const type = (status as Record<string, unknown>)['type'];
+    return typeof type === 'string' ? type : undefined;
+  }
+  return undefined;
+}

--- a/shared/agent-chat-v1-compat.ts
+++ b/shared/agent-chat-v1-compat.ts
@@ -119,6 +119,17 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
         },
       ];
 
+    // #1411: this case used to ALSO synthesize an `agent-turn-completed-v2`
+    // whenever the event carried a turnId. That made the terminal patch
+    // ownerless — hermes, whose every failure path fires `chat:error` AND
+    // `chat:turn-completed`, emitted two terminals for one turn, while
+    // opencode's toast path emitted one and opencode-attached none. A pure
+    // event->patches mapper cannot tell those apart because it holds no turn
+    // state. Terminal ownership therefore lives one layer up, in
+    // `LegacyProtocolAdapterV2Bridge`, which sees the whole event stream:
+    // it emits exactly one terminal per turn, preferring the adapter's own
+    // completion (which carries the honest `reason`) and synthesizing a failed
+    // one only when the adapter never completes the errored turn.
     case 'chat:error':
       return [
         {
@@ -127,19 +138,6 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
           timestamp: event.timestamp,
           message: event.message,
         },
-        ...(event.turnId
-          ? [
-              {
-                type: 'agent-turn-completed-v2' as const,
-                sessionId: event.sessionId,
-                timestamp: event.timestamp,
-                turnId: event.turnId,
-                status: 'failed' as const,
-                completedAt: event.timestamp,
-                error: event.message,
-              },
-            ]
-          : []),
       ];
 
     case 'chat:text-delta':

--- a/test/agent-chat-v1-compat.test.ts
+++ b/test/agent-chat-v1-compat.test.ts
@@ -166,7 +166,13 @@ describe('Agent Chat v1 compatibility bridge', () => {
     ]);
   });
 
-  it('maps v1 errors to v2 session and failed-turn patches', () => {
+  // #1411 (inverted): this test used to pin the DEFECT — a `chat:error`
+  // carrying a turnId mapped to an error patch AND a synthesized terminal, so a
+  // hermes failure (which also fires `chat:turn-completed`) ended one turn
+  // twice. The mapper is now a faithful one-event-to-its-own-patches function;
+  // `LegacyProtocolAdapterV2Bridge` owns the single terminal patch, and
+  // `test/server/protocol-adapters/legacy-v2-bridge.test.ts` holds it to that.
+  it('maps a v1 error to an error patch only — never a terminal turn patch', () => {
     const event: ChatEvent = {
       type: 'chat:error',
       sessionId: 'session-1',
@@ -184,15 +190,6 @@ describe('Agent Chat v1 compatibility bridge', () => {
         sessionId: 'session-1',
         timestamp,
         message: 'OpenCode failed',
-      },
-      {
-        type: 'agent-turn-completed-v2',
-        sessionId: 'session-1',
-        timestamp,
-        turnId: 'turn-1',
-        status: 'failed',
-        completedAt: timestamp,
-        error: 'OpenCode failed',
       },
     ]);
   });

--- a/test/server/protocol-adapters/adapter-utils.test.ts
+++ b/test/server/protocol-adapters/adapter-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { reconnectWithStoredConfig } from '../../../server/protocol-adapters/adapter-utils.js';
+import {
+  ABANDONED_APPROVAL_REASON,
+  reconnectWithStoredConfig,
+  resolveAbandonedApprovals,
+  type AbandonedApprovalV2,
+} from '../../../server/protocol-adapters/adapter-utils.js';
+import type { AgentPatchV2 } from '../../../shared/agent-chat-protocol-v2.js';
 import { ClaudeProtocolAdapter } from '../../../server/protocol-adapters/claude-adapter.js';
 import { CodexNativeProtocolAdapter } from '../../../server/protocol-adapters/codex-native-adapter.js';
 import { HermesProtocolAdapter } from '../../../server/protocol-adapters/hermes-adapter.js';
@@ -110,6 +116,142 @@ describe('reconnectWithStoredConfig', () => {
         },
       })
     ).rejects.toThrow('transport refused');
+  });
+});
+
+describe('resolveAbandonedApprovals (#1407)', () => {
+  const approval = (
+    requestId: string,
+    turnId = 'turn-1'
+  ): AbandonedApprovalV2 => ({
+    requestId,
+    turnId,
+    card: {
+      id: `approval-${requestId}`,
+      kind: 'permission',
+      description: 'Agent wants to use Bash',
+      target: 'rm -rf /',
+    },
+  });
+
+  it('publishes a terminal card per approval, then one live-state drain', () => {
+    const patches: AgentPatchV2[] = [];
+    resolveAbandonedApprovals({
+      sessionId: 'session-1',
+      approvals: [approval('req-a'), approval('req-b', 'turn-2')],
+      emitPatch: (patch) => patches.push(patch),
+    });
+
+    expect(patches.map((patch) => patch.type)).toEqual([
+      'agent-item-updated-v2',
+      'agent-item-updated-v2',
+      'agent-live-state-updated-v2',
+    ]);
+
+    const first = patches[0];
+    expect(first?.type === 'agent-item-updated-v2' && first.item).toMatchObject(
+      {
+        type: 'approval',
+        id: 'approval-req-a',
+        requestId: 'req-a',
+        status: 'cancelled',
+        respondedBy: 'timeout',
+        decision: { kind: 'cancel' },
+        error: ABANDONED_APPROVAL_REASON,
+      }
+    );
+    expect(first?.type === 'agent-item-updated-v2' && first.turnId).toBe(
+      'turn-1'
+    );
+    const second = patches[1];
+    expect(second?.type === 'agent-item-updated-v2' && second.turnId).toBe(
+      'turn-2'
+    );
+
+    const drain = patches[2];
+    expect(drain?.type === 'agent-live-state-updated-v2' && drain.live).toEqual(
+      {
+        waitingOn: null,
+        activeRequestIds: [],
+      }
+    );
+  });
+
+  // The transcript must never claim a resolution the wire refused to carry, so
+  // the provider is released first and the card follows.
+  it('releases the wire before publishing the card', () => {
+    const order: string[] = [];
+    resolveAbandonedApprovals({
+      sessionId: 'session-1',
+      approvals: [approval('req-a')],
+      emitPatch: (patch) => order.push(patch.type),
+      denyOnWire: ({ requestId }) => order.push(`deny:${requestId}`),
+    });
+
+    expect(order).toEqual([
+      'deny:req-a',
+      'agent-item-updated-v2',
+      'agent-live-state-updated-v2',
+    ]);
+  });
+
+  it('emits nothing at all when no approval was outstanding', () => {
+    const emitPatch = vi.fn();
+    resolveAbandonedApprovals({
+      sessionId: 'session-1',
+      approvals: [],
+      emitPatch,
+      denyOnWire: emitPatch,
+    });
+    expect(emitPatch).not.toHaveBeenCalled();
+  });
+
+  it('carries the caller-supplied reason instead of the disconnect default', () => {
+    const patches: AgentPatchV2[] = [];
+    resolveAbandonedApprovals({
+      sessionId: 'session-1',
+      approvals: [approval('req-a')],
+      emitPatch: (patch) => patches.push(patch),
+      reason: 'Approval cancelled: the turn ended before it was answered.',
+    });
+    const card = patches[0];
+    expect(card?.type === 'agent-item-updated-v2' && card.item.error).toBe(
+      'Approval cancelled: the turn ended before it was answered.'
+    );
+  });
+
+  // Provider vocabulary is copied through untouched — the helper only owns how
+  // the card ENDS.
+  it('preserves the harness-shaped card fields', () => {
+    const patches: AgentPatchV2[] = [];
+    resolveAbandonedApprovals({
+      sessionId: 'session-1',
+      approvals: [
+        {
+          requestId: 'cmd-7',
+          turnId: 'turn-1',
+          card: {
+            id: 'approval-cmd-7',
+            kind: 'command',
+            description: 'Run command: ls',
+            target: 'ls',
+            details: { kind: 'command', command: 'ls', cwd: '/tmp' },
+            supported: {
+              scopes: ['once'],
+              amendmentTypes: [],
+              canCancel: true,
+            },
+          },
+        },
+      ],
+      emitPatch: (patch) => patches.push(patch),
+    });
+    const card = patches[0];
+    expect(card?.type === 'agent-item-updated-v2' && card.item).toMatchObject({
+      kind: 'command',
+      details: { kind: 'command', command: 'ls', cwd: '/tmp' },
+      supported: { scopes: ['once'], amendmentTypes: [], canCancel: true },
+    });
   });
 });
 

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -354,6 +354,143 @@ describe('CodexNativeProtocolAdapter — connect', () => {
   });
 });
 
+// ── System-prompt appendix (#1409) ────────────────────────────────────────────
+
+/**
+ * Relay's profile system prompt + collaboration contract reach codex through
+ * the app-server's thread-scoped `developerInstructions`.
+ *
+ * Slot choice is load-bearing and asserted, not assumed: `baseInstructions`
+ * REPLACES codex's own operating prompt, so it must never carry Relay text.
+ *
+ * Prefix-cache invariant: `ThreadStartParams`/`ThreadResumeParams` accept the
+ * field and `TurnStartParams`/`TurnSteerParams` do not (codex-cli 0.147.0,
+ * `codex app-server generate-ts --experimental`). The appendix is therefore
+ * sent once per client generation and the system region stays byte-stable
+ * across every turn of one runtime.
+ */
+describe('CodexNativeProtocolAdapter — systemPromptAppendix', () => {
+  const APPENDIX =
+    'You are Relay profile "reviewer".\n\nrole: collaborator. Reply in the channel.';
+
+  it('sends the appendix as thread/start developerInstructions, never baseInstructions', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-appendix' },
+    });
+
+    await adapter.connect({ ...config, systemPromptAppendix: APPENDIX });
+
+    const threadStart = factory.lastClient!.calls.find(
+      (call) => call.method === 'thread/start'
+    );
+    expect(threadStart?.params).toMatchObject({
+      developerInstructions: APPENDIX,
+    });
+    // `baseInstructions` is codex's own prompt template; writing Relay text
+    // there would delete the harness's operating instructions.
+    expect(threadStart?.params).not.toHaveProperty('baseInstructions');
+
+    await adapter.disconnect();
+  });
+
+  it('never repeats the appendix per turn — turn/start and turn/steer stay user-region only', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-appendix' },
+    });
+
+    await adapter.connect({ ...config, systemPromptAppendix: APPENDIX });
+    const client = factory.lastClient!;
+
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'first prompt' });
+    client.feedNotification('turn/started', { turn: { id: 'native-1' } });
+    client.serverResponses.set('turn/steer', { turnId: 'native-2' });
+    await adapter.steerMessage({
+      turnId: 'turn-1',
+      content: 'second prompt',
+    });
+
+    const turnCalls = client.calls.filter(
+      (call) => call.method === 'turn/start' || call.method === 'turn/steer'
+    );
+    expect(turnCalls).toHaveLength(2);
+    for (const call of turnCalls) {
+      expect(call.params).not.toHaveProperty('developerInstructions');
+      expect(call.params).not.toHaveProperty('baseInstructions');
+      // Not smuggled into the user turn region either: the input carries the
+      // operator's text and nothing else.
+      expect(call.params).toMatchObject({
+        input: [{ type: 'text', text: expect.not.stringContaining('Relay') }],
+      });
+    }
+    // Exactly one system-region write for the whole runtime.
+    expect(
+      client.calls.filter(
+        (call) =>
+          (call.params as Record<string, unknown> | null)?.[
+            'developerInstructions'
+          ] !== undefined
+      )
+    ).toHaveLength(1);
+
+    await adapter.disconnect();
+  });
+
+  it('replays the byte-identical appendix on thread/resume', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-appendix' },
+    });
+
+    await adapter.connect({ ...config, systemPromptAppendix: APPENDIX });
+    const startParams = factory.lastClient!.calls.find(
+      (call) => call.method === 'thread/start'
+    )?.params as Record<string, unknown>;
+
+    factory.lastClient!.serverResponses.set('thread/resume', {
+      thread: { id: 'thread-appendix' },
+    });
+    await adapter.resumeSession('thread-appendix');
+
+    const resumeParams = factory.lastClient!.calls.find(
+      (call) => call.method === 'thread/resume'
+    )?.params as Record<string, unknown>;
+    expect(resumeParams).toMatchObject({ developerInstructions: APPENDIX });
+    expect(resumeParams['developerInstructions']).toBe(
+      startParams['developerInstructions']
+    );
+
+    await adapter.disconnect();
+  });
+
+  it('omits the field entirely when the appendix is absent or blank', async () => {
+    for (const appendix of [undefined, '', '   \n  ']) {
+      const factory = makeStubFactory();
+      const adapter = new CodexNativeProtocolAdapter(factory);
+      factory.lastClient?.serverResponses.set('thread/start', {
+        thread: { id: 'thread-plain' },
+      });
+
+      await adapter.connect(
+        appendix === undefined
+          ? config
+          : { ...config, systemPromptAppendix: appendix }
+      );
+
+      const threadStart = factory.lastClient!.calls.find(
+        (call) => call.method === 'thread/start'
+      );
+      expect(threadStart?.params).not.toHaveProperty('developerInstructions');
+
+      await adapter.disconnect();
+    }
+  });
+});
+
 // ── Resume ────────────────────────────────────────────────────────────────────
 
 describe('CodexNativeProtocolAdapter — resumeSession', () => {

--- a/test/server/protocol-adapters/conformance/fixtures/claude.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/claude.fixture.ts
@@ -268,13 +268,11 @@ const fixture: AdapterConformanceFixture = {
     },
   ],
 
-  knownGaps: {
-    'b-abandoned-approval': {
-      issue: '#1407',
-      reason:
-        'onDisconnect writes the deny control_response to the child (correct on the wire) but emits no agent-item-updated-v2 resolving the approval item and no live-state patch draining activeRequestIds, so the reduced session keeps a permanently actionable approval card',
-    },
-  },
+  // No known gaps. #1407 is fixed: `onDisconnect` still writes the deny
+  // control_response to the child, but the wire deny and the terminal card are
+  // now one dance in `adapter-utils.resolveAbandonedApprovals`, so teardown
+  // also publishes the cancelled `agent-item-updated-v2` and drains
+  // `live.activeRequestIds`. `b-abandoned-approval` runs hard here.
 
   exercised: ['reasoning', 'commandExecution', 'streaming', 'telemetry'],
 

--- a/test/server/protocol-adapters/conformance/fixtures/codex.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/codex.fixture.ts
@@ -490,13 +490,10 @@ const fixture: AdapterConformanceFixture = {
     },
   ],
 
-  knownGaps: {
-    'b-abandoned-approval': {
-      issue: '#1407',
-      reason:
-        'teardownState() clears pendingApprovals/approvalMeta without settling the resolver, so handleCommandApprovalRequest never resumes: no native decision reaches the app-server and no agent-item-updated-v2 resolves the approval item. completeActiveTurn does drain live.activeRequestIds, but the reduced session keeps a permanently actionable approval card — the same shape as the claude gap',
-    },
-  },
+  // No known gaps. #1407 is fixed: `teardownState()` now answers each
+  // outstanding server request with its kind's decline envelope, publishes the
+  // cancelled card through the shared helper, and THEN settles the resolver so
+  // `handleCommandApprovalRequest` unwinds instead of awaiting forever.
 
   exercised: [
     'reasoning',

--- a/test/server/protocol-adapters/conformance/fixtures/hermes.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/hermes.fixture.ts
@@ -9,11 +9,11 @@
  *   (`response.created`, `reasoning_summary_text.delta/.done`,
  *   `output_item.added/.done` for `run_command` and `apply_patch`).
  * - `test/server/protocol-adapters/hermes-adapter.test.ts` — the v0.18.2
- *   `message` output-item reply shape (lines 838-873), the
- *   `function_call_arguments.delta/.done` buffering shape (lines 463-540), the
- *   `apply_patch` unified-diff shape (lines 542-580), the `response.error`
- *   failure shape (lines 348-379) and the `response.completed` usage payload
- *   (lines 777-809).
+ *   `message` output-item reply shape (lines 839-874), the
+ *   `function_call_arguments.delta/.done` buffering shape (lines 464-541), the
+ *   `apply_patch` unified-diff shape (lines 543-581), the `response.error`
+ *   failure shape (lines 349-380) and the `response.completed` usage payload
+ *   (lines 778-810).
  *
  * DELIBERATELY ABSENT: `response.output_text.delta`. The adapter maps it and
  * `hermes-adapter.test.ts` scripts it, but the shipping Hermes gateway
@@ -359,8 +359,10 @@ const fixture: AdapterConformanceFixture = {
   interruptedTurn: {
     // A turn cut in flight: the model has streamed a partial reasoning summary
     // and nothing else when the operator interrupts. The adapter's abort path
-    // (`hermes-adapter.ts` ~line 933) owns the terminal patch, and `interrupt()`
-    // additionally posts `/session/:id/abort` (~line 978); the stub answers
+    // (`hermes-adapter.ts` ~line 1008 — the path that also re-anchors the
+    // `previous_response_id` chain to the last finished response, #1409) owns
+    // the terminal patch, and `interrupt()` additionally posts
+    // `/session/:id/abort` (~line 1053); the stub answers
     // that route, which is what lets the harness's `guard(interrupt())` resolve
     // rather than time out.
     steps: [
@@ -412,7 +414,7 @@ const fixture: AdapterConformanceFixture = {
       // — the SSE hardening tests never exercise `permission.requested`. The
       // payload is therefore transcribed field-for-field from the only
       // authority available, `HermesProtocolAdapter.handlePermissionRequested`
-      // (`hermes-adapter.ts` ~line 1535), using its primary key spellings
+      // (`hermes-adapter.ts` ~line 1629), using its primary key spellings
       // (`requestID`, `permission.tool/description/target`) rather than its
       // fallbacks. Treat it as derived, not recorded, until a live capture
       // lands.
@@ -474,16 +476,16 @@ const fixture: AdapterConformanceFixture = {
   ],
 
   knownGaps: {
-    'a-terminal': {
-      issue: '#1411',
-      reason:
-        "the error turn emits TWO agent-turn-completed-v2 patches for conf-error: mapChatEventToAgentPatchV2 synthesizes one from chat:error (it carries a turnId) and hermes's failCurrentTurn then fires its own chat:turn-completed. Every hermes failure path fires both events, so no fixture can script a single-terminal failed turn. The simple and interrupted turns DO emit exactly one terminal patch each — that half stays asserted through expect.requiredPatchTypes on every segment",
-    },
-    'b-abandoned-approval': {
-      issue: '#1407',
-      reason:
-        'LegacyProtocolAdapterV2Bridge.onDisconnect unsubscribes from the inner adapter BEFORE calling inner.disconnect(), so the abort-driven chat:turn-completed and idle chat:session-status that would drain the approval are mapped to nothing. Same family as the claude/mock/codex gaps: the wire side is fine, the patch stream keeps a permanently actionable approval card',
-    },
+    // (a) is NOT gapped any more. #1411 is fixed: the terminal patch has a
+    // single owner in `LegacyProtocolAdapterV2Bridge`, which drops the second
+    // completion hermes's `failCurrentTurn` produces (`chat:error` +
+    // `chat:turn-completed`) and carries the error text onto the one that
+    // survives. This fixture's error turn — `response.error` mid-stream — is
+    // the exact repro from the issue, so invariant (a) now runs hard on it.
+    // `b-abandoned-approval` is NOT gapped any more either. #1407 is fixed in
+    // the same bridge seam: it keeps an approval ledger of its own and resolves
+    // whatever is outstanding on teardown, so it no longer depends on an inner
+    // teardown event arriving after it has unsubscribed.
     'e-capability-drift': {
       issue: '#1305',
       // Scoped: only the `streaming` row is gapped, so `fixtureErrors` and the

--- a/test/server/protocol-adapters/conformance/fixtures/mock.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/mock.fixture.ts
@@ -88,13 +88,10 @@ const fixture: AdapterConformanceFixture = {
     'streaming',
   ],
 
-  knownGaps: {
-    'b-abandoned-approval': {
-      issue: '#1407',
-      reason:
-        'onDisconnect aborts the turn controller and runTurn DOES emit the resolution, but BaseProtocolAdapterV2.disconnect() clears its handler set first, so no onPatch subscriber ever sees it — the approval stays pending for every consumer, not just this suite',
-    },
-  },
+  // No known gaps. #1407 is fixed: `onDisconnect` no longer leans on the
+  // aborted turn to publish the resolution a microtask later — where
+  // `BaseProtocolAdapterV2.disconnect()` had already dropped every handler —
+  // and resolves the card synchronously instead.
 
   unexercisable: [
     {

--- a/test/server/protocol-adapters/conformance/fixtures/opencode-attached.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/opencode-attached.fixture.ts
@@ -16,8 +16,8 @@
  *   - `message.part.updated` (`{ part, delta }`) — `opencode-adapter.test.ts`
  *     lines 158-187 (both the web and attached drives) and the recorded server
  *     double `test/fixtures/opencode-serve-stub.cjs` `emitTurn()`.
- *   - `session.status` — same serve stub; see the QUIRK note below on the two
- *     status encodings.
+ *   - `session.status` — same serve stub; see the note below on the wire
+ *     encoding this fixture scripts.
  *   - `tool.execute.before` / `tool.execute.after` / `permission.asked` — the
  *     property names both OpenCode adapters read off the wire
  *     (`opencode-adapter.ts` `handleToolStarted` / `handleToolFinished` /
@@ -25,39 +25,27 @@
  *     hook payloads in `server/opencode-relay.ts` carry the same `tool` /
  *     `result` nesting).
  *
- * ── Known adapter shortfalls this fixture pins (#1412, all `knownGaps`) ──────
- * The attached adapter is the only registered OpenCode surface that never
- * fires `chat:turn-completed`: `OpenCodeProtocolAdapter.handleSessionStatus`
- * closes the turn on `session.status` idle/error, the attached adapter's
- * `session.status` handler only re-broadcasts `chat:session-status`. Nothing
- * else in it produces a terminal either — its `chat:error` carries no `turnId`,
- * so `mapChatEventToAgentPatchV2` cannot synthesize the failed terminal it
- * synthesizes for turn-scoped errors. Consequence: no turn this adapter starts
- * can ever end, for any transcript.
+ * ── #1412, now closed: the terminal turn patch ──────────────────────────────
+ * This adapter used to be the only registered OpenCode surface that never
+ * fired `chat:turn-completed`, so `agent-turn-completed-v2` was unreachable in
+ * every form and no transcript could end a turn. Every invariant that reads a
+ * terminal was gapped on that one root cause. The adapter now ends its turns
+ * from `session.status` idle/error, from `session.error` (whose `chat:error`
+ * carries the `turnId` so the failure binds to the turn), and from `interrupt()`
+ * — so all of those gaps are gone and the terminal is asserted, per segment,
+ * per status. The `a-terminal` escape in `harness.ts` went with them.
  *
- * The harness's cited-gap escape (see `awaitTerminal` in `harness.ts`) lets the
- * lifecycle run past a terminal that never arrives when — and only when — a
- * fixture cites an `a-terminal` gap. So (c) no-silent-drop and (d) determinism
- * are NOT gapped here: both are asserted and both hold. Only the invariants the
- * missing terminal genuinely blocks are skipped.
+ * `session.status` is scripted in its REAL wire encoding — `{ status: { type:
+ * 'busy' | 'idle' } }`, exactly what `test/fixtures/opencode-serve-stub.cjs`
+ * `emitTurn()` sends. Before #1412 the handler compared `status === 'idle'` as
+ * a bare string and the object encoding mapped to nothing at all, so scripting
+ * the true shape here is what keeps that regression out.
  *
- * Not a UI hang today: `channel-agent-binder.ts` `handleLiveState` finalizes a
- * channel turn on a bare `live.status === 'idle'` "even when a matching
- * `agent-turn-completed-v2` never fired". The floor still asserts it, because
- * the invariant is stated at the ADAPTER boundary — and that compensation is
- * explicitly skipped while an approval is outstanding, which is exactly the
- * state this adapter can also never leave (see the `b-*` gaps).
- *
- * Two smaller shape gaps are documented here but deliberately kept OUT of the
- * scripted transcript, so invariant (c) keeps its teeth for whoever fixes the
- * terminal gap:
- *   - `session.status` on the real wire is `{ status: { type: 'idle' } }`
- *     (serve stub `emitTurn()`; `opencode-adapter.ts` `statusType()` unwraps
- *     both encodings). The attached handler compares `status === 'idle'` as a
- *     bare string, so the object encoding maps to nothing at all.
- *   - `question.asked` fires `chat:input-request`, for which
- *     `mapChatEventToAgentPatchV2` has no case — a guaranteed silent drop
- *     through the bridge.
+ * One shape gap is documented but deliberately kept OUT of the transcript, so
+ * invariant (c) keeps its teeth: `question.asked` fires `chat:input-request`,
+ * for which `mapChatEventToAgentPatchV2` has no case — a guaranteed silent drop
+ * through the bridge, the same class as the hermes `chat:telemetry` trap, and
+ * consistent with `questions: false` in the registry.
  */
 import { OpenCodeAttachedAdapter } from '../../../../../server/protocol-adapters/opencode-attached-adapter.js';
 import { LegacyProtocolAdapterV2Bridge } from '../../../../../server/protocol-adapters/legacy-v2-bridge.js';
@@ -72,10 +60,6 @@ import type {
 
 /** Relay session id; the adapter builds every session route from it. */
 const SESSION = 'conf-opencode-attached';
-
-/** Root cause every gap below shares. */
-const NO_TERMINAL_TURN_PATCH =
-  'OpenCodeAttachedAdapter never fires chat:turn-completed (its session.status handler only re-broadcasts chat:session-status, unlike OpenCodeProtocolAdapter.handleSessionStatus which closes the turn) and its chat:error carries no turnId, so the compat bridge cannot synthesize a failed terminal either. No scripted transcript can end a turn, so every invariant that reads a terminal patch is unevaluable.';
 
 /**
  * Capability set transcribed from
@@ -114,11 +98,15 @@ function native(event: unknown, label?: string): FixtureFeedStep {
     : { kind: 'native', event, label };
 }
 
-/** `session.status` in the string encoding this adapter's handler accepts. */
-function sessionStatus(status: 'active' | 'idle' | 'error'): unknown {
+/**
+ * `session.status` in the encoding the real server sends — the nested
+ * `{ status: { type } }` form `test/fixtures/opencode-serve-stub.cjs`
+ * `emitTurn()` emits, with `busy` (not `active`) as the running state.
+ */
+function sessionStatus(status: 'busy' | 'idle' | 'error'): unknown {
   return {
     type: 'session.status',
-    properties: { sessionID: SESSION, status },
+    properties: { sessionID: SESSION, status: { type: status } },
   };
 }
 
@@ -184,7 +172,7 @@ const fixture: AdapterConformanceFixture = {
 
   simpleTurn: {
     steps: [
-      native(sessionStatus('active'), 'server acknowledges the prompt'),
+      native(sessionStatus('busy'), 'server acknowledges the prompt'),
       native(textDelta('conformance ', 'conformance '), 'streamed text chunk'),
       native(
         textDelta('conformance says hi', 'says hi'),
@@ -251,15 +239,15 @@ const fixture: AdapterConformanceFixture = {
     ],
     expect: {
       terminalStatus: 'completed',
-      // `agent-turn-completed-v2` is deliberately absent: it is the one patch
-      // this adapter can never emit (#1412), and invariant (a) — not this
-      // sanity list — is where that is recorded. Re-add it the moment the
-      // adapter closes turns, so the gap cannot silently reopen.
+      // `agent-turn-completed-v2` is listed explicitly: it is the patch #1412
+      // made unreachable, so naming it here — not only in invariant (a) — is
+      // what stops the gap silently reopening.
       requiredPatchTypes: [
         'agent-turn-started-v2',
         'agent-item-delta-v2',
         'agent-item-updated-v2',
         'agent-live-state-updated-v2',
+        'agent-turn-completed-v2',
       ],
       textIncludes: ['pwd'],
     },
@@ -267,7 +255,7 @@ const fixture: AdapterConformanceFixture = {
 
   interruptedTurn: {
     steps: [
-      native(sessionStatus('active'), 'server acknowledges the prompt'),
+      native(sessionStatus('busy'), 'server acknowledges the prompt'),
       native(
         textDelta('conformance long ', 'conformance long '),
         'partial answer before the interrupt'
@@ -282,7 +270,7 @@ const fixture: AdapterConformanceFixture = {
 
   errorTurn: {
     steps: [
-      native(sessionStatus('active'), 'server acknowledges the prompt'),
+      native(sessionStatus('busy'), 'server acknowledges the prompt'),
       native(
         {
           type: 'session.error',
@@ -299,7 +287,7 @@ const fixture: AdapterConformanceFixture = {
 
   approvalFlow: {
     request: [
-      native(sessionStatus('active'), 'server acknowledges the prompt'),
+      native(sessionStatus('busy'), 'server acknowledges the prompt'),
       native(
         {
           type: 'permission.asked',
@@ -341,29 +329,11 @@ const fixture: AdapterConformanceFixture = {
     },
   ],
 
-  knownGaps: {
-    'a-terminal': { issue: '#1412', reason: NO_TERMINAL_TURN_PATCH },
-    'b-approval-ids': {
-      issue: '#1412',
-      reason: `${NO_TERMINAL_TURN_PATCH} Independently: respondToApproval() POSTs /permission/<id>/allow and fires nothing, so the pending approval item never reaches a resolved state either.`,
-    },
-    'b-teardown': {
-      issue: '#1412',
-      reason: `${NO_TERMINAL_TURN_PATCH} Independently: nothing drains live.activeRequestIds, so the approval raised by permission.asked stays pending through disconnect().`,
-    },
-    'b-abandoned-approval': {
-      issue: '#1412',
-      reason: `${NO_TERMINAL_TURN_PATCH} Independently: onDetach() only aborts the SSE and message controllers — it neither denies the outstanding permission on the wire nor emits any patch resolving the approval item.`,
-    },
-    // (c) and (d) are NOT gapped: with the harness's cited-gap escape the run
-    // completes, and both hold — every scripted event maps to a patch and two
-    // replays agree. They stay asserted so the terminal gap cannot be used as
-    // cover for a second regression.
-    'e-capability-drift': {
-      issue: '#1412',
-      reason: `${NO_TERMINAL_TURN_PATCH} Independently: capabilities.interrupt is declared true, but with no terminal patch of any status the interrupt detector can never see an interrupted turn, so the flag is unbacked end to end.`,
-    },
-  },
+  // No known gaps. Everything #1412 gapped is asserted — (a) terminal, every
+  // (b) approval invariant, and (e) capability drift — and #1407 with it: the
+  // bridge now denies the outstanding permission through
+  // `inner.respondToApproval` and publishes the cancelled card itself, so
+  // `onDetach()` aborting its controllers no longer strands the approval.
 };
 
 export default fixture;

--- a/test/server/protocol-adapters/conformance/fixtures/opencode.fixture.ts
+++ b/test/server/protocol-adapters/conformance/fixtures/opencode.fixture.ts
@@ -394,7 +394,7 @@ const fixture: AdapterConformanceFixture = {
     {
       capability: 'reasoning',
       reason:
-        'SUSPECTED REGISTRY DRIFT, not a fixture gap: `OpenCodeProtocolAdapter` never fires `chat:reasoning` on any code path (`handleMessagePartUpdated` returns early unless `part.type === "text"`), so no transcript over this transport can manifest it. Reported as UNKNOWN rather than DRIFT because the harness cannot distinguish "adapter has no path" from "fixture did not drive it" — see the fixture notes on #1407-adjacent capability honesty.',
+        'SUSPECTED REGISTRY DRIFT, not a fixture gap: `OpenCodeProtocolAdapter` never fires `chat:reasoning` on any code path (`handleMessagePartUpdated` returns early unless `part.type === "text"`), so no transcript over this transport can manifest it. Reported as UNKNOWN rather than DRIFT because the harness cannot distinguish "adapter has no path" from "fixture did not drive it".',
     },
     {
       capability: 'fileChanges',
@@ -423,13 +423,11 @@ const fixture: AdapterConformanceFixture = {
     },
   ],
 
-  knownGaps: {
-    'b-abandoned-approval': {
-      issue: '#1407',
-      reason:
-        'opencode variant of the shared teardown gap: `LegacyProtocolAdapterV2Bridge.onDisconnect` unsubscribes from the inner adapter BEFORE awaiting `inner.disconnect()`, so the `chat:turn-completed` + idle `chat:session-status` the aborted message POST produces are mapped by nobody. The pending approval item and `live.activeRequestIds` survive into the reduced session.',
-    },
-  },
+  // No known gaps. #1407 is fixed for the whole legacy family at once:
+  // `LegacyProtocolAdapterV2Bridge` keeps its own approval ledger — fed by the
+  // patches it publishes, so it needs no opencode vocabulary — and resolves
+  // whatever is still outstanding on teardown instead of hoping an inner
+  // teardown event it has already unsubscribed from would do it.
 };
 
 export default fixture;

--- a/test/server/protocol-adapters/conformance/harness-self.test.ts
+++ b/test/server/protocol-adapters/conformance/harness-self.test.ts
@@ -258,17 +258,21 @@ describe('conformance harness self-tests', () => {
     );
   });
 
-  it('(b) the abandoned-approval probe reports the stranded approval claude leaves (#1407)', async () => {
-    // Red-to-green pin for #1407. The probe is otherwise dead code today (every
-    // approval-bearing fixture gaps `b-abandoned-approval`), so this is the one
-    // place it actually runs — and it must SEE the defect, not shrug at it.
-    // When #1407 lands, this expectation flips to `toEqual([])` and the
-    // per-fixture `b-abandoned-approval` gaps come out.
+  it('(b) the abandoned-approval probe sees claude resolve the stranded approval (#1407)', async () => {
+    // Inverted when #1407 landed: this used to pin the DEFECT (at least one
+    // approval left pending) because every approval-bearing fixture gapped
+    // `b-abandoned-approval` and the probe ran nowhere else. The per-fixture
+    // gaps are gone now, so the invariant bites for real on every adapter and
+    // this test holds the same line at the probe level.
     const abandoned = await runAbandonedApprovalProbe(claudeFixture);
     expect(
-      pendingApprovalIds(abandoned).length,
-      'claude disconnects with the approval still pending — if this is now empty, #1407 is fixed: drop the knownGaps entries and invert this test'
-    ).toBeGreaterThan(0);
+      pendingApprovalIds(abandoned),
+      'claude must resolve outstanding approvals on disconnect (#1407)'
+    ).toEqual([]);
+    expect(
+      abandoned.live.activeRequestIds,
+      'claude must drain live.activeRequestIds on disconnect (#1407)'
+    ).toEqual([]);
   }, 30_000);
 
   it('(b) the probe fails loudly when a transcript surfaces no approval at all', async () => {

--- a/test/server/protocol-adapters/conformance/harness.ts
+++ b/test/server/protocol-adapters/conformance/harness.ts
@@ -40,12 +40,6 @@ const QUIESCENCE_POLLS = 3;
 const QUIESCENCE_BUDGET_MS = 250;
 /** Upper bound on any single `waitFor` predicate. */
 const WAIT_TIMEOUT_MS = 3_000;
-/**
- * Shorter budget for a wait the fixture has already told us will fail (a cited
- * `a-terminal` gap). Spending the full budget four times per run, twice per
- * determinism check, is pure wall clock — nothing is asserted on the result.
- */
-const GAPPED_WAIT_TIMEOUT_MS = 500;
 /** Upper bound on one whole lifecycle run. */
 export const LIFECYCLE_TIMEOUT_MS = 30_000;
 
@@ -438,42 +432,20 @@ export async function runLifecycle(
   };
 
   /**
-   * Invariant (a) is the one gap that can abort the whole run: an adapter that
-   * never ends a turn stalls every later segment. When the fixture cites an
-   * `a-terminal` gap the harness keeps going, so the remaining invariants stay
-   * assessable instead of collapsing into one un-diagnosable timeout. Any other
-   * adapter still fails here, loudly.
+   * A missing terminal aborts the whole run: an adapter that never ends a turn
+   * stalls every later segment, so there is nothing honest to report past it.
+   * This used to carry an escape for a fixture citing an `a-terminal` gap —
+   * `opencode-attached` was its only user, and #1412 closed that hole, so the
+   * wait is unconditional again and every adapter fails here, loudly.
    */
-  const terminalGapped = fixture.knownGaps?.['a-terminal'] !== undefined;
-  const turnBudgetMs = terminalGapped
-    ? GAPPED_WAIT_TIMEOUT_MS
-    : WAIT_TIMEOUT_MS;
-
   const awaitTerminal = async (
     segment: TurnSegmentName,
     turnId: string
   ): Promise<void> => {
-    try {
-      await waitFor(
-        () => hasTerminal(patches, turnId),
-        `${segment} terminal turn patch (${turnId})`,
-        turnBudgetMs
-      );
-    } catch (err) {
-      if (!terminalGapped) throw err;
-    }
-  };
-
-  /** Same tolerance for the promises a never-ending turn can strand. */
-  const guardTurnPromise = async (
-    promise: Promise<unknown>,
-    label: string
-  ): Promise<void> => {
-    try {
-      await guard(promise, label, turnBudgetMs);
-    } catch (err) {
-      if (!terminalGapped) throw err;
-    }
+    await waitFor(
+      () => hasTerminal(patches, turnId),
+      `${segment} terminal turn patch (${turnId})`
+    );
   };
 
   const runTurnSegment = async (
@@ -512,9 +484,8 @@ export async function runLifecycle(
     }
 
     await awaitTerminal(segment, turnId);
-    if (interrupted)
-      await guardTurnPromise(interrupted, `${segment} interrupt()`);
-    await guardTurnPromise(send, `${segment} sendMessage()`);
+    if (interrupted) await guard(interrupted, `${segment} interrupt()`);
+    await guard(send, `${segment} sendMessage()`);
     await settle();
     segments[segment] = patches.slice(start);
   };
@@ -562,7 +533,7 @@ export async function runLifecycle(
     }
 
     await awaitTerminal(segment, turnId);
-    await guardTurnPromise(send, `${segment} sendMessage()`);
+    await guard(send, `${segment} sendMessage()`);
     await settle();
     segments[segment] = patches.slice(start);
   };
@@ -1228,7 +1199,9 @@ export function describeAdapterConformance(
   );
 
   // The harder half: tear down while an approval is still outstanding. A
-  // fixture without an approvalFlow has nothing to abandon.
+  // fixture without an approvalFlow has nothing to abandon — which is only a
+  // legitimate answer when the registry does not claim approvals at all, so
+  // the else-branch below refuses to let a declared capability go unprobed.
   if (fixture.approvalFlow) {
     invariant(
       'b-abandoned-approval',
@@ -1245,6 +1218,17 @@ export function describeAdapterConformance(
           `[${adapterId}] disconnecting on a live approval left live.activeRequestIds populated`
         ).toEqual([]);
       }
+    );
+  } else {
+    it(
+      '(b) an adapter that declares approvals scripts one to abandon',
+      () => {
+        expect(
+          registeredAdapter(adapterId).capabilities.approvals === true,
+          `[${adapterId}] registry declares approvals:true but the fixture has no approvalFlow, so the abandoned-approval invariant (#1407) cannot run`
+        ).toBe(false);
+      },
+      LIFECYCLE_TIMEOUT_MS
     );
   }
 

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createAdapterV2 } from '../../../server/protocol-adapters/index.js';
 import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
 import {
+  buildRelayHermesSessionInstructions,
   HermesProtocolAdapter,
   resolveHermesGatewaySettings,
 } from '../../../server/protocol-adapters/hermes-adapter.js';
@@ -979,5 +980,320 @@ describe('Hermes assistant reply finalization (#1181)', () => {
     const completes = assistantCompletes(events);
     expect(completes).toHaveLength(1);
     expect(completes[0]).toMatchObject({ content: 'ok' });
+  });
+});
+
+/**
+ * #1409 (1): Hermes has no separate system-prompt slot — the Responses API's
+ * `instructions` field IS the system region — so `config.systemPromptAppendix`
+ * (the profile prompt + Relay's collaboration contract, assembled in
+ * `server/channel-agent-runtime.ts`) must be folded into the instructions block
+ * the adapter already sends per `/v1/responses` call. Before this it was
+ * silently dropped and hermes profiles ran with no profile prompt at all.
+ *
+ * The second assertion in each case is the prefix-cache invariant: the system
+ * region must be byte-identical across every turn of one runtime, which is why
+ * the adapter composes it once at connect instead of per turn.
+ */
+describe('Hermes systemPromptAppendix delivery (#1409)', () => {
+  const APPENDIX =
+    'You are the ebi profile.\n\nRelay collaboration contract: report back in the channel.';
+
+  let gateway: InlineGateway | undefined;
+  let adapter: HermesProtocolAdapter | undefined;
+
+  afterEach(async () => {
+    if (adapter) {
+      await adapter.disconnect().catch(() => {});
+      adapter = undefined;
+    }
+    if (gateway) {
+      await new Promise<void>((resolve) =>
+        gateway!.server.close(() => resolve())
+      );
+      gateway = undefined;
+    }
+  });
+
+  async function startCompletingGateway(): Promise<InlineGateway> {
+    let turn = 0;
+    return startInlineGateway((send, res) => {
+      const id = `resp_appendix_${++turn}`;
+      send({ type: 'response.created', response: { id } });
+      send({ type: 'response.output_text.done', text: 'ok' });
+      send({
+        type: 'response.completed',
+        response: { id, status: 'completed' },
+      });
+      res.end();
+    });
+  }
+
+  it('folds the appendix into instructions after the channel prompt, byte-identically on every turn', async () => {
+    gateway = await startCompletingGateway();
+    adapter = new HermesProtocolAdapter();
+
+    await adapter.connect({
+      ...configFor(gateway.endpoint, 'sess-appendix-1'),
+      systemPromptAppendix: APPENDIX,
+      extra: {
+        endpoint: gateway.endpoint,
+        apiToken: 'inline-key',
+        instructions: 'Prefer terse answers.',
+      },
+    });
+    await adapter.sendMessage('turn-1', 'hello');
+    await adapter.sendMessage('turn-2', 'again');
+
+    const relayContext = buildRelayHermesSessionInstructions({
+      sessionId: 'sess-appendix-1',
+      cwd: process.cwd(),
+    });
+    expect(gateway.requests).toHaveLength(2);
+    // Relay session context, then channel promptDefaults, then the Relay
+    // appendix LAST so channel-authored text cannot redefine the boundary.
+    expect(gateway.requests[0]?.['instructions']).toBe(
+      `${relayContext}\n\nPrefer terse answers.\n\n${APPENDIX}`
+    );
+    expect(gateway.requests[1]?.['instructions']).toBe(
+      gateway.requests[0]?.['instructions']
+    );
+  });
+
+  it('delivers the appendix when the channel has no promptDefaults of its own', async () => {
+    gateway = await startCompletingGateway();
+    adapter = new HermesProtocolAdapter();
+
+    await adapter.connect({
+      ...configFor(gateway.endpoint, 'sess-appendix-2'),
+      systemPromptAppendix: APPENDIX,
+    });
+    await adapter.sendMessage('turn-1', 'hello');
+
+    const relayContext = buildRelayHermesSessionInstructions({
+      sessionId: 'sess-appendix-2',
+      cwd: process.cwd(),
+    });
+    expect(gateway.requests[0]?.['instructions']).toBe(
+      `${relayContext}\n\n${APPENDIX}`
+    );
+  });
+
+  it('keeps the one-shot ticket kickoff after the appendix and drops it on later turns', async () => {
+    gateway = await startCompletingGateway();
+    adapter = new HermesProtocolAdapter();
+
+    await adapter.connect({
+      ...configFor(gateway.endpoint, 'sess-appendix-3'),
+      systemPromptAppendix: APPENDIX,
+      extra: {
+        endpoint: gateway.endpoint,
+        apiToken: 'inline-key',
+        initialInstructions: 'You are working on ticket GH-42.',
+      },
+    });
+    await adapter.sendMessage('turn-1', 'hello');
+    await adapter.sendMessage('turn-2', 'again');
+
+    const relayContext = buildRelayHermesSessionInstructions({
+      sessionId: 'sess-appendix-3',
+      cwd: process.cwd(),
+    });
+    expect(gateway.requests[0]?.['instructions']).toBe(
+      `${relayContext}\n\n${APPENDIX}\n\nYou are working on ticket GH-42.`
+    );
+    // The persistent region stays byte-stable; only the one-shot kickoff drops.
+    expect(gateway.requests[1]?.['instructions']).toBe(
+      `${relayContext}\n\n${APPENDIX}`
+    );
+  });
+
+  it('ignores a whitespace-only appendix instead of padding the system region', async () => {
+    gateway = await startCompletingGateway();
+    adapter = new HermesProtocolAdapter();
+
+    await adapter.connect({
+      ...configFor(gateway.endpoint, 'sess-appendix-4'),
+      systemPromptAppendix: '   \n  ',
+    });
+    await adapter.sendMessage('turn-1', 'hello');
+
+    expect(gateway.requests[0]?.['instructions']).toBe(
+      buildRelayHermesSessionInstructions({
+        sessionId: 'sess-appendix-4',
+        cwd: process.cwd(),
+      })
+    );
+  });
+});
+
+/**
+ * #1409 (2): a user interrupt used to null `_lastResponseId`, so the turn after
+ * ANY interrupt posted without `previous_response_id` and Hermes started a
+ * fresh, context-free conversation. The next turn must re-anchor to the last
+ * response the gateway actually finished — and must never resurrect the
+ * in-flight id of the response that was aborted.
+ */
+describe('Hermes interrupt chain re-anchor (#1409)', () => {
+  let gateway: InlineGateway | undefined;
+  let adapter: HermesProtocolAdapter | undefined;
+
+  afterEach(async () => {
+    if (adapter) {
+      await adapter.disconnect().catch(() => {});
+      adapter = undefined;
+    }
+    if (gateway) {
+      await new Promise<void>((resolve) =>
+        gateway!.server.close(() => resolve())
+      );
+      gateway = undefined;
+    }
+  });
+
+  async function waitFor(
+    predicate: () => boolean,
+    what: string
+  ): Promise<void> {
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if (predicate()) return;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error(`timed out waiting for ${what}`);
+  }
+
+  it('chains the turn after an interrupt from the last completed response, not the aborted one', async () => {
+    let turn = 0;
+    gateway = await startInlineGateway((send, res) => {
+      turn += 1;
+      if (turn === 2) {
+        // The interrupted turn: the response is created and starts thinking,
+        // then the stream stays open until the client aborts it. Its id is
+        // never finished upstream, so it must not become the next anchor.
+        send({
+          type: 'response.created',
+          response: { id: 'resp_interrupted_2' },
+        });
+        send({
+          type: 'response.reasoning_summary_text.delta',
+          delta: 'thinking...',
+        });
+        return;
+      }
+      const id = `resp_completed_${turn}`;
+      send({ type: 'response.created', response: { id } });
+      send({ type: 'response.output_text.done', text: 'ok' });
+      send({
+        type: 'response.completed',
+        response: { id, status: 'completed' },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-interrupt-1'));
+    await adapter.sendMessage('turn-1', 'remember 42');
+
+    const interrupted = adapter.sendMessage('turn-2', 'and then?');
+    // Wait until the adapter has really consumed `response.created` for the
+    // in-flight response, so this test proves the re-anchor rather than an
+    // anchor that was never advanced.
+    await waitFor(
+      () => events.some((event) => event.type === 'chat:reasoning'),
+      'the interrupted turn to start streaming'
+    );
+    await adapter.interrupt('turn-2');
+    await interrupted;
+
+    const completed = events.filter(
+      (event) => event.type === 'chat:turn-completed'
+    );
+    expect(completed.at(-1)).toMatchObject({
+      turnId: 'turn-2',
+      reason: 'interrupted',
+    });
+
+    await adapter.sendMessage('turn-3', 'continue');
+    expect(gateway.requests).toHaveLength(3);
+    expect(gateway.requests[2]?.['previous_response_id']).toBe(
+      'resp_completed_1'
+    );
+  });
+
+  it('re-anchors to the resumed response id when the first turn after resume is interrupted', async () => {
+    let turn = 0;
+    gateway = await startInlineGateway((send, res) => {
+      turn += 1;
+      if (turn === 1) {
+        send({
+          type: 'response.created',
+          response: { id: 'resp_interrupted_1' },
+        });
+        send({
+          type: 'response.reasoning_summary_text.delta',
+          delta: 'thinking...',
+        });
+        return;
+      }
+      send({ type: 'response.created', response: { id: 'resp_after' } });
+      send({
+        type: 'response.completed',
+        response: { id: 'resp_after', status: 'completed' },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-interrupt-2'));
+    await adapter.resumeSession('resp_restored_from_disk');
+
+    const interrupted = adapter.sendMessage('turn-1', 'continue');
+    await waitFor(
+      () => events.some((event) => event.type === 'chat:reasoning'),
+      'the interrupted turn to start streaming'
+    );
+    await adapter.interrupt('turn-1');
+    await interrupted;
+
+    await adapter.sendMessage('turn-2', 'again');
+    expect(gateway.requests[1]?.['previous_response_id']).toBe(
+      'resp_restored_from_disk'
+    );
+  });
+
+  it('re-anchors after a failed response instead of dropping the chain', async () => {
+    let turn = 0;
+    gateway = await startInlineGateway((send, res) => {
+      turn += 1;
+      if (turn === 2) {
+        send({ type: 'response.created', response: { id: 'resp_failed_2' } });
+        send({ type: 'response.error', message: 'gateway blew up' });
+        res.end();
+        return;
+      }
+      const id = `resp_completed_${turn}`;
+      send({ type: 'response.created', response: { id } });
+      send({
+        type: 'response.completed',
+        response: { id, status: 'completed' },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-interrupt-3'));
+    await adapter.sendMessage('turn-1', 'remember 42');
+    await adapter.sendMessage('turn-2', 'boom');
+    await adapter.sendMessage('turn-3', 'continue');
+
+    expect(gateway.requests).toHaveLength(3);
+    expect(gateway.requests[2]?.['previous_response_id']).toBe(
+      'resp_completed_1'
+    );
   });
 });

--- a/test/server/protocol-adapters/legacy-v2-bridge.test.ts
+++ b/test/server/protocol-adapters/legacy-v2-bridge.test.ts
@@ -7,8 +7,14 @@ import type {
   SessionOptions,
 } from '../../../server/protocol-adapter.js';
 import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
-import type { AgentCapabilitySetV2 } from '../../../shared/agent-chat-protocol-v2.js';
-import type { ChatEventSource } from '../../../shared/chat-events.js';
+import type {
+  AgentCapabilitySetV2,
+  AgentPatchV2,
+} from '../../../shared/agent-chat-protocol-v2.js';
+import type {
+  ChatEvent,
+  ChatEventSource,
+} from '../../../shared/chat-events.js';
 
 const BASE_CONFIG: AdapterConfig = {
   cwd: '/repo',
@@ -112,4 +118,392 @@ describe('LegacyProtocolAdapterV2Bridge reconnect', () => {
     expect(patches).toContain('agent-turn-started-v2');
     expect(patches).toContain('agent-item-updated-v2');
   });
+});
+
+/**
+ * A legacy adapter whose event stream the test writes by hand, so each failure
+ * choreography below is the SHAPE a real adapter fires, replayed exactly.
+ */
+class ScriptedLegacyAdapter extends BaseProtocolAdapter {
+  readonly agentType = 'mock';
+  readonly runtimeOwnership = 'attached' as const;
+
+  private currentStatus: AdapterStatus = 'disconnected';
+
+  get status(): AdapterStatus {
+    return this.currentStatus;
+  }
+
+  async connect(_config: AdapterConfig): Promise<void> {
+    this.currentStatus = 'connected';
+  }
+
+  protected async onDisconnect(): Promise<void> {
+    this.currentStatus = 'disconnected';
+  }
+
+  /**
+   * How this harness answers on its own wire. Both OpenCode lanes fire a
+   * `chat:approval-response` once the provider accepts the decision, so a test
+   * that needs the real teardown race installs that echo here.
+   */
+  approvalWireEcho:
+    | ((requestId: string, decision: 'allow' | 'allow-always' | 'deny') => void)
+    | null = null;
+
+  async reconnect(): Promise<void> {}
+  async sendMessage(): Promise<void> {}
+  async interrupt(): Promise<void> {}
+  async respondToApproval(
+    requestId: string,
+    decision: 'allow' | 'allow-always' | 'deny'
+  ): Promise<void> {
+    const echo = this.approvalWireEcho;
+    if (!echo) return;
+    // A real wire answers after a round-trip, so the echo lands on a LATER
+    // microtask than the cancelled card — which is the ordering the fix has to
+    // survive, not a synchronous one it would win by accident.
+    await Promise.resolve();
+    echo(requestId, decision);
+  }
+  async respondToInput(): Promise<void> {}
+  async createSession(): Promise<string> {
+    return 'created-session';
+  }
+  async resumeSession(): Promise<void> {}
+  async forkSession(): Promise<string> {
+    return 'forked-session';
+  }
+
+  /** Fire one legacy event, filling in the envelope every adapter sets. */
+  fire(event: Partial<ChatEvent> & Pick<ChatEvent, 'type'>): void {
+    this.emit({
+      sessionId: 'sess-bridge',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      source: 'mock' as ChatEventSource,
+      ...event,
+    } as ChatEvent);
+  }
+
+  startTurn(turnId: string): void {
+    this.fire({ type: 'chat:turn-started', turnId, turnIndex: 0 });
+  }
+}
+
+async function bridgeWithScript(): Promise<{
+  inner: ScriptedLegacyAdapter;
+  bridge: LegacyProtocolAdapterV2Bridge;
+  patches: AgentPatchV2[];
+  drain: () => Promise<void>;
+}> {
+  const inner = new ScriptedLegacyAdapter();
+  const bridge = new LegacyProtocolAdapterV2Bridge(inner, CAPABILITIES);
+  const patches: AgentPatchV2[] = [];
+  bridge.onPatch((patch) => patches.push(patch));
+  await bridge.connect(BASE_CONFIG);
+  // The bridge's fallback completion is deferred by exactly one microtask, so
+  // one awaited tick is the whole wait — no wall clock, nothing to flake on.
+  const drain = async (): Promise<void> => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+  return { inner, bridge, patches, drain };
+}
+
+function terminals(
+  patches: AgentPatchV2[],
+  turnId: string
+): Extract<AgentPatchV2, { type: 'agent-turn-completed-v2' }>[] {
+  return patches.filter(
+    (
+      patch
+    ): patch is Extract<AgentPatchV2, { type: 'agent-turn-completed-v2' }> =>
+      patch.type === 'agent-turn-completed-v2' && patch.turnId === turnId
+  );
+}
+
+/**
+ * #1411 (inverted pins). These used to be impossible to state: the terminal
+ * `agent-turn-completed-v2` had no owner, so hermes emitted two per failed
+ * turn, opencode one or two depending on which failure path fired, and
+ * opencode-attached none. The bridge now owns it, and the conformance floor
+ * re-arms hermes's invariant (a) on the back of these.
+ */
+describe('LegacyProtocolAdapterV2Bridge terminal turn ownership (#1411)', () => {
+  it('emits ONE terminal when the adapter pairs chat:error with its own completion (hermes failCurrentTurn)', async () => {
+    const { inner, patches, drain } = await bridgeWithScript();
+    inner.startTurn('turn-1');
+
+    // hermes-adapter.ts `failCurrentTurn`: error, then the adapter's own
+    // completion carrying the honest reason, then the error session status.
+    inner.fire({
+      type: 'chat:error',
+      kind: 'protocol',
+      message: 'gateway blew up',
+      retryable: true,
+      turnId: 'turn-1',
+    });
+    inner.fire({
+      type: 'chat:turn-completed',
+      turnId: 'turn-1',
+      reason: 'failed',
+      durationMs: 0,
+      toolCallCount: 0,
+      messageCount: 0,
+    });
+    inner.fire({ type: 'chat:session-status', status: 'error' });
+    await drain();
+
+    const completed = terminals(patches, 'turn-1');
+    expect(
+      completed.length,
+      'hermes fires chat:error AND chat:turn-completed on every failure path — the bridge must publish one terminal, not two'
+    ).toBe(1);
+    expect(completed[0]?.status).toBe('failed');
+    // The error text used to ride the synthesized patch; it now rides the one
+    // terminal that survives, so a failed turn still says why.
+    expect(completed[0]?.error).toBe('gateway blew up');
+  });
+
+  it("keeps the adapter's own reason instead of flattening it to failed", async () => {
+    const { inner, patches, drain } = await bridgeWithScript();
+    inner.startTurn('turn-1');
+
+    // hermes `response.incomplete` fails the turn with reason 'error', and an
+    // aborted turn completes with reason 'interrupted' — neither is 'failed'.
+    inner.fire({
+      type: 'chat:error',
+      kind: 'protocol',
+      message: 'Hermes response is incomplete: max_output_tokens',
+      retryable: true,
+      turnId: 'turn-1',
+    });
+    inner.fire({
+      type: 'chat:turn-completed',
+      turnId: 'turn-1',
+      reason: 'interrupted',
+      durationMs: 0,
+      toolCallCount: 0,
+      messageCount: 0,
+    });
+    await drain();
+
+    const completed = terminals(patches, 'turn-1');
+    expect(completed.length).toBe(1);
+    expect(completed[0]?.status).toBe('interrupted');
+  });
+
+  it('completes the turn itself when the adapter errors without completing (opencode tui.toast.show)', async () => {
+    const { inner, patches, drain } = await bridgeWithScript();
+    inner.startTurn('turn-1');
+
+    // opencode-adapter.ts `failCurrentTurn`: error + error status, and the turn
+    // is never completed on the wire.
+    inner.fire({
+      type: 'chat:error',
+      kind: 'unknown',
+      message: 'OpenCode: conformance provider failure',
+      retryable: true,
+      turnId: 'turn-1',
+    });
+    inner.fire({
+      type: 'chat:session-status',
+      status: 'error',
+      error: 'OpenCode: conformance provider failure',
+    });
+    await drain();
+
+    const completed = terminals(patches, 'turn-1');
+    expect(
+      completed.length,
+      'nothing else will ever end this turn — the bridge owes it a terminal'
+    ).toBe(1);
+    expect(completed[0]?.status).toBe('failed');
+    expect(completed[0]?.error).toBe('OpenCode: conformance provider failure');
+    // Ownership is not a licence to reorder: the error patch still precedes it.
+    expect(patches.map((patch) => patch.type)).toEqual([
+      'agent-turn-started-v2',
+      'agent-error-v2',
+      'agent-live-state-updated-v2',
+      'agent-turn-completed-v2',
+    ]);
+  });
+
+  it('drops a second completion for a turn that already ended (opencode idle + POST resolution)', async () => {
+    const { inner, patches, drain } = await bridgeWithScript();
+    inner.startTurn('turn-1');
+
+    // `handleSessionStatus('idle')` completes the turn from the SSE stream and
+    // the resolving message POST completes it again with the same turn id.
+    for (let i = 0; i < 2; i += 1) {
+      inner.fire({
+        type: 'chat:turn-completed',
+        turnId: 'turn-1',
+        reason: 'completed',
+        durationMs: 0,
+        toolCallCount: 0,
+        messageCount: 1,
+      });
+    }
+    await drain();
+
+    expect(terminals(patches, 'turn-1').length).toBe(1);
+  });
+
+  it('does not manufacture a terminal for an error with no turn id', async () => {
+    const { inner, patches, drain } = await bridgeWithScript();
+    inner.startTurn('turn-1');
+
+    // An error with no turnId is a session-level event that binds to no turn,
+    // so guessing one here would attribute a failure to whatever happened to be
+    // running. This was opencode-attached's `session.error` shape until #1412
+    // made it carry the turnId; the bridge rule is unchanged and still applies
+    // to any adapter that reports a session-level failure.
+    inner.fire({
+      type: 'chat:error',
+      kind: 'unknown',
+      message: 'conformance provider failure',
+      retryable: true,
+    });
+    await drain();
+
+    expect(terminals(patches, 'turn-1')).toEqual([]);
+  });
+
+  it('leaves a later turn free to end on its own after an errored one', async () => {
+    const { inner, patches, drain } = await bridgeWithScript();
+
+    inner.startTurn('turn-1');
+    inner.fire({
+      type: 'chat:error',
+      kind: 'unknown',
+      message: 'first turn died',
+      retryable: true,
+      turnId: 'turn-1',
+    });
+    await drain();
+
+    inner.startTurn('turn-2');
+    inner.fire({
+      type: 'chat:turn-completed',
+      turnId: 'turn-2',
+      reason: 'completed',
+      durationMs: 0,
+      toolCallCount: 0,
+      messageCount: 1,
+    });
+    await drain();
+
+    expect(terminals(patches, 'turn-1').map((patch) => patch.status)).toEqual([
+      'failed',
+    ]);
+    expect(terminals(patches, 'turn-2').map((patch) => patch.status)).toEqual([
+      'completed',
+    ]);
+  });
+
+  it('does not fire an armed fallback after disconnect', async () => {
+    const { inner, bridge, patches } = await bridgeWithScript();
+    inner.startTurn('turn-1');
+    inner.fire({
+      type: 'chat:error',
+      kind: 'unknown',
+      message: 'died on the way out',
+      retryable: true,
+      turnId: 'turn-1',
+    });
+    await bridge.disconnect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(terminals(patches, 'turn-1')).toEqual([]);
+  });
+});
+
+/** Every approval patch the bridge published for one request id, in order. */
+function approvalItems(
+  patches: AgentPatchV2[],
+  requestId: string
+): { status?: string; respondedBy?: string }[] {
+  return patches.flatMap((patch) => {
+    if (
+      patch.type !== 'agent-item-started-v2' &&
+      patch.type !== 'agent-item-updated-v2'
+    ) {
+      return [];
+    }
+    if (patch.item.type !== 'approval' || patch.item.requestId !== requestId) {
+      return [];
+    }
+    return [
+      {
+        ...(patch.item.status === undefined
+          ? {}
+          : { status: patch.item.status }),
+        ...(patch.item.respondedBy === undefined
+          ? {}
+          : { respondedBy: patch.item.respondedBy }),
+      },
+    ];
+  });
+}
+
+/**
+ * #1407, teardown ordering. The cancelled card is only the LAST word if the
+ * inner subscription is gone before the wire deny goes out: the deny is
+ * unawaited and both OpenCode lanes answer it with a `chat:approval-response`,
+ * which maps to a `completed` / `respondedBy: 'user'` update. `onDisconnect`
+ * always unlistened first; `reconnect` used to cancel with the subscription
+ * still attached, so the transcript ended up claiming the operator denied an
+ * approval they never saw.
+ */
+describe('LegacyProtocolAdapterV2Bridge approval teardown ordering (#1407)', () => {
+  it.each([
+    [
+      'reconnect',
+      async (bridge: LegacyProtocolAdapterV2Bridge) => bridge.reconnect(),
+    ],
+    [
+      'disconnect',
+      async (bridge: LegacyProtocolAdapterV2Bridge) => bridge.disconnect(),
+    ],
+  ])(
+    'cancels an outstanding approval and stays cancelled across %s',
+    async (_label, teardown) => {
+      const { inner, bridge, patches } = await bridgeWithScript();
+      inner.approvalWireEcho = (requestId, decision) => {
+        inner.fire({
+          type: 'chat:approval-response',
+          turnId: 'turn-1',
+          requestId,
+          decision,
+          respondedBy: 'user',
+        });
+      };
+      inner.startTurn('turn-1');
+      inner.fire({
+        type: 'chat:approval-request',
+        turnId: 'turn-1',
+        requestId: 'per-1',
+        kind: 'permission',
+        toolName: 'bash',
+        description: 'Run pwd in the workspace',
+        target: 'pwd',
+      });
+
+      await teardown(bridge);
+      // Let the wire deny's echo land, if anything is still listening for it.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const items = approvalItems(patches, 'per-1');
+      expect(items.at(-1)).toEqual({
+        status: 'cancelled',
+        respondedBy: 'timeout',
+      });
+      expect(items).not.toContainEqual(
+        expect.objectContaining({ respondedBy: 'user' })
+      );
+    }
+  );
 });

--- a/test/server/protocol-adapters/opencode-adapter.test.ts
+++ b/test/server/protocol-adapters/opencode-adapter.test.ts
@@ -4,14 +4,17 @@ import type { ChildProcess, spawn } from 'node:child_process';
 import { describe, expect, it, vi } from 'vitest';
 import {
   CHANNEL_ADAPTER_LAUNCH_CONTRACTS,
+  PROVIDER_DESCRIPTORS,
   createAdapterV2,
 } from '../../../server/protocol-adapters/index.js';
+import { providerResumeId } from '../../../server/channel-agent-runtime.js';
 import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
 import { OpenCodeProtocolAdapter } from '../../../server/protocol-adapters/opencode-adapter.js';
 import {
   OpenCodeAttachedAdapter,
   probeOpenCodeAttachedApi,
 } from '../../../server/protocol-adapters/opencode-attached-adapter.js';
+import { openCodeStatusType } from '../../../server/protocol-adapters/opencode-shared.js';
 import { mapChatEventToAgentPatchV2 } from '../../../shared/agent-chat-v1-compat.js';
 import type { ChatEvent } from '../../../shared/agent-chat-protocol.js';
 
@@ -184,5 +187,403 @@ describe('OpenCode streaming capability is backed by real deltas', () => {
 
     const patches = mapChatEventToAgentPatchV2(delta!);
     expect(patches.map((patch) => patch.type)).toContain('agent-item-delta-v2');
+  });
+});
+
+/**
+ * Deferred `/abort` response so a test can interleave the server's own idle
+ * with the abort ack the adapter is still waiting on.
+ */
+interface DeferredAbort {
+  resolve: () => void;
+}
+
+/**
+ * Offline attached adapter: `/global/health` answers 200 and `/event` hands
+ * back an already-finished stream, so `connect()` completes without a server.
+ * Events are collected AFTER connect, so the connect handshake stays out of the
+ * assertions.
+ */
+async function connectedAttachedAdapter(options?: {
+  permissionStatus?: number;
+  abortStatus?: number;
+  deferAbort?: DeferredAbort;
+}): Promise<{
+  adapter: OpenCodeAttachedAdapter;
+  events: ChatEvent[];
+  requests: string[];
+  drive: (event: OpenCodeEventLike) => void;
+  dispose: () => Promise<void>;
+}> {
+  const requests: string[] = [];
+  let releaseAbort: (() => void) | undefined;
+  const abortGate = options?.deferAbort
+    ? new Promise<void>((resolve) => {
+        releaseAbort = resolve;
+      })
+    : undefined;
+  if (options?.deferAbort && releaseAbort) {
+    options.deferAbort.resolve = releaseAbort;
+  }
+
+  const fetchMock = vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input, init) => {
+      const url = String(input);
+      requests.push(`${(init?.method ?? 'GET').toUpperCase()} ${url}`);
+      if (url.endsWith('/global/health')) {
+        return new Response('{}', { status: 200 });
+      }
+      if (url.endsWith('/event')) {
+        return new Response('', { status: 200 });
+      }
+      if (url.endsWith('/abort')) {
+        if (abortGate) await abortGate;
+        return new Response('true', { status: options?.abortStatus ?? 200 });
+      }
+      if (url.includes('/permission/')) {
+        return new Response('{}', { status: options?.permissionStatus ?? 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+
+  const adapter = new OpenCodeAttachedAdapter();
+  await adapter.connect({
+    cwd: '/tmp',
+    port: 1,
+    sessionId: 'attached-session',
+    hookToken: 'x',
+    configDir: '/tmp',
+    extra: { endpoint: 'http://127.0.0.1:14096' },
+  });
+
+  const events: ChatEvent[] = [];
+  const off = adapter.on((event) => {
+    events.push(event);
+  });
+
+  return {
+    adapter,
+    events,
+    requests,
+    drive: (event) =>
+      (
+        adapter as unknown as {
+          mapOpenCodeEvent(event: OpenCodeEventLike): void;
+        }
+      ).mapOpenCodeEvent(event),
+    dispose: async () => {
+      off();
+      await adapter.disconnect();
+      fetchMock.mockRestore();
+    },
+  };
+}
+
+/**
+ * Inverted pins for #1412. Every assertion here was impossible to state before
+ * the fix: the attached adapter started turns and never ended them, so
+ * `agent-turn-completed-v2` was unreachable in `completed`, `failed`, and
+ * `interrupted` form alike and the conformance fixture had to gap invariant (a)
+ * outright. Reverting any handler below turns one of these red.
+ */
+describe('OpenCodeAttachedAdapter turn lifecycle (#1412)', () => {
+  it.each([
+    ['bare string (tolerated)', 'idle'],
+    ['nested object (real wire encoding)', { type: 'idle' }],
+  ])('ends the turn on session.status idle — %s', async (_label, status) => {
+    const rig = await connectedAttachedAdapter();
+    try {
+      await rig.adapter.sendMessage('turn-1', 'hi');
+      rig.events.length = 0;
+
+      rig.drive({ type: 'session.status', properties: { status } });
+
+      expect(rig.events.map((event) => event.type)).toEqual([
+        'chat:turn-completed',
+        'chat:session-status',
+      ]);
+      expect(rig.events[0]).toMatchObject({
+        type: 'chat:turn-completed',
+        turnId: 'turn-1',
+        reason: 'completed',
+      });
+    } finally {
+      await rig.dispose();
+    }
+  });
+
+  it('treats the busy status as active without ending the turn', async () => {
+    const rig = await connectedAttachedAdapter();
+    try {
+      await rig.adapter.sendMessage('turn-1', 'hi');
+      rig.events.length = 0;
+
+      rig.drive({
+        type: 'session.status',
+        properties: { status: { type: 'busy' } },
+      });
+
+      expect(rig.events).toEqual([
+        expect.objectContaining({
+          type: 'chat:session-status',
+          status: 'active',
+        }),
+      ]);
+    } finally {
+      await rig.dispose();
+    }
+  });
+
+  it('binds session.error to the live turn and ends it as failed', async () => {
+    const rig = await connectedAttachedAdapter();
+    try {
+      await rig.adapter.sendMessage('turn-1', 'hi');
+      rig.events.length = 0;
+
+      rig.drive({
+        type: 'session.error',
+        properties: { error: 'provider blew up' },
+      });
+
+      // The turnId is what lets the bridge attribute the failure; without it
+      // the error floats at session level and the terminal carries no message.
+      expect(rig.events[0]).toMatchObject({
+        type: 'chat:error',
+        turnId: 'turn-1',
+        message: 'provider blew up',
+      });
+      expect(rig.events[1]).toMatchObject({
+        type: 'chat:turn-completed',
+        turnId: 'turn-1',
+        reason: 'failed',
+      });
+    } finally {
+      await rig.dispose();
+    }
+  });
+
+  it('ends the turn as interrupted on the abort ack, and idle does not re-end it', async () => {
+    const rig = await connectedAttachedAdapter();
+    try {
+      await rig.adapter.sendMessage('turn-1', 'hi');
+      rig.events.length = 0;
+
+      await rig.adapter.interrupt('turn-1');
+      expect(rig.events).toEqual([
+        expect.objectContaining({
+          type: 'chat:turn-completed',
+          turnId: 'turn-1',
+          reason: 'interrupted',
+        }),
+      ]);
+
+      rig.events.length = 0;
+      rig.drive({
+        type: 'session.status',
+        properties: { status: { type: 'idle' } },
+      });
+      expect(rig.events.map((event) => event.type)).toEqual([
+        'chat:session-status',
+      ]);
+    } finally {
+      await rig.dispose();
+    }
+  });
+
+  it('reports interrupted even when the server idles before the abort ack', async () => {
+    const deferred: DeferredAbort = { resolve: () => {} };
+    const rig = await connectedAttachedAdapter({ deferAbort: deferred });
+    try {
+      await rig.adapter.sendMessage('turn-1', 'hi');
+      rig.events.length = 0;
+
+      const interrupting = rig.adapter.interrupt('turn-1');
+      // The abort POST is still in flight; the server settles first.
+      rig.drive({
+        type: 'session.status',
+        properties: { status: { type: 'idle' } },
+      });
+      deferred.resolve();
+      await interrupting;
+
+      const terminals = rig.events.filter(
+        (event) => event.type === 'chat:turn-completed'
+      );
+      expect(terminals).toHaveLength(1);
+      expect(terminals[0]).toMatchObject({
+        turnId: 'turn-1',
+        reason: 'interrupted',
+      });
+    } finally {
+      await rig.dispose();
+    }
+  });
+
+  it('leaves the turn open when the server refuses the abort', async () => {
+    const rig = await connectedAttachedAdapter({ abortStatus: 500 });
+    try {
+      await rig.adapter.sendMessage('turn-1', 'hi');
+      rig.events.length = 0;
+
+      await rig.adapter.interrupt('turn-1');
+      // No ack, so no evidence the run stopped: closing the turn here would
+      // strand every later delta on a finished turn.
+      expect(rig.events).toEqual([]);
+
+      // The operator's intent survives, so the server's own idle still reports
+      // the stop honestly — as interrupted, exactly once.
+      rig.drive({
+        type: 'session.status',
+        properties: { status: { type: 'idle' } },
+      });
+      expect(rig.events[0]).toMatchObject({
+        type: 'chat:turn-completed',
+        turnId: 'turn-1',
+        reason: 'interrupted',
+      });
+    } finally {
+      await rig.dispose();
+    }
+  });
+
+  it('announces an approval decision only when the server accepted it', async () => {
+    const accepted = await connectedAttachedAdapter();
+    try {
+      await accepted.adapter.sendMessage('turn-1', 'hi');
+      accepted.events.length = 0;
+      await accepted.adapter.respondToApproval('per_1', 'allow');
+      expect(accepted.events).toEqual([
+        expect.objectContaining({
+          type: 'chat:approval-response',
+          requestId: 'per_1',
+          decision: 'allow',
+          turnId: 'turn-1',
+        }),
+      ]);
+    } finally {
+      await accepted.dispose();
+    }
+
+    const refused = await connectedAttachedAdapter({ permissionStatus: 500 });
+    try {
+      await refused.adapter.sendMessage('turn-1', 'hi');
+      refused.events.length = 0;
+      await refused.adapter.respondToApproval('per_1', 'allow');
+      expect(refused.events).toEqual([]);
+    } finally {
+      await refused.dispose();
+    }
+  });
+
+  it('binds an approval response to the turn that asked, even after idle closed it', async () => {
+    const rig = await connectedAttachedAdapter();
+    try {
+      await rig.adapter.sendMessage('turn-1', 'hi');
+      rig.drive({
+        type: 'permission.asked',
+        properties: {
+          requestID: 'per_1',
+          toolName: 'bash',
+          description: 'Run pwd',
+          target: 'pwd',
+        },
+      });
+      // #1412 made idle end the turn, which clears `_currentTurnId`. A human
+      // answering after that must still land on the card's own turn.
+      rig.drive({
+        type: 'session.status',
+        properties: { status: { type: 'idle' } },
+      });
+      rig.events.length = 0;
+
+      await rig.adapter.respondToApproval('per_1', 'allow');
+
+      expect(rig.events).toEqual([
+        expect.objectContaining({
+          type: 'chat:approval-response',
+          requestId: 'per_1',
+          turnId: 'turn-1',
+        }),
+      ]);
+    } finally {
+      await rig.dispose();
+    }
+  });
+});
+
+/**
+ * One provider, one decoder. `session.status` arrives as a bare string OR as
+ * the nested `{ type }` object the real server sends, and both OpenCode lanes
+ * read the same stream — so the decoding lives in `opencode-shared.ts` rather
+ * than in a copy per lane. The copy is what #1412 was: the attached lane
+ * compared the bare string only, so the real encoding mapped to nothing and its
+ * turns never ended.
+ */
+describe('OpenCode session.status decoding is shared by both lanes', () => {
+  it('decodes both wire encodings and refuses to guess at anything else', () => {
+    expect(openCodeStatusType('idle')).toBe('idle');
+    expect(openCodeStatusType({ type: 'idle' })).toBe('idle');
+    expect(openCodeStatusType({ type: 7 })).toBeUndefined();
+    expect(openCodeStatusType(undefined)).toBeUndefined();
+    expect(openCodeStatusType(null)).toBeUndefined();
+  });
+
+  it.each([
+    ['bare string', 'idle'],
+    ['nested object (real wire encoding)', { type: 'idle' }],
+  ])('maps idle to a session-status on both lanes — %s', (_label, status) => {
+    const event = { type: 'session.status', properties: { status } };
+    for (const adapter of [
+      new OpenCodeProtocolAdapter(),
+      new OpenCodeAttachedAdapter(),
+    ]) {
+      const statuses = driveOpenCodeEvent(adapter, event).filter(
+        (chatEvent) => chatEvent.type === 'chat:session-status'
+      );
+      expect(statuses).toEqual([expect.objectContaining({ status: 'idle' })]);
+    }
+  });
+});
+
+/**
+ * Resume honesty (#1409). Neither OpenCode lane can restore a prior
+ * conversation on the routes it speaks, so all three rungs of the ladder —
+ * descriptor key, capability flag, adapter method — have to say the same thing.
+ * A silent no-op `resumeSession` used to say the opposite to any caller that
+ * reached it.
+ */
+describe('OpenCode resume honesty (#1409)', () => {
+  it('declares no resume state key, so the binder re-orients a respawned runtime', () => {
+    for (const id of ['opencode', 'opencode-attached'] as const) {
+      expect(PROVIDER_DESCRIPTORS[id].resumeStateKey).toBeNull();
+      expect(PROVIDER_DESCRIPTORS[id].bridgedCapabilities.resume).toBe(false);
+      // No blob shape can produce a resume id, so `hasProviderResumeState` in
+      // `channel-agent-binder` is false and the fresh runtime is oriented from
+      // cursor 0 (#1408) rather than starved by the durable delivered cursor.
+      expect(
+        providerResumeId(id, {
+          openCodeSessionId: 'ses_1',
+          lastDeliveredSeq: 12,
+        })
+      ).toBeUndefined();
+    }
+  });
+
+  it('refuses resumeSession instead of silently pretending to resume', async () => {
+    await expect(
+      new OpenCodeProtocolAdapter().resumeSession('ses_1')
+    ).rejects.toThrow(/no rebind route/);
+    await expect(
+      new OpenCodeAttachedAdapter().resumeSession('ses_1')
+    ).rejects.toThrow(/no route to rebind/);
+  });
+
+  it('refuses resume at the V2 bridge for both registered lanes', async () => {
+    for (const id of ['opencode', 'opencode-attached'] as const) {
+      await expect(createAdapterV2(id).resumeSession('ses_1')).rejects.toThrow(
+        /does not support resume/
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

Harness-fidelity slice (token-efficiency epic #1406, slice B) closing **#1409** plus all three defects the conformance suite caught on day one: **#1407, #1411, #1412**.

- **System-prompt delivery**: codex (`developerInstructions` at thread start) and hermes (composed once at connect into the byte-stable instructions block — prefix-cache invariant now structural, pinned by a bytes-equal test across turns) now receive `config.systemPromptAppendix`. OpenCode's transport has no instruction route; refusal documented, not faked via message prefixes.
- **Hermes interrupt re-anchor** (#1409): aborts re-anchor to the last completed response id instead of nulling the chain — user interrupts no longer sever continuity. Test pins `previous_response_id` after interrupt.
- **opencode-attached terminal patches** (#1412): `session.status` was string-compared against the real `{ status: { type } }` wire shape — idle never mapped. Every turn now ends exactly once; error turns terminalize as failed with the error text.
- **Single terminal-patch owner on the legacy bridge** (#1411): turn ledger in `LegacyProtocolAdapterV2Bridge` — failed turns complete exactly once; no more doubled turn-done notifications, delegation callbacks, or attention clearing.
- **Abandoned approvals** (#1407): shared teardown helper in `adapter-utils` resolves every pending approval as denied on disconnect, wired into all six adapters, each mapping the denial onto its own wire.

**Conformance suite: 11 issue-cited skips → 0.** The repro transcripts for all three defects now run as hard invariants. Sole remaining cited gap is #1305 (hermes streaming flag timing), scoped to one reconciliation row with a stale-gap guard that fails if it stops drifting.

Adversarial review: 8 findings — 1 P2 (opencode status decoding copied between the provider's two lanes; deduplicated into provider-scoped `opencode-shared.ts`, not adapter-utils, per the quirk/choreography rule) + 7 P3, all applied, stricter option taken where offered.

CHANGELOG `[Unreleased]` Fixed entry included.

Adapter generality: turn-lifecycle terminal ownership and abandoned-approval teardown are choreography and live once in the bridge / adapter-utils; OpenCode's `session.status` decoding is a provider quirk shared by its two lanes, deduplicated into provider-scoped `opencode-shared.ts`; everything else — system-prompt delivery, resume refusals, abort/approval acks — stays adapter-local, nothing copied to siblings.

## Verification

- `npm run check` exit 0
- `npx vitest run test/server/protocol-adapters/` — 11 files, 389 tests, **0 skips** (was 11)
- Full `npm test`: 493 files, 7036 tests, all green (even the #1415 flake behaved this run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)