### PR TITLE
feat(auth): scoped read-only credentials and lookup tools for every bound agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,17 @@ workflow.
 
 ### Agent runtimes
 
+#### Added
+
+- Agents can now look up channel history themselves. Every bound agent runtime
+  receives a scoped read-only credential for its own channel, channel search is
+  available to in-scope agents through the gateway (`relay-ide v1 channels
+search`), and Claude channel agents get the Relay MCP facade mounted
+  automatically so history, threads, and roster lookups work without asking a
+  human to paste context. Codex agents get the same credential for the CLI;
+  their MCP mount is deliberately skipped because Codex starts MCP servers with
+  a stripped environment the credential cannot reach (#1410)
+
 #### Fixed
 
 - Codex and Hermes agents now receive the profile system prompt and Relay's

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -76,6 +76,8 @@ import {
 import {
   channelSubscriptionFilterValidationError,
   normalizeChannelSubscriptionFilter,
+  CHANNEL_SEARCH_MAX_RESULTS,
+  CHANNEL_SEARCH_QUERY_MAX_CHARS,
   type ChannelSubscriptionFilter,
 } from '../shared/channel-chat-protocol.js';
 import { retainOutputPredicateSuffix } from '../shared/cli-gateway-sessions-wait.js';
@@ -1605,6 +1607,7 @@ const CLI_GATEWAY_ACTOR_TOKEN_COMMANDS = new Set<RelayCliGatewayCommand>([
   'channels.subscribe',
   'channels.threads.history',
   'channels.roster',
+  'channels.search',
   'channels.post',
   'cockpit.list',
   'cockpit.get',
@@ -5369,6 +5372,9 @@ type ChannelCliValueFlag =
   | '--after-seq'
   | '--max-events'
   | '--idle-timeout-ms'
+  | '--query'
+  | '--workspace-id'
+  | '--include-archived'
   | '--input-json';
 
 /** Strict, command-local parser for the six stable channel gateway commands. */
@@ -5558,6 +5564,82 @@ function validateChannelPostCliInput(input: Record<string, unknown>): void {
       { field: 'threadId' }
     );
   }
+}
+
+/**
+ * `channels search` (#1410): the handle-dereference companion to
+ * `channels history`. `--channel-id` narrows to one channel; omitting it
+ * searches exactly the channels the credential is scoped to — the hub refuses
+ * a scope-less actor credential outright rather than widening to every channel.
+ */
+async function runGatewayChannelsSearch(
+  channelArgs: string[]
+): Promise<void> {
+  const values = parseChannelCliFlags('channels.search', channelArgs, [
+    '--query',
+    '--channel-id',
+    '--workspace-id',
+    '--include-archived',
+    '--limit',
+  ]);
+  const query = values.get('--query')?.trim() ?? '';
+  if (!query) {
+    gatewayInvalid('channels.search', '--query is required', { field: 'q' });
+  }
+  if (query.length > CHANNEL_SEARCH_QUERY_MAX_CHARS) {
+    gatewayInvalid('channels.search', '--query is too long', {
+      field: 'q',
+      maxChars: CHANNEL_SEARCH_QUERY_MAX_CHARS,
+    });
+  }
+  const search = new URLSearchParams({ q: query });
+  for (const [flag, key] of [
+    ['--channel-id', 'channelId'],
+    ['--workspace-id', 'workspaceId'],
+  ] as const) {
+    const raw = values.get(flag);
+    if (raw === undefined) continue;
+    const value = raw.trim();
+    if (!value) {
+      gatewayInvalid('channels.search', `${flag} must be non-empty`, {
+        field: key,
+      });
+    }
+    search.set(key, value);
+  }
+  const includeArchived = values.get('--include-archived');
+  if (includeArchived !== undefined) {
+    if (includeArchived !== 'true' && includeArchived !== 'false') {
+      gatewayInvalid(
+        'channels.search',
+        '--include-archived must be true or false',
+        { field: 'includeArchived', value: includeArchived }
+      );
+    }
+    search.set('includeArchived', includeArchived);
+  }
+  const limit = values.get('--limit');
+  if (limit !== undefined) {
+    const parsed = Number(limit);
+    if (
+      !limit.trim() ||
+      !Number.isSafeInteger(parsed) ||
+      parsed < 1 ||
+      parsed > CHANNEL_SEARCH_MAX_RESULTS
+    ) {
+      gatewayInvalid('channels.search', '--limit has an invalid value', {
+        field: 'limit',
+        value: limit,
+      });
+    }
+    search.set('limit', limit);
+  }
+  const result = await gatewayHttpJson({
+    commandName: 'channels.search',
+    pathName: `/channels/search?${search}`,
+    capabilities: ['context:read'],
+  });
+  printGatewayEnvelope(gatewayOk('channels.search', result), 0);
 }
 
 async function runGatewayChannels(gatewayArgs: string[]): Promise<void> {
@@ -5762,6 +5844,8 @@ async function runGatewayChannels(gatewayArgs: string[]): Promise<void> {
     });
     printGatewayEnvelope(gatewayOk('channels.roster', result), 0);
   }
+
+  if (subcommand === 'search') await runGatewayChannelsSearch(channelArgs);
 
   if (subcommand === 'post') {
     const values = parseChannelCliFlags('channels.post', channelArgs, [

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -124,9 +124,14 @@ a public session id, identifies an agent in a conversation. Public session and
 inbox commands operate on terminal execution records or WorkContexts; they do not
 launch, resume, or address private channel runtimes.
 
-The stable gateway exposes scoped list/get/history/thread-history/roster/post
-commands plus a durable `channels.subscribe` stream. Search and browser-only
-conveniences remain outside the gateway contract.
+The stable gateway exposes scoped
+list/get/history/thread-history/roster/search/post commands plus a durable
+`channels.subscribe` stream. `channels.search` (#1410) searches only the
+channels the credential is scoped to: an actor credential with no `channelIds`
+scope is refused, and a `channelId` outside the scope is rejected before any
+read. Browser-only conveniences (attachments, agent commands, interrupt,
+approvals, read-state) remain outside the gateway contract and stay closed to
+scoped actors.
 
 ### Local MCP channel facade (#1399)
 

--- a/docs/MCP_HARNESS_RELAY_BRIDGE.md
+++ b/docs/MCP_HARNESS_RELAY_BRIDGE.md
@@ -406,19 +406,77 @@ Slice 0 makes only the following current manifest commands candidates for MCP
 exposure in Slice 3; the transport must not infer visibility from a similarly
 authenticated HTTP route:
 
-| Surface                                                                                               | MCP status   | Required actor-channel behavior                                                                                                                             |
-| ----------------------------------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `channels.list`                                                                                       | Candidate    | Actor requires a non-empty `channelIds` scope; response is filtered to it.                                                                                  |
-| `channels.get`, `channels.history`, `channels.threads.history`, `channels.roster`, `channels.post`    | Candidate    | The requested channel id must be in `channelIds`; otherwise reject before read/write. `post` uses only its declared command body, not browser conveniences. |
-| `channels.search`                                                                                     | **Excluded** | It has no stable command-manifest entry and scoped actors are denied on the private route. Do not expose it merely because transcript read exists.          |
-| Channel attachment upload/download                                                                    | **Excluded** | These are private actor-denied HTTP operations with no stable command contract. A future exposure needs its own bounded content/redaction/scope design.     |
-| Read state, agent commands, approval/interrupt, runtime steering, browser-cookie and node-link routes | **Excluded** | They are operator/private control or browser lanes, not external-harness MCP operations.                                                                    |
+| Surface                                                                                               | MCP status   | Required actor-channel behavior                                                                                                                                                                                                                                                                                                                                        |
+| ----------------------------------------------------------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `channels.list`                                                                                       | Candidate    | Actor requires a non-empty `channelIds` scope; response is filtered to it.                                                                                                                                                                                                                                                                                             |
+| `channels.get`, `channels.history`, `channels.threads.history`, `channels.roster`, `channels.post`    | Candidate    | The requested channel id must be in `channelIds`; otherwise reject before read/write. `post` uses only its declared command body, not browser conveniences.                                                                                                                                                                                                            |
+| `channels.search`                                                                                     | **Excluded** | Since #1410 it IS a stable manifest command reachable by an in-scope actor over the CLI gateway (candidate channels come from `channelIds`; a scope-less credential is refused). It stays out of the MCP tuple anyway — the eight-verb facade is deliberately closed, and CLI covers search. Adding it is a separate decision, not an implication of the gateway verb. |
+| Channel attachment upload/download                                                                    | **Excluded** | These are private actor-denied HTTP operations with no stable command contract. A future exposure needs its own bounded content/redaction/scope design.                                                                                                                                                                                                                |
+| Read state, agent commands, approval/interrupt, runtime steering, browser-cookie and node-link routes | **Excluded** | They are operator/private control or browser lanes, not external-harness MCP operations.                                                                                                                                                                                                                                                                               |
 
 This matrix is intentionally stronger than route authentication: every future
 MCP-visible row must have a manifest command, explicit channel/workspace/
 WorkContext authorization, and negative sibling-channel tests. It also rejects
 the stale claim that operator grants cannot carry `channelIds`: Slice 0 grants
 and scoped actor credentials both carry and validate that dimension.
+
+#### Shipped: auto-mounting the stdio facade into channel runtimes (#1410)
+
+Every bound agent runtime that holds a credential lease also receives
+`AdapterConfig.relayMcp` — a `{ command, args }` launch spec for
+`dist/bin/relay-mcp.js`, resolved by `server/relay-mcp-launch.ts`. The mount and
+the credential travel together: no lease, no mount, so an agent is never handed
+a Relay tool it could only get 401s from.
+
+The spec carries a path and nothing else. Credentials reach the facade **only**
+by environment inheritance from the agent process Relay spawned
+(`RELAY_IDE_ACTOR_TOKEN`, `RELAY_IDE_PORT`). An MCP mount is written into
+provider argv or config files, both readable by any process on the box, so a
+token must never be placed there.
+
+Adapter support is a per-provider quirk, not shared choreography:
+
+| Provider                        | Mount               | Why                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `claude`                        | `--mcp-config` JSON | Inline stdio server named `relay`, no `env` block, and never `--strict-mcp-config` (which would drop the operator's own servers). Verified on CLI 2.1.235: a `--mcp-config` stdio child inherits the full parent environment, so the lease token reaches the facade.                                                                                                                                                                                                       |
+| `codex`                         | **None**            | `-c mcp_servers.relay.command=…` / `.args=[…]` merges correctly (verified on codex-cli 0.147.0), but codex starts MCP servers with a fixed core environment (`HOME`, `LANG`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`) that `shell_environment_policy.inherit=all` does not widen. The remaining delivery paths are a token in argv (`mcp_servers.relay.env.*`) or writing the operator's `config.toml`; both are refused. Codex runtimes use `relay-ide v1 channels …`. |
+| `pi`, `prime-agent`, `opencode` | **Not yet**         | The credential is injected; a native mount is a follow-up per adapter.                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `hermes`, `opencode-attached`   | **None**            | Gateway launches have no child process, therefore no credential and nothing to mount.                                                                                                                                                                                                                                                                                                                                                                                      |
+
+The mounted tuple is exactly the closed eight in `shared/relay-mcp.ts`.
+Auto-mounting makes that tuple the reach of every credentialed agent's MCP host,
+so widening it is a separate decision with its own review — `channels.search`
+became a gateway verb in the same slice and deliberately stayed out.
+
+##### Accepted residual risks
+
+These are inside Relay's stated threat model (the hub, the agent processes it
+spawns, and their MCP children all run as the same OS user, and any same-user
+process can already read `/proc/<pid>/environ`). They are recorded so the next
+reviewer meets them as decisions, not as discoveries.
+
+- **Env inheritance is indiscriminate.** The delivery mechanism the claude mount
+  relies on — the CLI passing its full environment to every `--mcp-config` stdio
+  child — applies to _every_ MCP server that agent has configured, including the
+  operator's own user-level and project `.mcp.json` servers. Since #1410 that
+  means every MCP server a claude bound agent mounts inherits
+  `RELAY_IDE_ACTOR_TOKEN`, so a compromised third-party MCP package can read and
+  subscribe to that channel's transcript for the remainder of the lease (≤15
+  minutes, read-only for ordinary bound agents). Before #1410 the same exposure
+  existed for orchestrator runtimes only, with the read/write lease. Narrowing it
+  needs a wrapper launcher that scrubs `RELAY_IDE_*` from the environment of
+  non-Relay MCP children; no provider offers per-server env control today.
+- **`dev:self` trusts the checkout's build output.** In self-hosted development
+  the resolver's second candidate is `<repo>/dist/bin/relay-mcp.js`, inside a
+  working tree the agents themselves can edit. An agent that rewrites that file
+  gets its code executed inside every other channel runtime's MCP child, with
+  that runtime's lease token in the environment — a cross-channel path that only
+  the same-user trust domain bounds. Packaged installs do not have this: the
+  first candidate is the installed `dist/bin/relay-mcp.js` beside the server.
+  Every candidate the resolver returns is an absolute path checked at resolve
+  time; relative `PATH` entries are skipped rather than resolved, because the
+  provider — not Relay — spawns the command and would resolve a relative one
+  against the agent's cwd.
 
 ### Completion and event contract
 

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -120,6 +120,14 @@ Lane separation is fail-closed:
 
 Typed CLI actor denials use stable reason codes such as `CLI_ACTOR_CREDENTIAL_MISSING`, `CLI_ACTOR_BROWSER_COOKIE_REJECTED`, `CLI_ACTOR_NODE_CREDENTIAL_REJECTED`, `CLI_ACTOR_ROUTE_UNSUPPORTED`, `CLI_ACTOR_MALFORMED_CREDENTIAL`, `CLI_ACTOR_WRONG_AUDIENCE`, `CLI_ACTOR_EXPIRED`, `CLI_ACTOR_REVOKED`, `CLI_ACTOR_MISSING_SCOPE`, `CLI_ACTOR_WRONG_SESSION_SCOPE`, `CLI_ACTOR_WRONG_GLOBAL_SESSION_SCOPE`, `CLI_ACTOR_WRONG_WORK_CONTEXT_SCOPE`, `CLI_ACTOR_UNKNOWN_CAPABILITY`, and `CLI_ACTOR_INSUFFICIENT_CAPABILITY`. Failure payloads may include safe credential ids, denied bits, the expected audience, and correlation ids, but never raw bearer strings, browser cookies, node credential material, or secret hashes.
 
+### Standing runtime leases for bound agents (#1410)
+
+Every bound channel agent runtime that Relay spawns as a child process carries a standing scoped actor credential, minted per `(channel, profile)` runtime by `server/orchestrator-credential-lifecycle.ts`. Ordinary bound agents get `session:read` + `context:read` only, pinned to their own `channelIds` and nothing else; the persistent channel orchestrator keeps its separate read/write lease. There is no `context:write` on the read lease — a bound agent answers through the channel bridge, never by posting with its own credential — and no `session:create:terminal`, which would turn a read handle into process execution. The lease is TTL-bounded by the registry clamp (15 minutes), rotates only when the adapter can re-receive environment (`refreshRuntimeEnv`), and is revoked when the runtime ends.
+
+Delivery is environment injection into the spawned agent process (`RELAY_IDE_ACTOR_TOKEN`, `RELAY_IDE_PORT`, `RELAY_IDE_RUNTIME_ID`) and nothing else. A credential must never reach an agent through channel-visible text, prompt content, argv, or a provider config file. Gateway-launch providers with no child process therefore get no credential.
+
+The stdio MCP facade mounted into such a runtime is a view of that same credential, never a second grant: it authenticates purely from inherited environment, and the mount spec carries a path and arguments only. Two accepted residual risks follow from that delivery mechanism and are recorded in `docs/MCP_HARNESS_RELAY_BRIDGE.md` § "Accepted residual risks": provider environment inheritance is indiscriminate, so every other MCP server that agent mounts also inherits the lease token; and self-hosted development resolves the facade from the checkout's own `dist/`, which agents can edit. Both are bounded by the same-OS-user trust domain this policy already declines to claim isolation within.
+
 Relay issue `#177` remains the first-load/PIN explanation ticket. These docs clarify the security boundary, but closing `#177` should wait until the visible browser first-load copy also explains where the PIN comes from and how to reset it.
 
 ## Trust tiers

--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -17,9 +17,14 @@ import type {
   OrchestratorCredentialLifecycle,
   OrchestratorCredentialLifecycleDeps,
 } from './orchestrator-credential-lifecycle.js';
-import { startOrchestratorCredentialLifecycle } from './orchestrator-credential-lifecycle.js';
+import {
+  ORCHESTRATOR_ACTOR_CAPABILITIES,
+  READONLY_RUNTIME_ACTOR_CAPABILITIES,
+  startOrchestratorCredentialLifecycle,
+} from './orchestrator-credential-lifecycle.js';
 import type { AdapterConfig } from './protocol-adapter.js';
 import type { ProtocolAdapterV2 } from './protocol-adapter-v2.js';
+import { relayMcpLaunchSpec } from './relay-mcp-launch.js';
 import {
   createAdapterV2,
   providerDescriptor,
@@ -118,20 +123,26 @@ export interface ChannelAgentRuntimeManagerOptions {
 
 type RuntimeEndHandler = (runtimeId: string) => void;
 
-let orchestratorCredentialAuthority:
-  | Pick<
-      OrchestratorCredentialLifecycleDeps,
-      'issueCredential' | 'revokeCredential'
-    >
-  | undefined;
+type RuntimeCredentialAuthority = Pick<
+  OrchestratorCredentialLifecycleDeps,
+  'issueCredential' | 'revokeCredential'
+>;
+
+let orchestratorCredentialAuthority: RuntimeCredentialAuthority | undefined;
+let runtimeReadCredentialAuthority: RuntimeCredentialAuthority | undefined;
 
 export function configureChannelAgentRuntimes(input: {
-  orchestratorCredentials?: Pick<
-    OrchestratorCredentialLifecycleDeps,
-    'issueCredential' | 'revokeCredential'
-  >;
+  /** Read/write lease for the persistent channel orchestrator. */
+  orchestratorCredentials?: RuntimeCredentialAuthority;
+  /**
+   * Read-only lease every other bound agent runtime carries (#1410). Kept a
+   * separate issuer, not a flag on the orchestrator one, so the two lanes have
+   * distinct audit markers and neither can be reached by mistake.
+   */
+  runtimeReadCredentials?: RuntimeCredentialAuthority;
 }): void {
   orchestratorCredentialAuthority = input.orchestratorCredentials;
+  runtimeReadCredentialAuthority = input.runtimeReadCredentials;
 }
 
 /**
@@ -362,6 +373,92 @@ export class ChannelAgentRuntimeManager {
     return () => this.endHandlers.delete(handler);
   }
 
+  /**
+   * Standing read-only actor lease for one ordinary bound agent runtime (#1410).
+   *
+   * Three adapter classes, one rule each:
+   * - `refreshRuntimeEnv` present (claude today) -> rotating lease, same
+   *   machinery the orchestrator uses.
+   * - `command`/`embedded` launch without `refreshRuntimeEnv` -> one static
+   *   TTL-bounded token injected at spawn; it expires and the next spawn mints
+   *   a fresh one.
+   * - `gateway` launch (hermes, opencode-attached) -> NO credential. There is no
+   *   child process to inject into, and the only other delivery path would be
+   *   channel-visible prompt text, which the credential contract forbids.
+   *
+   * Read access is additive, so a mint failure is a warning and an
+   * uncredentialed spawn. Only the orchestrator lease is spawn-fatal.
+   */
+  private startRuntimeReadLease(
+    id: string,
+    adapter: ProtocolAdapterV2,
+    params: CreateChannelAgentRuntimeParams
+  ): OrchestratorCredentialLifecycle | undefined {
+    const channelId = params.channelId?.trim();
+    // Unbound runtime: there is no channel to scope reads to, and an unscoped
+    // credential is denied by the router's deny-without-scope guard anyway.
+    if (!channelId) return undefined;
+    const authority = runtimeReadCredentialAuthority;
+    if (!authority) return undefined;
+    const launchKind = providerDescriptor(params.providerId)?.launch.requirement
+      .kind;
+    if (launchKind !== 'command' && launchKind !== 'embedded') {
+      logger.debug('channel runtime launch has no env to inject a lease into', {
+        runtimeId: id,
+        providerId: params.providerId,
+        launchKind: launchKind ?? 'unknown',
+      });
+      return undefined;
+    }
+    try {
+      return startOrchestratorCredentialLifecycle(
+        {
+          runtimeId: id,
+          channelId,
+          profileActorId: params.profileActorId,
+          port: params.port,
+          ...(params.displayName ? { displayName: params.displayName } : {}),
+          leaseKind: 'channel-runtime-read',
+          capabilities: [...READONLY_RUNTIME_ACTOR_CAPABILITIES],
+          rotation: adapter.refreshRuntimeEnv ? 'refresh' : 'static',
+        },
+        {
+          ...authority,
+          applyRuntimeEnv: async (nextEnv) => {
+            const runtime = this.runtimes.get(id);
+            if (
+              !runtime ||
+              runtime.status !== 'active' ||
+              !runtime.adapter.refreshRuntimeEnv
+            ) {
+              throw new Error(
+                'Channel runtime unavailable during credential refresh'
+              );
+            }
+            await runtime.adapter.refreshRuntimeEnv(nextEnv);
+          },
+          failClosed: () => {
+            // Fail closed on the CREDENTIAL, not on the runtime: revoke and stop
+            // leasing, but never destroy a healthy agent over a read handle.
+            logger.warn('channel runtime read credential lease ended early', {
+              runtimeId: id,
+              providerId: params.providerId,
+            });
+            this.leases.get(id)?.stop();
+            this.leases.delete(id);
+          },
+        }
+      );
+    } catch {
+      // Never log the issuer error: it can carry credential material.
+      logger.warn('channel runtime starts without a read credential', {
+        runtimeId: id,
+        providerId: params.providerId,
+      });
+      return undefined;
+    }
+  }
+
   async create(
     params: CreateChannelAgentRuntimeParams
   ): Promise<ChannelAgentRuntime> {
@@ -395,6 +492,9 @@ export class ChannelAgentRuntimeManager {
           profileActorId: params.profileActorId,
           port: params.port,
           ...(params.displayName ? { displayName: params.displayName } : {}),
+          leaseKind: 'orchestrator',
+          capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+          rotation: 'refresh',
         },
         {
           ...orchestratorCredentialAuthority,
@@ -418,11 +518,33 @@ export class ChannelAgentRuntimeManager {
         }
       );
       processEnv = { ...processEnv, ...lease.processEnv };
+    } else {
+      lease = this.startRuntimeReadLease(id, adapter, params);
+      // Lease env is merged LAST on purpose: a named profile's `processEnv` must
+      // not be able to shadow RELAY_IDE_ACTOR_TOKEN with a token of its own.
+      if (lease) processEnv = { ...processEnv, ...lease.processEnv };
     }
     processEnv = sanitizeChannelAdapterProcessEnv(
       params.providerId,
       processEnv
     );
+
+    // The MCP facade is a VIEW of the credential this runtime already carries,
+    // never a second grant: mount it only when a lease was actually started, so
+    // an uncredentialed runtime (gateway launch, unbound runtime, mint failure)
+    // cannot be handed a Relay tool it could never authenticate. The facade
+    // child inherits the agent process env, which is where the token lives — the
+    // spec below is a path, and adapters must keep it that way.
+    const relayMcp = lease ? relayMcpLaunchSpec() : undefined;
+    if (lease && !relayMcp) {
+      logger.debug(
+        'relay MCP facade not found; runtime keeps CLI access only',
+        {
+          runtimeId: id,
+          providerId: params.providerId,
+        }
+      );
+    }
 
     const initialAgentAttribution = agentAttributionFromConfig({
       ...(params.model ? { model: params.model } : {}),
@@ -534,6 +656,7 @@ export class ChannelAgentRuntimeManager {
         .filter((part): part is string => Boolean(part?.trim()))
         .join('\n\n'),
       ...(Object.keys(processEnv).length > 0 ? { processEnv } : {}),
+      ...(relayMcp ? { relayMcp } : {}),
       ...(params.permissionMode
         ? { permissionMode: params.permissionMode }
         : {}),

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -882,6 +882,30 @@ function parseStringQuery(value: unknown): string | undefined {
   return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
 }
 
+/**
+ * The channel a `/channels/search` request names, parsed ONCE for both layers.
+ *
+ * The actor-scope middleware in `server/index.ts` decides which channel the
+ * credential is validated against, and the route below enforces
+ * `denyOutOfScopeChannel` plus the candidate set on the same value. If the two
+ * parsed the query differently — Express turns `?channelId=A&channelId=B` into
+ * an array, which a bare `typeof === 'string'` check reads as *absent* — the
+ * middleware would authorize a different requested scope than the route
+ * enforces. That divergence is not exploitable while both guards are in place,
+ * but it is exactly the seam that becomes a bypass when either side is later
+ * refactored alone. One exported helper removes it permanently: import this in
+ * the middleware rather than re-deriving the value.
+ */
+export function channelSearchRequestedChannelId(
+  query: unknown
+): string | undefined {
+  const record =
+    typeof query === 'object' && query !== null
+      ? (query as Record<string, unknown>)
+      : {};
+  return parseStringQuery(record['channelId']);
+}
+
 /** Same truthiness the `/workspace-topics` search route uses for its flags. */
 function parseBooleanQuery(value: unknown): boolean {
   const raw = Array.isArray(value) ? value[0] : value;
@@ -1091,13 +1115,20 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
   const getAuth = deps.requireReadActorAuth?.('channels.get') ?? auth;
   const runGetAuth = deps.requireReadActorAuth?.('channels.run.get') ?? auth;
   const historyAuth = deps.requireReadActorAuth?.('channels.history') ?? auth;
-  // Search is a filtered read of the same durable message log `channels.history`
-  // already grants, so it rides that verb rather than minting a new gateway
-  // command: a credential that may read a channel's transcript may search it,
-  // and one that may not, cannot. When a scoped actor supplies a `channelId` the
-  // requested scope is that single channel; a scope-less search is denied by the
-  // actor lane (browser searches keep their existing authority).
-  const searchAuth = auth;
+  // Search is a filtered read of the same durable message log, but it gets its
+  // OWN gateway verb (#1410) rather than riding `channels.history`. The actor
+  // lane authorizes by the `x-relay-cli-command` header, so reusing the history
+  // command name would let any history-capable credential search while naming
+  // the wrong operation in the audit trail. A distinct verb carries its own
+  // contract schema, capability row, and revocable allowlist entry.
+  //
+  // Opening the verb is NOT a loosening of the private-route deny: the route
+  // below still runs `denyMissingCapability(CONTEXT_READ)`,
+  // `denyChannelReadWithoutScope` (a scope-less credential cannot search at
+  // all) and `denyOutOfScopeChannel` on an explicit `channelId`, and the
+  // candidate set for an unnamed search is exactly the credential's
+  // `channelIds`. Browser searches keep their existing authority.
+  const searchAuth = deps.requireReadActorAuth?.('channels.search') ?? auth;
   const threadHistoryAuth =
     deps.requireReadActorAuth?.('channels.threads.history') ?? auth;
   const postAuth = deps.requireWriteActorAuth?.('channels.post') ?? auth;
@@ -1166,7 +1197,6 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
   // ids are all `topic:`-prefixed, so `search` can never BE a channel id — the
   // ordering is about routing, not about a namespace collision.)
   router.get('/channels/search', searchAuth, (req, res) => {
-    if (denyScopedActorPrivateRoute(req, res)) return;
     if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
     if (denyChannelReadWithoutScope(req, res)) return;
     const store = storeOr503(res, deps.store);
@@ -1194,7 +1224,9 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     const query = parsedQuery.text;
     const includeArchived = parseBooleanQuery(req.query['includeArchived']);
     const limit = parseSearchLimit(req.query['limit']);
-    const scopeChannelId = parseStringQuery(req.query['channelId']);
+    // Same helper the actor-scope middleware uses, so the channel the
+    // credential was validated against is the channel enforced here.
+    const scopeChannelId = channelSearchRequestedChannelId(req.query);
     if (scopeChannelId && denyOutOfScopeChannel(req, res, scopeChannelId))
       return;
     const scopeWorkspaceId = parseStringQuery(req.query['workspaceId']);

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -76,6 +76,7 @@ export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
   'channels.subscribe',
   'channels.threads.history',
   'channels.roster',
+  'channels.search',
   'context.get',
   'context.list',
   'inbox.list',
@@ -145,6 +146,16 @@ export interface CliGatewayActorIssueInput {
 }
 
 export type PersistentOrchestratorCredentialIssueInput = Omit<
+  CliGatewayActorIssueInput,
+  'metadata'
+>;
+
+/**
+ * Input for the standing read-only runtime lease (#1410). `metadata` is omitted
+ * for the same reason as the orchestrator lease: the reason marker is stamped by
+ * the trusted issuer, never carried in from a caller.
+ */
+export type ChannelRuntimeReadCredentialIssueInput = Omit<
   CliGatewayActorIssueInput,
   'metadata'
 >;
@@ -349,6 +360,9 @@ export function cliGatewayActorCommandCapabilities(
   // Channel conversation verbs (#1165): reads gate on context:read, the single
   // post write gates on context:write. Mounting the router alone is not enough —
   // the capability map must resolve or gateway auth fails at runtime.
+  // `channels.search` (#1410) is a read of the same durable message log, so it
+  // gates on the same bit; its blast radius is bounded by the credential's
+  // `channelIds` scope, not by this capability row.
   if (
     command === 'channels.list' ||
     command === 'channels.get' ||
@@ -356,7 +370,8 @@ export function cliGatewayActorCommandCapabilities(
     command === 'channels.history' ||
     command === 'channels.subscribe' ||
     command === 'channels.threads.history' ||
-    command === 'channels.roster'
+    command === 'channels.roster' ||
+    command === 'channels.search'
   )
     return ['context:read'];
   if (command === 'channels.post') return ['context:write'];
@@ -474,12 +489,34 @@ export function cliGatewayActorFailure(input: {
   };
 }
 
+/**
+ * Reason markers only the trusted in-process issuers below may stamp.
+ *
+ * These are security-weighted: `persistent-orchestrator` reaches the verbatim
+ * sender-id branch and the agent-brake bypass in the channel router, and
+ * `channel-runtime-read` marks the standing read lease (#1410) so a later
+ * consumer can tell an internally minted read handle from an operator-issued
+ * one. Every externally supplied metadata blob is stripped of them, so no
+ * caller can forge either marker through the issue/grant surface.
+ */
+const TRUSTED_INTERNAL_CREDENTIAL_REASONS = [
+  'persistent-orchestrator',
+  'channel-runtime-read',
+] as const;
+
+type TrustedInternalCredentialReason =
+  (typeof TRUSTED_INTERNAL_CREDENTIAL_REASONS)[number];
+
 function credentialIssueMetadata(
   metadata: unknown
 ): Record<string, unknown> | undefined {
   if (!isRecord(metadata)) return undefined;
   const sanitized = { ...metadata };
-  if (sanitized['reason'] === 'persistent-orchestrator') {
+  const reason = sanitized['reason'];
+  if (
+    typeof reason === 'string' &&
+    (TRUSTED_INTERNAL_CREDENTIAL_REASONS as readonly string[]).includes(reason)
+  ) {
     delete sanitized['reason'];
   }
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;
@@ -488,13 +525,13 @@ function credentialIssueMetadata(
 function issueCliGatewayActorCredentialInternal(
   registry: ScopedActorCredentialRegistry,
   input: CliGatewayActorIssueInput,
-  persistentOrchestrator: boolean
+  trustedReason: TrustedInternalCredentialReason | null
 ): { token: string; credential: ScopedActorCredentialRecord } {
   const scope = coerceScope(input.scope);
   const capabilities = coerceCapabilities(input.capabilities);
   const ttlMs = typeof input.ttlMs === 'number' ? input.ttlMs : 5 * 60 * 1000;
-  const metadata = persistentOrchestrator
-    ? { reason: 'persistent-orchestrator' }
+  const metadata = trustedReason
+    ? { reason: trustedReason }
     : credentialIssueMetadata(input.metadata);
   return registry.issue({
     actor: coerceActor(input.actor),
@@ -517,7 +554,7 @@ export function issueCliGatewayActorCredential(
   registry: ScopedActorCredentialRegistry,
   input: CliGatewayActorIssueInput = {}
 ): { token: string; credential: ScopedActorCredentialRecord } {
-  return issueCliGatewayActorCredentialInternal(registry, input, false);
+  return issueCliGatewayActorCredentialInternal(registry, input, null);
 }
 
 /**
@@ -528,7 +565,33 @@ export function issuePersistentOrchestratorCliGatewayActorCredential(
   registry: ScopedActorCredentialRegistry,
   input: PersistentOrchestratorCredentialIssueInput
 ): { token: string; credential: ScopedActorCredentialRecord } {
-  return issueCliGatewayActorCredentialInternal(registry, input, true);
+  return issueCliGatewayActorCredentialInternal(
+    registry,
+    input,
+    'persistent-orchestrator'
+  );
+}
+
+/**
+ * Trusted in-process issuer for the standing read-only lease every bound agent
+ * runtime carries (#1410).
+ *
+ * The marker is an audit breadcrumb, NOT a privilege: nothing branches on it,
+ * and the credential's actual reach is decided by the capability bits and the
+ * channel scope the caller pins. It exists so this lane is distinguishable from
+ * `persistent-orchestrator` — a read lease must never land on the verbatim
+ * sender-id / agent-brake-bypass path — and so the reason cannot be forged from
+ * outside once something does branch on it.
+ */
+export function issueChannelRuntimeReadCliGatewayActorCredential(
+  registry: ScopedActorCredentialRegistry,
+  input: ChannelRuntimeReadCredentialIssueInput
+): { token: string; credential: ScopedActorCredentialRecord } {
+  return issueCliGatewayActorCredentialInternal(
+    registry,
+    input,
+    'channel-runtime-read'
+  );
 }
 
 export function issueCliGatewayActorCredentialWithGrant(

--- a/server/index.ts
+++ b/server/index.ts
@@ -248,7 +248,10 @@ import {
   type ChannelAttachmentStore,
 } from './channel-attachments.js';
 import { createChannelHub, type ChannelHub } from './channel-hub.js';
-import { createChannelChatRouter } from './channel-chat-router.js';
+import {
+  channelSearchRequestedChannelId,
+  createChannelChatRouter,
+} from './channel-chat-router.js';
 import { createChannelSubscriptionRouter } from './channel-subscription-router.js';
 import {
   createChannelAgentBinder,
@@ -372,6 +375,7 @@ import {
   createCliGatewayActorRegistry,
   createCliGatewayHandshakeGrantRegistry,
   isCliGatewayActorTokenRequest,
+  issueChannelRuntimeReadCliGatewayActorCredential,
   issueCliGatewayActorCredential,
   issueCliGatewayActorCredentialWithGrant,
   issuePersistentOrchestratorCliGatewayActorCredential,
@@ -2611,6 +2615,27 @@ async function main(): Promise<void> {
     const channelIds = credential?.scope?.channelIds;
     return channelIds && channelIds.length > 0 ? { channelIds } : undefined;
   };
+  // `channels.search` (#1410) names its channel in the QUERY string, not in a
+  // `:id` path param, so it needs its own resolver. A search that names a
+  // channel requests exactly that channel (the middleware rejects it when the
+  // credential is not scoped to it, before the route runs); an unnamed search
+  // requests the credential's OWN channel scope, exactly like `channels.list`,
+  // and the route then searches only those channels. Middleware defense in
+  // depth: the route repeats both checks.
+  //
+  // The channel id comes from `channelSearchRequestedChannelId`, the SAME parser
+  // the route's `denyOutOfScopeChannel` and candidate set use. Parsing it twice
+  // is how a middleware/route divergence becomes a bypass: Express hands
+  // `?channelId=A&channelId=B` through as an array, and a local
+  // `typeof === 'string'` check would read that as *no channel named* while the
+  // route enforced the first element.
+  const channelSearchScopeFromRequest = (
+    req: express.Request
+  ): { channelIds?: string[] } | undefined => {
+    const channelId = channelSearchRequestedChannelId(req.query);
+    if (channelId) return { channelIds: [channelId] };
+    return channelListScopeFromCredential(req);
+  };
   app.use(
     createChannelChatRouter({
       store: channelMessageStore,
@@ -2642,13 +2667,15 @@ async function main(): Promise<void> {
         requireCliGatewayAuthForActorCommand(command, {
           ...(command === 'channels.list'
             ? { scopeForRequest: channelListScopeFromCredential }
-            : command === 'channels.get' ||
-                command === 'channels.run.get' ||
-                command === 'channels.history' ||
-                command === 'channels.threads.history' ||
-                command === 'channels.roster'
-              ? { scopeForRequest: channelScopeFromParams }
-              : {}),
+            : command === 'channels.search'
+              ? { scopeForRequest: channelSearchScopeFromRequest }
+              : command === 'channels.get' ||
+                  command === 'channels.run.get' ||
+                  command === 'channels.history' ||
+                  command === 'channels.threads.history' ||
+                  command === 'channels.roster'
+                ? { scopeForRequest: channelScopeFromParams }
+                : {}),
           ...(options ?? {}),
         }),
       requireWriteActorAuth: (command, options) =>
@@ -3224,6 +3251,15 @@ async function main(): Promise<void> {
     orchestratorCredentials: {
       issueCredential: (input) =>
         issuePersistentOrchestratorCliGatewayActorCredential(
+          cliGatewayActorRegistry,
+          input
+        ),
+      revokeCredential: (credentialId, input) =>
+        cliGatewayActorRegistry.revoke(credentialId, input),
+    },
+    runtimeReadCredentials: {
+      issueCredential: (input) =>
+        issueChannelRuntimeReadCliGatewayActorCredential(
           cliGatewayActorRegistry,
           input
         ),

--- a/server/orchestrator-credential-lifecycle.ts
+++ b/server/orchestrator-credential-lifecycle.ts
@@ -1,3 +1,4 @@
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
 import {
   DEFAULT_SCOPED_ACTOR_CREDENTIAL_MAX_TTL_MS,
   type ScopedActorCredentialRecord,
@@ -12,10 +13,73 @@ export const ORCHESTRATOR_ACTOR_CAPABILITIES = [
   'session:create:terminal',
 ] as const;
 
-export const ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS =
+/**
+ * Standing lease for an ordinary bound agent runtime (#1410): read bits only.
+ *
+ * `context:read` is the bit every `channels.*` read verb gates on
+ * (`cliGatewayActorCommandCapabilities`); `session:read` is what makes
+ * `defaultCliGatewayActorScope` stamp the generic read task-ref marker. There is
+ * deliberately no `context:write` here — a bound agent replies through the
+ * channel bridge, never by posting with its own credential — and no
+ * `session:create:terminal`, which would turn a read handle into process
+ * execution.
+ */
+export const READONLY_RUNTIME_ACTOR_CAPABILITIES = [
+  'session:read',
+  'context:read',
+] as const;
+
+/**
+ * Hard registry clamp (`shared/scoped-actor-credentials.ts`). A lease may ask
+ * for less, never for more: a longer window is a registry-wide policy change,
+ * not a per-lease option.
+ */
+export const RUNTIME_ACTOR_CREDENTIAL_TTL_MS =
   DEFAULT_SCOPED_ACTOR_CREDENTIAL_MAX_TTL_MS;
+export const ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS =
+  RUNTIME_ACTOR_CREDENTIAL_TTL_MS;
 export const ORCHESTRATOR_ACTOR_REFRESH_RATIO = 1 / 2;
 export const ORCHESTRATOR_ACTOR_REFRESH_DEADLINE_SAFETY_MS = 1_000;
+
+/**
+ * Which runtime lease this is. Drives audit reason strings and public error
+ * text only — capability material comes from `input.capabilities`, so a new
+ * kind cannot silently inherit orchestrator privileges by naming itself.
+ */
+export type RuntimeCredentialLeaseKind =
+  | 'orchestrator'
+  | 'channel-runtime-read';
+
+/**
+ * `refresh` rotates at half lifetime through `applyRuntimeEnv` (adapters that
+ * implement `refreshRuntimeEnv`). `static` mints once at spawn and lets the
+ * credential expire: an adapter that cannot re-receive env must not be handed a
+ * token that outlives what it was minted for.
+ */
+export type RuntimeCredentialRotation = 'refresh' | 'static';
+
+interface LeaseAuditVocabulary {
+  /** Noun phrase used in public (material-free) error text. */
+  readonly subject: string;
+  readonly ended: string;
+  readonly rotated: string;
+  readonly refreshFailed: string;
+}
+
+const LEASE_AUDIT: Record<RuntimeCredentialLeaseKind, LeaseAuditVocabulary> = {
+  orchestrator: {
+    subject: 'orchestrator actor credential',
+    ended: 'orchestrator-runtime-ended',
+    rotated: 'orchestrator-token-rotated',
+    refreshFailed: 'orchestrator-token-refresh-failed',
+  },
+  'channel-runtime-read': {
+    subject: 'channel runtime read actor credential',
+    ended: 'channel-runtime-read-ended',
+    rotated: 'channel-runtime-read-rotated',
+    refreshFailed: 'channel-runtime-read-refresh-failed',
+  },
+};
 
 type TimerHandle = ReturnType<typeof setTimeout>;
 
@@ -46,6 +110,14 @@ export interface StartOrchestratorCredentialLifecycleInput {
   profileActorId: string;
   port: number;
   displayName?: string;
+  /** Audit/error vocabulary for this lease. Never a capability source. */
+  leaseKind: RuntimeCredentialLeaseKind;
+  /**
+   * Exact capability set to mint. Required (not defaulted) so a new caller is a
+   * compile error rather than an implicit orchestrator-privileged lease.
+   */
+  capabilities: readonly RelayCapabilityBit[];
+  rotation: RuntimeCredentialRotation;
 }
 
 function publicLifecycleError(message: string): Error {
@@ -76,7 +148,12 @@ function credentialRefreshDelay(
 }
 
 /**
- * Runtime-only credential lease for one persistent channel orchestrator.
+ * Runtime-only credential lease for one channel agent runtime.
+ *
+ * Two modes, one implementation. The persistent orchestrator takes the
+ * read/write lease and rotates (`rotation: 'refresh'`); every other bound agent
+ * takes a read-only lease that rotates when its adapter can re-receive env and
+ * otherwise simply expires (`rotation: 'static'`, #1410).
  *
  * The initial credential is minted synchronously before the caller creates the
  * adapter. Rotations are ordered mint -> runtime apply -> current swap -> old
@@ -111,9 +188,17 @@ export class OrchestratorCredentialLifecycle {
     return this.runtimeEnv(this.current.token);
   }
 
+  /** Audit/error vocabulary for this lease kind. */
+  private get audit(): LeaseAuditVocabulary {
+    return LEASE_AUDIT[this.input.leaseKind];
+  }
+
   /** Exposed for deterministic lifecycle tests and operator-driven recovery. */
   refreshNow(): Promise<void> {
     if (this.stopped) return Promise.resolve();
+    // A static lease has no delivery path for a replacement token; rotating it
+    // would revoke a working credential and hand the child nothing.
+    if (this.input.rotation === 'static') return Promise.resolve();
     if (this.rotationPromise) return this.rotationPromise;
     const rotation = this.rotate();
     this.rotationPromise = rotation;
@@ -128,7 +213,7 @@ export class OrchestratorCredentialLifecycle {
     this.stopped = true;
     this.clearRefreshTimer();
     this.cancelApplyDeadline();
-    this.safeRevoke(this.current.credential.id, 'orchestrator-runtime-ended');
+    this.safeRevoke(this.current.credential.id, this.audit.ended);
   }
 
   private issueInitial(): OrchestratorCredentialIssueResult {
@@ -136,15 +221,13 @@ export class OrchestratorCredentialLifecycle {
     try {
       issued = this.issue();
     } catch {
-      throw publicLifecycleError(
-        'Failed to provision orchestrator actor credential'
-      );
+      throw publicLifecycleError(`Failed to provision ${this.audit.subject}`);
     }
+    // A credential with an unreadable lifetime is rejected in BOTH modes: a
+    // static lease still relies on a real expiry to bound the injected token.
     if (credentialRefreshDelay(issued.credential, this.now()) === null) {
       this.safeRevoke(issued.credential.id, 'invalid-credential-lifetime');
-      throw publicLifecycleError(
-        'Failed to provision orchestrator actor credential'
-      );
+      throw publicLifecycleError(`Failed to provision ${this.audit.subject}`);
     }
     return issued;
   }
@@ -162,23 +245,54 @@ export class OrchestratorCredentialLifecycle {
         id: 'relay-ide',
         displayName: 'Relay',
       },
-      capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+      capabilities: [...this.input.capabilities],
+      // Scope only the dimensions the lease's own requests actually name.
+      //
+      // `validateCredentialScope` fails closed on an unnamed dimension: a
+      // credential that carries values a request does not name is rejected with
+      // `missing_scope`. Channel requests name a channel and nothing else — no
+      // HTTP channel route has a session in it — so a `sessionIds` pin on the
+      // read lease is not a narrowing, it is a credential that cannot be used
+      // at all (verified: `channels.history` scoped `{channelIds:[c]}` against a
+      // `{sessionIds,channelIds}` credential returns `missing_scope`).
+      //
+      // Dropping it costs no confinement, because the same catch-all is what
+      // confines the credential: a channel-only scope is accepted ONLY by
+      // routes that request `channelIds`. Every other route — sessions, work
+      // contexts, inbox — leaves the channel dimension unrequested and denies.
+      //
+      // The orchestrator lease still carries the pin, and that is a KNOWN
+      // DEFECT, not a working design: no route names both dimensions, so the
+      // orchestrator credential is denied `missing_scope` on BOTH lanes today
+      // (channel routes request `{channelIds}` alone; sessions/command-center
+      // routes request `{sessionIds, globalSessionIds}` alone). It is
+      // fail-closed — the lease authenticates nothing rather than too much —
+      // and the pin cannot simply be dropped here, because
+      // `authenticatedSourceRuntimeId` (`server/channel-chat-router.ts`) reads
+      // `scope.sessionIds[0]` to bind the credential to its private runtime
+      // before granting the verbatim sender-id / agent-brake bypass. Removing
+      // it would delete that binding instead of fixing the deny. Tracked in
+      // #1419; `test/sessions-orchestrator-credential.test.ts` asserts the
+      // current deny against real route scope shapes so it stays visible.
       scope: {
-        sessionIds: [this.input.runtimeId],
+        ...(this.input.leaseKind === 'orchestrator'
+          ? { sessionIds: [this.input.runtimeId] }
+          : {}),
         channelIds: [this.input.channelId],
       },
-      ttlMs: ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS,
+      ttlMs: RUNTIME_ACTOR_CREDENTIAL_TTL_MS,
     });
   }
 
   private scheduleRefresh(): void {
     if (this.stopped) return;
+    // Static leases never rotate: the credential expires and the next spawn
+    // mints a fresh one.
+    if (this.input.rotation === 'static') return;
     const delay = credentialRefreshDelay(this.current.credential, this.now());
     if (delay === null) {
       this.triggerFailClosed(
-        publicLifecycleError(
-          'Orchestrator actor credential lifetime is invalid'
-        )
+        publicLifecycleError(`Invalid ${this.audit.subject} lifetime`)
       );
       return;
     }
@@ -201,45 +315,32 @@ export class OrchestratorCredentialLifecycle {
     try {
       replacement = this.issue();
       if (credentialRefreshDelay(replacement.credential, this.now()) === null) {
-        throw publicLifecycleError(
-          'Orchestrator actor credential lifetime is invalid'
-        );
+        throw publicLifecycleError(`Invalid ${this.audit.subject} lifetime`);
       }
       if (this.stopped) {
-        this.safeRevoke(
-          replacement.credential.id,
-          'orchestrator-runtime-ended'
-        );
+        this.safeRevoke(replacement.credential.id, this.audit.ended);
         return;
       }
 
       await this.applyBeforeCurrentExpires(this.runtimeEnv(replacement.token));
       if (this.stopped) {
-        this.safeRevoke(
-          replacement.credential.id,
-          'orchestrator-runtime-ended'
-        );
+        this.safeRevoke(replacement.credential.id, this.audit.ended);
         return;
       }
 
       const previous = this.current;
       this.current = replacement;
       replacement = null;
-      this.safeRevoke(previous.credential.id, 'orchestrator-token-rotated');
+      this.safeRevoke(previous.credential.id, this.audit.rotated);
       this.scheduleRefresh();
     } catch {
       if (replacement) {
-        this.safeRevoke(
-          replacement.credential.id,
-          'orchestrator-token-refresh-failed'
-        );
+        this.safeRevoke(replacement.credential.id, this.audit.refreshFailed);
       }
       if (!this.stopped) {
         this.clearRefreshTimer();
         this.triggerFailClosed(
-          publicLifecycleError(
-            'Failed to refresh orchestrator actor credential'
-          )
+          publicLifecycleError(`Failed to refresh ${this.audit.subject}`)
         );
       }
     }
@@ -274,7 +375,7 @@ export class OrchestratorCredentialLifecycle {
     if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
       return Promise.reject(
         publicLifecycleError(
-          'Orchestrator actor credential refresh deadline elapsed'
+          `Refresh deadline elapsed for ${this.audit.subject}`
         )
       );
     }
@@ -295,7 +396,7 @@ export class OrchestratorCredentialLifecycle {
         () =>
           finish(
             publicLifecycleError(
-              'Orchestrator actor credential refresh deadline elapsed'
+              `Refresh deadline elapsed for ${this.audit.subject}`
             )
           ),
         remainingMs
@@ -305,19 +406,13 @@ export class OrchestratorCredentialLifecycle {
         timer,
         cancel: () =>
           finish(
-            publicLifecycleError(
-              'Orchestrator actor credential refresh was cancelled'
-            )
+            publicLifecycleError(`Refresh cancelled for ${this.audit.subject}`)
           ),
       };
       void this.deps.applyRuntimeEnv(processEnv).then(
         () => finish(),
         () =>
-          finish(
-            publicLifecycleError(
-              'Failed to apply orchestrator actor credential'
-            )
-          )
+          finish(publicLifecycleError(`Failed to apply ${this.audit.subject}`))
       );
     });
   }

--- a/server/protocol-adapter.ts
+++ b/server/protocol-adapter.ts
@@ -7,6 +7,7 @@
 
 import { createLogger } from './logger.js';
 import type { ChatEvent } from '../shared/chat-events.js';
+import type { RelayMcpLaunchSpec } from './relay-mcp-launch.js';
 
 const logger = createLogger('protocol-adapter');
 
@@ -41,6 +42,18 @@ export interface AdapterConfig {
    * field into their provider-specific launch argument.
    */
   systemPromptAppendix?: string;
+  /**
+   * Launch spec for the local stdio Relay MCP facade, present only when this
+   * runtime actually holds an actor credential lease (#1410).
+   *
+   * Shared choreography, provider-specific mount: adapters that can declare an
+   * MCP server natively translate this into their own launch surface. It is a
+   * command plus arguments and NOTHING else — the facade authenticates from the
+   * environment the agent process passes to its MCP child, so a token must
+   * never be written here. MCP mounts land in provider argv or config, which is
+   * readable by any process on the box.
+   */
+  relayMcp?: RelayMcpLaunchSpec;
   /** Additional agent-specific configuration */
   extra?: Record<string, unknown>;
 }

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -1399,6 +1399,39 @@ export class ClaudeProtocolAdapter
     args.push('--include-partial-messages');
     args.push('--permission-prompt-tool', 'stdio');
 
+    // Relay MCP facade mount (#1410) — a claude QUIRK for the shared
+    // `config.relayMcp` choreography. Three rules this must keep:
+    //  - inline JSON, no `env` block: the facade authenticates from the env this
+    //    process passes to its MCP children (verified on CLI 2.1.235: a
+    //    `--mcp-config` stdio child inherits the full parent environment), and a
+    //    token in argv would be readable through `ps`.
+    //  - NO `--strict-mcp-config`: that flag would ignore every other MCP
+    //    configuration, silently removing the operator's own servers.
+    //  - emitted before the operator's `claudeArgs` and immediately followed by
+    //    a flag, because `--mcp-config <configs...>` is variadic and would
+    //    otherwise swallow the next bare token.
+    //
+    // Accepted, documented consequence: that same full-environment inheritance
+    // is indiscriminate, so EVERY other MCP server this agent has configured
+    // (user config, project `.mcp.json`) also receives RELAY_IDE_ACTOR_TOKEN.
+    // See docs/MCP_HARNESS_RELAY_BRIDGE.md § "Accepted residual risks" — it is
+    // inside the same-OS-user trust domain, and narrowing it needs a wrapper
+    // launcher that scrubs RELAY_IDE_* for non-Relay MCP children.
+    if (config.relayMcp) {
+      args.push(
+        '--mcp-config',
+        JSON.stringify({
+          mcpServers: {
+            relay: {
+              type: 'stdio',
+              command: config.relayMcp.command,
+              args: config.relayMcp.args,
+            },
+          },
+        })
+      );
+    }
+
     const mode = permissionMode(config.permissionMode) ?? 'default';
     args.push('--permission-mode', mode);
 

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -1190,6 +1190,25 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
   // ── Internal: client wiring ───────────────────────────────────────────────
 
+  /**
+   * Codex deliberately does NOT mount `config.relayMcp` (#1410).
+   *
+   * The app-server accepts the mount itself — `-c mcp_servers.relay.command=…`
+   * plus `-c mcp_servers.relay.args=[…]` merges a `relay` server alongside the
+   * operator's own (verified on codex-cli 0.147.0 via `codex mcp list`). What it
+   * does not do is give that child the credential: codex spawns MCP servers with
+   * a fixed core environment (HOME, LANG, LOGNAME, PATH, SHELL, TERM, USER —
+   * measured by starting a probe server through `thread/start`), and
+   * `shell_environment_policy.inherit=all` does not change it. So
+   * `RELAY_IDE_ACTOR_TOKEN` never reaches the facade, and the only remaining
+   * delivery paths are `mcp_servers.relay.env.*` (a token in argv, readable by
+   * `ps`) or writing the operator's `config.toml`. Both are refused.
+   *
+   * Mounting anyway would hand the agent a Relay tool that answers 401 on every
+   * call. Codex runtimes keep the credential in their OWN process env and reach
+   * Relay through `relay-ide v1 channels …`. Re-evaluate when codex gains
+   * per-server env inheritance.
+   */
   private createClient(config: AdapterConfig): CodexAppServerClient {
     const extra = isRecord(config.extra) ? config.extra : {};
     const opts: CodexAppServerClientOptions = {

--- a/server/relay-mcp-launch.ts
+++ b/server/relay-mcp-launch.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * How to start the local stdio Relay MCP facade (`bin/relay-mcp.ts`).
+ *
+ * This is a launch spec, never a credential carrier: the facade reads Relay's
+ * URL and token exclusively from the environment it inherits from the agent
+ * process Relay spawned (`RELAY_IDE_ACTOR_TOKEN` / `RELAY_IDE_PORT`). Nothing
+ * here may ever be widened to carry a token — an MCP mount is written into
+ * provider argv/config, which is world-readable through `ps`.
+ */
+export interface RelayMcpLaunchSpec {
+  command: string;
+  args: string[];
+}
+
+interface RelayMcpLaunchDeps {
+  /** Location of THIS module, used to find the sibling compiled bin. */
+  moduleUrl?: string;
+  execPath?: string;
+  exists?: (candidate: string) => boolean;
+  isExecutableFile?: (candidate: string) => boolean;
+  pathEnv?: string | undefined;
+  pathSeparator?: string;
+}
+
+function defaultIsExecutableFile(candidate: string): boolean {
+  try {
+    if (!fs.statSync(candidate).isFile()) return false;
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the facade launch spec, or `undefined` when this installation has no
+ * built facade.
+ *
+ * Three layouts, checked in order:
+ *  1. package/dist mode — this module is `dist/server/relay-mcp-launch.js`, so
+ *     the compiled bin is `../bin/relay-mcp.js` (the `resolveRelayctlBinaryPath`
+ *     pattern in `server/pty-handler.ts`).
+ *  2. source-dev mode — this module is `server/relay-mcp-launch.ts` under tsx,
+ *     and a build output may sit at `../dist/bin/relay-mcp.js`.
+ *  3. an installed `relay-mcp` on PATH (the package `bin` entry).
+ *
+ * Returning `undefined` is a normal outcome (a source checkout that was never
+ * built): callers mount nothing rather than pointing a provider at a path that
+ * does not exist.
+ *
+ * Every candidate this returns is ABSOLUTE. The provider — not Relay — spawns
+ * the command, and it resolves a relative command against the AGENT's cwd (a
+ * workspace repo), not the hub's, so a relative `PATH` entry such as `.` would
+ * be checked here and executed somewhere else. Relative entries are skipped
+ * rather than resolved, because resolving them would mount whatever happens to
+ * sit in the hub's working directory.
+ */
+export function resolveRelayMcpLaunch(
+  deps: RelayMcpLaunchDeps = {}
+): RelayMcpLaunchSpec | undefined {
+  const execPath = deps.execPath ?? process.execPath;
+  const exists = deps.exists ?? ((candidate) => fs.existsSync(candidate));
+  const isExecutableFile = deps.isExecutableFile ?? defaultIsExecutableFile;
+  let here: string;
+  try {
+    here = path.dirname(fileURLToPath(deps.moduleUrl ?? import.meta.url));
+  } catch {
+    return undefined;
+  }
+  for (const candidate of [
+    path.join(here, '..', 'bin', 'relay-mcp.js'),
+    path.join(here, '..', 'dist', 'bin', 'relay-mcp.js'),
+  ]) {
+    if (exists(candidate)) return { command: execPath, args: [candidate] };
+  }
+  const separator = deps.pathSeparator ?? path.delimiter;
+  const pathEnv =
+    deps.pathEnv !== undefined ? deps.pathEnv : process.env['PATH'];
+  for (const entry of (pathEnv ?? '').split(separator)) {
+    // Relative `PATH` entries (`.`, `node_modules/.bin`, `''` for cwd) are
+    // skipped, not resolved: the mounted command string is handed to the
+    // provider, which resolves it against the agent's cwd rather than the one
+    // `isExecutableFile` just checked.
+    if (!entry || !path.isAbsolute(entry)) continue;
+    const candidate = path.join(entry, 'relay-mcp');
+    if (isExecutableFile(candidate)) return { command: candidate, args: [] };
+  }
+  return undefined;
+}
+
+let cached: { spec: RelayMcpLaunchSpec | undefined } | undefined;
+
+/**
+ * Process-memoized `resolveRelayMcpLaunch`. Runtime spawn is a hot-ish path and
+ * the answer cannot change while the server is running.
+ */
+export function relayMcpLaunchSpec(): RelayMcpLaunchSpec | undefined {
+  cached ??= { spec: resolveRelayMcpLaunch() };
+  return cached.spec;
+}

--- a/shared/agent-roster.ts
+++ b/shared/agent-roster.ts
@@ -37,6 +37,7 @@ export function collaborationPromptAppendix(
       '- Coordinate implementation workers; do not perform every task yourself.',
       '- Reply in the channel and coordinate agent profiles with explicit `@mentions`; Relay routes those mentions to private runtimes.',
       '- Use `relay-ide v1 channels post --input-json \'{"channelId":"<channel-id>","text":"<message>"}\' --json` only when you need a separate channel post; take <channel-id> from the `[relay channel-id=… trigger-seq=…]` line of your latest message packet. Relay derives the sender.',
+      '- Look up channel history yourself instead of asking for a re-paste. The `[relay channel-id=… trigger-seq=…]` line gives you both values: `relay-ide v1 channels history --channel-id <channel-id> --after-seq <trigger-seq minus 1> --json` reads the messages around your turn, `relay-ide v1 channels search --query "<text>" --json` finds messages across the channels you are scoped to, and `relay-ide v1 channels threads history --channel-id <channel-id> --thread-id <root-message-id> --json` opens one thread once history or search has given you that root message id.',
       '- `relay-ide v1 sessions create --json` creates terminal workers only. It never creates an agent participant.',
       '- Keep fan-out ownership and pending work in channel context; Relay preserves channel and thread history.',
       '- Keep every routed reply explicitly addressed to its intended operator or agent.',
@@ -47,7 +48,8 @@ export function collaborationPromptAppendix(
     '',
     '- Reply normally; Relay persists the response in the originating channel and thread.',
     '- Address another agent profile with an explicit `@mention`. Do not address private runtimes through session or inbox ids.',
-    '- Use `relay-ide v1 channels post --input-json \'{"channelId":"<channel-id>","text":"<message>"}\' --json` only for a separate channel post; take <channel-id> from the `[relay channel-id=… trigger-seq=…]` line of your latest message packet. Relay derives the sender.',
+    '- Your reply to this turn is the normal way to speak. `relay-ide v1 channels post --input-json \'{"channelId":"<channel-id>","text":"<message>"}\' --json` is for a separate channel post and needs a write-capable credential; take <channel-id> from the `[relay channel-id=… trigger-seq=…]` line of your latest message packet. Relay derives the sender.',
+    '- Look up channel history yourself instead of asking for a re-paste. The `[relay channel-id=… trigger-seq=…]` line gives you both values: `relay-ide v1 channels history --channel-id <channel-id> --after-seq <trigger-seq minus 1> --json` reads the messages around your turn, `relay-ide v1 channels search --query "<text>" --json` finds messages across the channels you are scoped to, and `relay-ide v1 channels threads history --channel-id <channel-id> --thread-id <root-message-id> --json` opens one thread once history or search has given you that root message id.',
     '- Use WorkContexts and artifacts for bounded durable work evidence. Never place secrets, provider state, raw terminal bytes, or hidden prompts in collaboration metadata.',
     '- Public `sessions` commands are terminal-only. They do not launch, resume, or discover channel agent participants.',
   ].join('\n');

--- a/shared/channel-client.ts
+++ b/shared/channel-client.ts
@@ -14,6 +14,7 @@ import {
   type ChannelEventV1,
   type ChannelMessage,
   type ChannelMessageId,
+  type ChannelMessageSearchResponse,
   type ChannelReducerState,
   type ChannelSenderRef,
   type ChannelSnapshotEventV1,
@@ -292,6 +293,19 @@ export interface RelayChannelClient {
   roster(input: {
     channelId: string;
   }): Promise<{ roster: ChannelRosterEntry[] }>;
+  /**
+   * Search the durable message log (#1410). Omitting `channelId` searches the
+   * credential's own channel scope, not every channel: a scope-less actor
+   * credential is refused by the hub, and an out-of-scope `channelId` is
+   * rejected before any read.
+   */
+  search(input: {
+    q: string;
+    channelId?: string;
+    workspaceId?: string;
+    includeArchived?: boolean;
+    limit?: number;
+  }): Promise<ChannelMessageSearchResponse>;
   post(input: ChannelPostInput): Promise<ChannelPostResult>;
   subscribe(
     input: ChannelSubscribeInput
@@ -1155,6 +1169,17 @@ export function createRelayChannelClient(
       request(
         'channels.roster',
         `/channels/${encodeURIComponent(channelId)}/roster`
+      ),
+    search: ({ q, channelId, workspaceId, includeArchived, limit }) =>
+      request<ChannelMessageSearchResponse>(
+        'channels.search',
+        pathWithQuery('/channels/search', {
+          q,
+          channelId,
+          workspaceId,
+          includeArchived,
+          limit,
+        })
       ),
     post: ({ channelId, ...body }) =>
       request<Omit<ChannelPostResult, 'message'> & { message: ChannelMessage }>(

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -7,6 +7,10 @@ import {
   CONTEXT_PACKET_KINDS,
   SESSION_INBOX_MESSAGE_STATES,
 } from './context-packet.js';
+import {
+  CHANNEL_SEARCH_MAX_RESULTS,
+  CHANNEL_SEARCH_QUERY_MAX_CHARS,
+} from './channel-chat-protocol.js';
 import { SUPERVISOR_SEND_KEY_NAMES } from './supervisor-actions.js';
 
 export const RELAY_CLI_GATEWAY_MAJOR = 'v1' as const;
@@ -102,6 +106,7 @@ export type RelayCliGatewayCommand =
   | 'channels.subscribe'
   | 'channels.threads.history'
   | 'channels.roster'
+  | 'channels.search'
   | 'channels.post'
   | 'cockpit.list'
   | 'cockpit.get'
@@ -3631,6 +3636,31 @@ const channelRosterInputSchema: RelayJsonSchema = {
   required: ['channelId'],
 };
 
+/**
+ * `channels.search` (#1410) is its OWN verb rather than a filtered ride on
+ * `channels.history`. The actor lane authorizes by the `x-relay-cli-command`
+ * header, so a credential that searched under the history command name would
+ * be lying about the operation in the audit trail; a distinct verb gets its own
+ * schema, capability row, and revocable allowlist entry.
+ *
+ * `channelId` narrows the search to one channel. Omitting it does NOT widen an
+ * actor beyond its credential: the route searches exactly the actor's scoped
+ * channels (`channelIds`), and a scope-less actor credential is denied.
+ */
+const channelSearchInputSchema: RelayJsonSchema = {
+  title: 'ChannelsSearchInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    q: { type: 'string', minLength: 1, maxLength: CHANNEL_SEARCH_QUERY_MAX_CHARS },
+    channelId: stringSchema,
+    workspaceId: stringSchema,
+    includeArchived: booleanSchema,
+    limit: { type: 'integer', minimum: 1, maximum: CHANNEL_SEARCH_MAX_RESULTS },
+  },
+  required: ['q'],
+};
+
 const channelListOutputDataSchema: RelayJsonSchema = {
   title: 'ChannelsListData',
   type: 'object',
@@ -3683,6 +3713,25 @@ const channelRosterOutputDataSchema: RelayJsonSchema = {
     roster: { type: 'array', items: channelObjectSchema },
   },
   required: ['roster'],
+};
+
+/**
+ * `unavailableReason` is load-bearing: a refused query and a consulted-but-empty
+ * index must never look alike, or a caller reports "no matches" for text the
+ * server declined to look up.
+ */
+const channelSearchOutputDataSchema: RelayJsonSchema = {
+  title: 'ChannelsSearchData',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    query: stringSchema,
+    results: { type: 'array', items: channelObjectSchema },
+    truncated: booleanSchema,
+    unavailableReason: stringSchema,
+    scopeAlias: stringSchema,
+  },
+  required: ['query', 'results', 'truncated'],
 };
 
 const okOutput = (title: string, data: RelayJsonSchema): RelayJsonSchema => ({
@@ -6875,6 +6924,39 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'FORBIDDEN',
       'INVALID_ARGUMENT',
       'NOT_FOUND',
+      'SERVER_UNAVAILABLE',
+    ],
+  },
+  {
+    name: 'channels.search',
+    cli: [
+      'relay-ide',
+      'v1',
+      'channels',
+      'search',
+      '--query',
+      '<text>',
+      '--channel-id',
+      '<id>',
+      '--limit',
+      '<n>',
+      '--json',
+    ],
+    summary:
+      'Search durable channel messages inside the actor’s channel scope; an unscoped credential is denied and an out-of-scope channelId is rejected.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:read'],
+    inputSchema: channelSearchInputSchema,
+    outputSchema: okOutput(
+      'ChannelsSearchOutput',
+      channelSearchOutputDataSchema
+    ),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'INVALID_ARGUMENT',
       'SERVER_UNAVAILABLE',
     ],
   },

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -174,6 +174,7 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'channels.subscribe': 'subscribe to channel messages',
   'channels.threads.history': 'channel thread history',
   'channels.roster': 'channel roster',
+  'channels.search': 'search channel messages',
   'channels.post': 'post channel message',
   'cockpit.list': 'terminal attention cockpit',
   'cockpit.get': 'terminal cockpit detail',

--- a/test/channel-agent-runtime.test.ts
+++ b/test/channel-agent-runtime.test.ts
@@ -15,6 +15,7 @@ import type {
 } from '../shared/agent-chat-protocol-v2.js';
 import { emptyAgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
 import { CHANNEL_ADAPTER_LAUNCH_CONTRACTS } from '../server/protocol-adapters/index.js';
+import { relayMcpLaunchSpec } from '../server/relay-mcp-launch.js';
 import {
   scheduleRelayProcessTreeReap,
   type ProcessInfo,
@@ -192,8 +193,10 @@ async function runtimeModule() {
 }
 
 afterEach(async () => {
-  const { channelAgentRuntimes } = await runtimeModule();
+  const { channelAgentRuntimes, configureChannelAgentRuntimes } =
+    await runtimeModule();
   await channelAgentRuntimes.close();
+  configureChannelAgentRuntimes({});
   adapterState.last = null;
   adapterState.all.length = 0;
   adapterState.onConnect = null;
@@ -558,6 +561,133 @@ describe('ChannelAgentRuntimeManager', () => {
         expect(connectedEnv).not.toHaveProperty(key);
       }
     }
+  });
+
+  it('injects the standing read lease into every command/embedded launch and nothing else (#1410)', async () => {
+    const { channelAgentRuntimes, configureChannelAgentRuntimes } =
+      await runtimeModule();
+    const issued: {
+      capabilities: unknown;
+      scope: unknown;
+      ttlMs: unknown;
+    }[] = [];
+    let issueCount = 0;
+    configureChannelAgentRuntimes({
+      runtimeReadCredentials: {
+        issueCredential: (input) => {
+          issueCount++;
+          issued.push({
+            capabilities: input.capabilities,
+            scope: input.scope,
+            ttlMs: input.ttlMs,
+          });
+          const issuedAt = Date.now();
+          return {
+            token: `relay-sac-v1.credential-${issueCount}.redacted`,
+            credential: {
+              id: `credential-${issueCount}`,
+              actor: { type: 'agent', id: 'agent-profile:test' },
+              issuer: { id: 'relay-ide' },
+              audience: 'relay:cli-gateway:v1',
+              capabilities: ['session:read', 'context:read'],
+              scope: {
+                sessionIds: [`channel-runtime-${issueCount}`],
+                channelIds: ['channel-A'],
+              },
+              metadata: { reason: 'channel-runtime-read' },
+              issuedAt: new Date(issuedAt).toISOString(),
+              expiresAt: new Date(issuedAt + 15 * 60 * 1000).toISOString(),
+              correlationId: `correlation-${issueCount}`,
+            },
+          };
+        },
+        revokeCredential: vi.fn(),
+      },
+    });
+
+    for (const [providerId, contract] of Object.entries(
+      CHANNEL_ADAPTER_LAUNCH_CONTRACTS
+    )) {
+      const before = issueCount;
+      await channelAgentRuntimes.create({
+        id: `channel-runtime-${providerId}`,
+        channelId: 'channel-A',
+        providerId,
+        profileActorId: `agent-profile:${providerId}:named`,
+        cwd: '/tmp',
+        displayName: `#eng · ${providerId}`,
+        port: 3456,
+        configDir: '/tmp',
+      });
+      const connectedConfig = adapterState.last!.connectConfigs[0]!;
+      const connectedEnv = connectedConfig.processEnv;
+      const spawnsChild =
+        contract.requirement.kind === 'command' ||
+        contract.requirement.kind === 'embedded';
+
+      // #1410: the MCP facade is a view of the credential, so the mount and the
+      // token travel together in BOTH directions. A mount without a credential
+      // would hand the agent a Relay tool that can only answer 401.
+      expect(Boolean(connectedConfig.relayMcp)).toBe(
+        spawnsChild && Boolean(relayMcpLaunchSpec())
+      );
+      if (connectedConfig.relayMcp) {
+        expect(Object.keys(connectedConfig.relayMcp).sort()).toEqual([
+          'args',
+          'command',
+        ]);
+        expect(JSON.stringify(connectedConfig.relayMcp)).not.toContain(
+          'relay-sac-v1'
+        );
+      }
+
+      if (spawnsChild) {
+        // A denylist that stripped the token would silently disable every
+        // handle deref for that provider, with no error anywhere.
+        expect(connectedEnv?.RELAY_IDE_ACTOR_TOKEN).toMatch(/^relay-sac-v1\./);
+        expect(connectedEnv?.RELAY_IDE_PORT).toBe('3456');
+        expect(connectedEnv?.RELAY_IDE_RUNTIME_ID).toBe(
+          `channel-runtime-${providerId}`
+        );
+        expect(issueCount).toBe(before + 1);
+      } else {
+        // Gateway launches have no child env; the only other delivery path
+        // would be channel-visible text, which the contract forbids.
+        expect(connectedEnv?.RELAY_IDE_ACTOR_TOKEN).toBeUndefined();
+        expect(issueCount).toBe(before);
+      }
+    }
+
+    expect(issued.length).toBeGreaterThan(0);
+    for (const call of issued) {
+      expect(call.capabilities).toEqual(['session:read', 'context:read']);
+      expect(call.ttlMs).toBe(15 * 60 * 1000);
+      // Channel and nothing else: a dimension the channel routes never name
+      // (a session pin) makes every `channels.*` request fail `missing_scope`.
+      expect(call.scope).toEqual({ channelIds: ['channel-A'] });
+    }
+  });
+
+  it('mounts no MCP facade for a runtime that holds no credential (#1410)', async () => {
+    const { channelAgentRuntimes, configureChannelAgentRuntimes } =
+      await runtimeModule();
+    // No read-credential authority configured: nothing to lease, so nothing to
+    // mount. Same shape as a mint failure or an unbound runtime.
+    configureChannelAgentRuntimes({});
+    await channelAgentRuntimes.create({
+      id: 'channel-runtime-uncredentialed',
+      channelId: 'channel-A',
+      providerId: 'claude',
+      profileActorId: 'agent-profile:claude:default',
+      cwd: '/tmp',
+      displayName: '#eng · Claude',
+      port: 3456,
+      configDir: '/tmp',
+    });
+
+    const connectedConfig = adapterState.last!.connectConfigs[0]!;
+    expect(connectedConfig.relayMcp).toBeUndefined();
+    expect(connectedConfig.processEnv?.RELAY_IDE_ACTOR_TOKEN).toBeUndefined();
   });
 
   it('resumes from the channel binding provider session and remains outside the public session registry', async () => {

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../server/channel-hub.js';
 import {
   authenticatedSourceRuntimeId,
+  channelSearchRequestedChannelId,
   createChannelChatRouter,
 } from '../server/channel-chat-router.js';
 import {
@@ -132,6 +133,7 @@ async function harness(
       topicStore: WorkspaceTopicStore;
     }) => ChannelAgentBinder;
     requireWriteActorAuth?: (command: string) => RequestHandler;
+    requireReadActorAuth?: (command: string) => RequestHandler;
   } = {}
 ): Promise<Harness> {
   const dir = tmpDir();
@@ -213,6 +215,9 @@ async function harness(
         : {}),
       ...(options.requireWriteActorAuth
         ? { requireWriteActorAuth: options.requireWriteActorAuth as never }
+        : {}),
+      ...(options.requireReadActorAuth
+        ? { requireReadActorAuth: options.requireReadActorAuth as never }
         : {}),
       ...(options.historyMaxBytes !== undefined
         ? { historyMaxBytes: options.historyMaxBytes }
@@ -1731,6 +1736,138 @@ describe('channel routes — gateway capability mapping', () => {
       'context:write',
     ]);
   });
+
+  // #1410: search opened to in-scope actors under its OWN verb. The actor lane
+  // authorizes by the `x-relay-cli-command` header, so if the route asked for
+  // `channels.history` here, any history-capable credential could search while
+  // naming the wrong operation in the audit trail.
+  it('registers channels.search as its own read verb rather than riding channels.history', () => {
+    expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toContain('channels.search');
+    expect(CLI_GATEWAY_ACTOR_WRITE_COMMANDS).not.toContain(
+      'channels.search' as never
+    );
+    expect(cliGatewayActorCommandCapabilities('channels.search')).toEqual([
+      'context:read',
+    ]);
+  });
+
+  it('authorizes GET /channels/search through the channels.search middleware', async () => {
+    const commands: string[] = [];
+    const h = await harness({
+      requireReadActorAuth: (command) => (_req, _res, next) => {
+        commands.push(command);
+        next();
+      },
+    });
+    const res = await req<{ results: unknown[] }>({
+      port: h.port,
+      method: 'GET',
+      url: '/channels/search?q=anything',
+    });
+    expect(res.status).toBe(200);
+    expect(commands).toEqual(['channels.search']);
+  });
+
+  // One parser, two layers. `server/index.ts` builds the requested actor scope
+  // from this helper and the route enforces `denyOutOfScopeChannel` on the same
+  // value, so the middleware can never authorize a different channel than the
+  // route enforces. Express turns `?channelId=A&channelId=B` into an array — a
+  // bare `typeof === 'string'` check reads that as "no channel named".
+  it('parses the searched channelId identically for the middleware and the route', () => {
+    expect(channelSearchRequestedChannelId({ channelId: 'topic:a' })).toBe(
+      'topic:a'
+    );
+    expect(
+      channelSearchRequestedChannelId({ channelId: ['topic:b', 'topic:a'] })
+    ).toBe('topic:b');
+    expect(
+      channelSearchRequestedChannelId({ channelId: ['topic:a', 'topic:b'] })
+    ).toBe('topic:a');
+    expect(channelSearchRequestedChannelId({ channelId: '' })).toBeUndefined();
+    expect(channelSearchRequestedChannelId({ channelId: [] })).toBeUndefined();
+    expect(channelSearchRequestedChannelId({})).toBeUndefined();
+    expect(channelSearchRequestedChannelId(undefined)).toBeUndefined();
+    // A nested/object value is not a channel name and must not become one.
+    expect(
+      channelSearchRequestedChannelId({ channelId: { $ne: 'x' } })
+    ).toBeUndefined();
+  });
+});
+
+describe('channel routes — private routes stay closed to the standing read lease (#1410)', () => {
+  it('denies every private channel route for a channel-scoped actor', async () => {
+    const h = await harness({
+      binder: {
+        interrupt: async () => {
+          throw new Error('binder must never be reached');
+        },
+        respondToApproval: async () => {
+          throw new Error('binder must never be reached');
+        },
+      },
+    });
+    const actorHeaders = {
+      'x-test-actor-id': 'agent-profile:claude:default',
+      'x-test-actor-scope': JSON.stringify({ channelIds: [h.channelId] }),
+      'x-relay-capabilities': 'context:read,context:write',
+    };
+    // Opening search moved exactly one deny. Enumerate the rest so a future
+    // "just drop denyScopedActorPrivateRoute" cannot pass silently.
+    for (const [method, url] of [
+      ['POST', `/channels/${encodeURIComponent(h.channelId)}/attachments`],
+      [
+        'GET',
+        `/channels/${encodeURIComponent(h.channelId)}/attachments/att-1`,
+      ],
+      ['POST', `/channels/${encodeURIComponent(h.channelId)}/agent-commands`],
+      [
+        'POST',
+        `/channels/${encodeURIComponent(h.channelId)}/agent-runtimes/restart`,
+      ],
+      [
+        'POST',
+        `/channels/${encodeURIComponent(h.channelId)}/agents/claude/interrupt`,
+      ],
+      [
+        'POST',
+        `/channels/${encodeURIComponent(h.channelId)}/agents/claude/approvals`,
+      ],
+    ] as const) {
+      const denied = await req<{
+        error: { code: string; details?: Record<string, unknown> };
+      }>({
+        port: h.port,
+        method,
+        url,
+        body: method === 'POST' ? {} : undefined,
+        headers: actorHeaders,
+      });
+      expect([method, url, denied.status]).toEqual([method, url, 403]);
+      expect(denied.body.error.details?.['reasonCode']).toBe(
+        'CHANNEL_PRIVATE_ROUTE_ACTOR_FORBIDDEN'
+      );
+    }
+
+    // Read state is operator-only through a different guard, and stays so.
+    for (const [method, url] of [
+      ['GET', '/channels/read-state'],
+      ['PUT', `/channels/${encodeURIComponent(h.channelId)}/read-state`],
+    ] as const) {
+      const denied = await req<{
+        error: { details?: Record<string, unknown> };
+      }>({
+        port: h.port,
+        method,
+        url,
+        body: method === 'PUT' ? { lastReadSeq: 1 } : undefined,
+        headers: actorHeaders,
+      });
+      expect([url, denied.status]).toEqual([url, 403]);
+      expect(denied.body.error.details?.['reasonCode']).toBe(
+        'CHANNEL_READ_STATE_HUMAN_ONLY'
+      );
+    }
+  });
 });
 
 describe('channel routes — channel-scope escape (Slice 0 gate)', () => {
@@ -1792,13 +1929,46 @@ describe('channel routes — channel-scope escape (Slice 0 gate)', () => {
       body: { text: 'quarantine leak marker' },
     });
     expect(seededB.status).toBe(201);
-    const globalSearch = await req<{ results: unknown[] }>({
+    // #1410: an in-scope actor MAY search, but an unnamed search reaches only
+    // its own channels. B's row is indexed and matching, and must still not
+    // appear — search is scope-narrowed at the candidate set, not filtered
+    // after the index answered.
+    const globalSearch = await req<{ results: Array<{ channelId: string }> }>({
       port: h.port,
       method: 'GET',
       url: '/channels/search?q=quarantine',
       headers: actorHeaders(a, 'GET'),
     });
-    expect(globalSearch.status).toBe(403);
+    expect(globalSearch.status).toBe(200);
+    expect(globalSearch.body.results).toEqual([]);
+    const seededA = await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(a)}/messages`,
+      body: { text: 'quarantine marker in scope' },
+    });
+    expect(seededA.status).toBe(201);
+    const ownSearch = await req<{ results: Array<{ channelId: string }> }>({
+      port: h.port,
+      method: 'GET',
+      url: '/channels/search?q=quarantine',
+      headers: actorHeaders(a, 'GET'),
+    });
+    expect(ownSearch.status).toBe(200);
+    expect(ownSearch.body.results.map((hit) => hit.channelId)).toEqual([a]);
+    // An explicit out-of-scope channelId is refused before the store is read.
+    const crossSearch = await req<{
+      error: { code: string; details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/search?q=quarantine&channelId=${encodeURIComponent(b)}`,
+      headers: actorHeaders(a, 'GET'),
+    });
+    expect(crossSearch.status).toBe(403);
+    expect(crossSearch.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_OUT_OF_SCOPE'
+    );
 
     // (b) Every channel-B read/write is 403 FORBIDDEN before touching the store.
     for (const [method, url] of [
@@ -1845,10 +2015,11 @@ describe('channel routes — channel-scope escape (Slice 0 gate)', () => {
       });
       expect(denied.status).toBe(403);
       expect(denied.body.error.code).toBe('FORBIDDEN');
+      // #1410 opened search to in-scope actors via `channels.search`. A
+      // credential with NO channel scope still cannot enumerate or search:
+      // the deny simply names the missing scope instead of the private route.
       expect(denied.body.error.details?.['reasonCode']).toBe(
-        url === '/channels'
-          ? 'CHANNEL_SCOPE_REQUIRED'
-          : 'CHANNEL_PRIVATE_ROUTE_ACTOR_FORBIDDEN'
+        'CHANNEL_SCOPE_REQUIRED'
       );
     }
 
@@ -1933,7 +2104,7 @@ describe('channel routes — agent commands', () => {
     expect(h.store.history(h.channelId, { limit: 10 })).toEqual([]);
   });
 
-  it('denies actor search, interrupt, and approval with no store or binder side effect', async () => {
+  it('lets an in-scope actor search while interrupt and approval stay denied with no binder side effect', async () => {
     const calls: string[] = [];
     const h = await harness({
       binder: {
@@ -1955,7 +2126,9 @@ describe('channel routes — agent commands', () => {
       'x-test-actor-id': 'agent-profile:codex:scoped',
       'x-test-actor-scope': JSON.stringify({ channelIds: [h.channelId] }),
     };
-    const search = await req<{ error: unknown }>({
+    // #1410: search is the ONE surface this slice opened. It reads the same
+    // durable log `channels.history` already grants, inside the same scope.
+    const search = await req<{ results: Array<{ channelId: string }> }>({
       port: h.port,
       method: 'GET',
       url: `/channels/search?q=private&channelId=${encodeURIComponent(h.channelId)}`,
@@ -1976,7 +2149,10 @@ describe('channel routes — agent commands', () => {
       body: { requestId: 'approval-1', decision: { kind: 'accept' } },
     });
     expect([search.status, interrupt.status, approval.status]).toEqual([
-      403, 403, 403,
+      200, 403, 403,
+    ]);
+    expect(search.body.results.map((hit) => hit.channelId)).toEqual([
+      h.channelId,
     ]);
     expect(calls).toEqual([]);
     expect(h.store.history(h.channelId, { limit: 10 })).toEqual(rowsBefore);

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -9,6 +9,7 @@ import {
   cliGatewayActorCommandCapabilities,
   cliGatewayActorFailure,
   classifyCliGatewayCredentialLane,
+  issueChannelRuntimeReadCliGatewayActorCredential,
   issueCliGatewayActorCredential,
   issueCliGatewayActorCredentialWithGrant,
   issuePersistentOrchestratorCliGatewayActorCredential,
@@ -178,6 +179,168 @@ test('reserves the persistent-orchestrator reason for the internal lease issuer'
   expect(internal.credential.metadata).toEqual({
     reason: 'persistent-orchestrator',
   });
+});
+
+test('reserves the channel-runtime-read reason for the internal read-lease issuer', () => {
+  const scopedRegistry = registry();
+  const ordinary = issueCliGatewayActorCredential(scopedRegistry, {
+    metadata: {
+      reason: 'channel-runtime-read',
+      trace: 'ordinary',
+    },
+  });
+  expect(ordinary.credential.metadata?.reason).toBeUndefined();
+
+  const grants = grantRegistry();
+  const grantBacked = issueCliGatewayActorCredentialWithGrant(
+    scopedRegistry,
+    grants,
+    {
+      ...grantLifecycleInput(
+        approveGrant(grants, 'grant-runtime-read-reason'),
+        'runtime-read-reason'
+      ),
+      metadata: {
+        reason: 'channel-runtime-read',
+        trace: 'grant',
+      },
+    }
+  );
+  expect(grantBacked.credential.metadata?.reason).toBeUndefined();
+
+  const internal = issueChannelRuntimeReadCliGatewayActorCredential(
+    scopedRegistry,
+    {
+      actor: { type: 'agent', id: 'collaborator-runtime' },
+      issuer: { id: 'relay-ide' },
+      capabilities: ['session:read', 'context:read'],
+      scope: {
+        sessionIds: ['collaborator-runtime'],
+        channelIds: ['channel-A'],
+      },
+    }
+  );
+  // The marker is an audit breadcrumb only: it must never buy the
+  // orchestrator's verbatim-sender / agent-brake-bypass identity.
+  expect(internal.credential.metadata).toEqual({
+    reason: 'channel-runtime-read',
+  });
+  expect(internal.credential.capabilities).toEqual([
+    'session:read',
+    'context:read',
+  ]);
+});
+
+test('resolves channel read verbs to context:read for a read-lease credential', () => {
+  for (const command of [
+    'channels.list',
+    'channels.get',
+    'channels.history',
+    'channels.threads.history',
+    'channels.run.get',
+    'channels.roster',
+    'channels.subscribe',
+    'channels.search',
+  ]) {
+    expect(cliGatewayActorCommandCapabilities(command)).toEqual([
+      'context:read',
+    ]);
+  }
+  // The standing lease carries no write bit, so this verb can never authorize.
+  expect(cliGatewayActorCommandCapabilities('channels.post')).toEqual([
+    'context:write',
+  ]);
+});
+
+test('a read-only channel-scoped credential can search its own channel and can never post', () => {
+  const scopedRegistry = registry();
+  // The scope shape the channel routes actually validate against: the
+  // middleware derives `channelIds` from the request, and nothing else — a
+  // channel request names no session, repo, or WorkContext.
+  const issued = issueCliGatewayActorCredential(scopedRegistry, {
+    capabilities: ['session:read', 'context:read'],
+    scope: { channelIds: ['A'] },
+  });
+
+  // (a) search inside the credential's own channel authorizes.
+  expect(
+    validateCliGatewayActorCredential(scopedRegistry, {
+      token: issued.token,
+      capabilities: cliGatewayActorCommandCapabilities('channels.search'),
+      scope: { channelIds: ['A'] },
+    })
+  ).toMatchObject({ ok: true, grantedBits: ['context:read'] });
+
+  // (b) search aimed at another channel fails closed on scope.
+  expect(
+    validateCliGatewayActorCredential(scopedRegistry, {
+      token: issued.token,
+      capabilities: cliGatewayActorCommandCapabilities('channels.search'),
+      scope: { channelIds: ['B'] },
+    })
+  ).toMatchObject({ ok: false, reason: 'wrong_channel_scope' });
+
+  // (c) the write verb is unreachable: the credential holds no context:write
+  // bit, so opening search never buys a post.
+  expect(
+    validateCliGatewayActorCredential(scopedRegistry, {
+      token: issued.token,
+      capabilities: cliGatewayActorCommandCapabilities('channels.post'),
+      scope: { channelIds: ['A'] },
+    })
+  ).toMatchObject({
+    ok: false,
+    reason: 'insufficient_capability',
+    deniedBits: ['context:write'],
+  });
+
+  // (d) a credential with no channel dimension at all cannot search: the
+  // channel rule is `requiredWhenRequested`, so absence denies rather than
+  // skips.
+  const unscoped = issueCliGatewayActorCredential(scopedRegistry, {
+    capabilities: ['session:read', 'context:read'],
+    scope: { workContextIds: ['wc:allowed'] },
+  });
+  expect(
+    validateCliGatewayActorCredential(scopedRegistry, {
+      token: unscoped.token,
+      capabilities: cliGatewayActorCommandCapabilities('channels.search'),
+      scope: { channelIds: ['A'] },
+    })
+  ).toMatchObject({ ok: false, reason: 'wrong_channel_scope' });
+});
+
+test('search is a named actor read verb, not a POST or an unnamed request', () => {
+  const token = 'relay-sac-v1.credential-id.[REDACTED]';
+  // The actor lane authorizes by the command header. A search request that
+  // names no command, or names a different verb, is not on the lane at all.
+  expect(
+    classifyCliGatewayCredentialLane(
+      req({ authorization: `Bearer ${token}`, actorMarker: 'v1' }),
+      'channels.search'
+    )
+  ).toBe('unsupported-route');
+  expect(
+    classifyCliGatewayCredentialLane(
+      req({
+        authorization: `Bearer ${token}`,
+        actorMarker: 'v1',
+        command: 'channels.history',
+      }),
+      'channels.search'
+    )
+  ).toBe('unsupported-route');
+  expect(
+    classifyCliGatewayCredentialLane(
+      req({
+        method: 'POST',
+        authorization: `Bearer ${token}`,
+        actorMarker: 'v1',
+        command: 'channels.search',
+      }),
+      'channels.search'
+    )
+  ).toBe('unsupported-route');
 });
 
 test('validates WorkContext-scoped actor credentials against exact artifact read scopes', () => {
@@ -450,6 +613,7 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
     'channels.subscribe',
     'channels.threads.history',
     'channels.roster',
+    'channels.search',
     'context.get',
     'context.list',
     'inbox.list',
@@ -492,6 +656,7 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
     'channels.subscribe',
     'channels.threads.history',
     'channels.roster',
+    'channels.search',
   ] as const) {
     expect(
       classifyCliGatewayCredentialLane(

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -17,6 +17,10 @@ import {
   relayCommandDefinitionsForSurface,
 } from '../shared/relay-command-manifest.js';
 import {
+  CHANNEL_SEARCH_MAX_RESULTS,
+  CHANNEL_SEARCH_QUERY_MAX_CHARS,
+} from '../shared/channel-chat-protocol.js';
+import {
   HIGH_RISK_CAPABILITIES,
   LEGACY_DEFAULT_ALLOWED_CAPABILITIES,
   RELAY_CAPABILITY_BITS,
@@ -263,6 +267,7 @@ describe('CLI gateway contract', () => {
       'channels.subscribe',
       'channels.threads.history',
       'channels.roster',
+      'channels.search',
       'channels.post',
       'cockpit.list',
       'cockpit.get',
@@ -291,6 +296,7 @@ describe('CLI gateway contract', () => {
       'channels.subscribe',
       'channels.threads.history',
       'channels.roster',
+      'channels.search',
     ] as const;
     const names = new Set(stableCommandNames());
     for (const verb of readVerbs) {
@@ -579,6 +585,48 @@ describe('CLI gateway contract', () => {
     expect(
       cursorSchema && schemaMatches(cursorSchema, { afterSeq: 4, extra: true })
     ).toBe(false);
+  });
+
+  it('models the channels.search input as a bounded, query-required read', () => {
+    expect(schemaAcceptsCommandInput('channels.search', { q: 'needle' })).toBe(
+      true
+    );
+    expect(
+      schemaAcceptsCommandInput('channels.search', {
+        q: 'needle',
+        channelId: 'channel-1',
+        workspaceId: 'ws-1',
+        includeArchived: true,
+        limit: CHANNEL_SEARCH_MAX_RESULTS,
+      })
+    ).toBe(true);
+    // The query is the whole command; an omitted or empty one is refused
+    // rather than silently answered with every message in scope.
+    expect(schemaAcceptsCommandInput('channels.search', {})).toBe(false);
+    expect(schemaAcceptsCommandInput('channels.search', { q: '' })).toBe(false);
+    expect(
+      schemaAcceptsCommandInput('channels.search', {
+        q: 'x'.repeat(CHANNEL_SEARCH_QUERY_MAX_CHARS + 1),
+      })
+    ).toBe(false);
+    for (const limit of [0, CHANNEL_SEARCH_MAX_RESULTS + 1, 1.5, '5']) {
+      expect(
+        schemaAcceptsCommandInput('channels.search', { q: 'needle', limit })
+      ).toBe(false);
+    }
+    // No undeclared knob may ride along into the hub query string.
+    expect(
+      schemaAcceptsCommandInput('channels.search', {
+        q: 'needle',
+        beforeSeq: 4,
+      })
+    ).toBe(false);
+    // Search reads; it must never be classified as a write or a stream.
+    expect(relayCommandDefinition('channels.search')).toMatchObject({
+      sideEffect: 'read',
+      requiresConfirmation: false,
+      scopeKinds: ['work-context', 'session'],
+    });
   });
 
   it('keeps cockpit limit validation aligned with its schema', () => {

--- a/test/cli-gateway/channels-read.test.ts
+++ b/test/cli-gateway/channels-read.test.ts
@@ -158,6 +158,26 @@ describe('channel read CLI gateway runtime wiring', () => {
       'channels.roster',
       '/channels/product%2Fmain/roster',
     ],
+    [
+      ['search', '--query', 'needle'],
+      'channels.search',
+      '/channels/search?q=needle',
+    ],
+    [
+      [
+        'search',
+        '--query',
+        'needle in haystack',
+        '--channel-id',
+        'product/main',
+        '--include-archived',
+        'true',
+        '--limit',
+        '10',
+      ],
+      'channels.search',
+      '/channels/search?q=needle+in+haystack&channelId=product%2Fmain&includeArchived=true&limit=10',
+    ],
   ] as const)(
     'maps %j to %s and its declared REST route',
     async (channelArgs, command, route) => {
@@ -224,6 +244,24 @@ describe('channel read CLI gateway runtime wiring', () => {
     [
       ['roster', '--channel-id', 'one', '--channel-id', 'two', '--json'],
       'channels.roster',
+    ],
+    [['search', '--json'], 'channels.search'],
+    [['search', '--query', '   ', '--json'], 'channels.search'],
+    [
+      ['search', '--query', 'needle', '--limit', '0', '--json'],
+      'channels.search',
+    ],
+    [
+      ['search', '--query', 'needle', '--limit', '51', '--json'],
+      'channels.search',
+    ],
+    [
+      ['search', '--query', 'needle', '--include-archived', 'yes', '--json'],
+      'channels.search',
+    ],
+    [
+      ['search', '--query', 'needle', '--after-seq', '3', '--json'],
+      'channels.search',
     ],
   ] as const)(
     'rejects malformed stable command argv %j',

--- a/test/orchestrator-credential-lifecycle.test.ts
+++ b/test/orchestrator-credential-lifecycle.test.ts
@@ -3,6 +3,8 @@ import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credent
 import {
   ORCHESTRATOR_ACTOR_CAPABILITIES,
   ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS,
+  READONLY_RUNTIME_ACTOR_CAPABILITIES,
+  RUNTIME_ACTOR_CREDENTIAL_TTL_MS,
   startOrchestratorCredentialLifecycle,
   type OrchestratorCredentialLifecycleDeps,
 } from '../server/orchestrator-credential-lifecycle.js';
@@ -99,6 +101,9 @@ describe('OrchestratorCredentialLifecycle', () => {
         profileActorId: 'agent-profile:test',
         port: 4567,
         displayName: 'Product orchestrator',
+        leaseKind: 'orchestrator',
+        capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+        rotation: 'refresh',
       },
       h.deps
     );
@@ -137,6 +142,9 @@ describe('OrchestratorCredentialLifecycle', () => {
         channelId: 'channel-A',
         profileActorId: 'agent-profile:test',
         port: 4567,
+        leaseKind: 'orchestrator',
+        capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+        rotation: 'refresh',
       },
       h.deps
     );
@@ -186,6 +194,9 @@ describe('OrchestratorCredentialLifecycle', () => {
         channelId: 'channel-A',
         profileActorId: 'agent-profile:test',
         port: 4567,
+        leaseKind: 'orchestrator',
+        capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+        rotation: 'refresh',
       },
       h.deps
     );
@@ -217,6 +228,9 @@ describe('OrchestratorCredentialLifecycle', () => {
           channelId: 'channel-A',
           profileActorId: 'agent-profile:test',
           port: 4567,
+          leaseKind: 'orchestrator',
+          capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+          rotation: 'refresh',
         },
         h.deps
       )
@@ -228,6 +242,9 @@ describe('OrchestratorCredentialLifecycle', () => {
           channelId: 'channel-A',
           profileActorId: 'agent-profile:test',
           port: 4567,
+          leaseKind: 'orchestrator',
+          capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+          rotation: 'refresh',
         },
         h.deps
       );
@@ -250,6 +267,9 @@ describe('OrchestratorCredentialLifecycle', () => {
         channelId: 'channel-A',
         profileActorId: 'agent-profile:test',
         port: 4567,
+        leaseKind: 'orchestrator',
+        capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+        rotation: 'refresh',
       },
       h.deps
     );
@@ -291,6 +311,9 @@ describe('OrchestratorCredentialLifecycle', () => {
         channelId: 'channel-A',
         profileActorId: 'agent-profile:test',
         port: 4567,
+        leaseKind: 'orchestrator',
+        capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+        rotation: 'refresh',
       },
       h.deps
     );
@@ -313,5 +336,160 @@ describe('OrchestratorCredentialLifecycle', () => {
 
     releaseApply?.();
     lease.stop();
+  });
+});
+
+describe('read-only runtime credential lease (#1410)', () => {
+  it('mints exactly the read bits, pinned to its own channel and nothing else', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const h = harness();
+
+    const lease = startOrchestratorCredentialLifecycle(
+      {
+        runtimeId: 'runtime-collaborator',
+        channelId: 'channel-A',
+        profileActorId: 'agent-profile:codex:default',
+        port: 4567,
+        displayName: '#eng · Codex',
+        leaseKind: 'channel-runtime-read',
+        capabilities: [...READONLY_RUNTIME_ACTOR_CAPABILITIES],
+        rotation: 'static',
+      },
+      h.deps
+    );
+
+    expect(READONLY_RUNTIME_ACTOR_CAPABILITIES).toEqual([
+      'session:read',
+      'context:read',
+    ]);
+    expect(h.issueCredential).toHaveBeenCalledWith({
+      actor: {
+        type: 'agent',
+        id: 'agent-profile:codex:default',
+        displayName: '#eng · Codex',
+      },
+      issuer: { id: 'relay-ide', displayName: 'Relay' },
+      capabilities: ['session:read', 'context:read'],
+      // Channel and NOTHING else. `validateCredentialScope` denies any
+      // credential dimension a request does not name, and a channel HTTP
+      // request names no session — a `sessionIds` pin here would make the lease
+      // unusable on every `channels.*` route it exists for. Confinement is not
+      // lost: that same rule means a channel-only credential is accepted ONLY by
+      // routes that request `channelIds`.
+      scope: { channelIds: ['channel-A'] },
+      ttlMs: 15 * 60 * 1000,
+    });
+    const issued = h.issueCredential.mock.calls[0]?.[0];
+    expect(issued.capabilities).not.toContain('context:write');
+    expect(issued.capabilities).not.toContain('session:create:terminal');
+    expect(issued.scope.sessionIds).toBeUndefined();
+    expect(lease.processEnv).toEqual({
+      RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-1.secret-1',
+      RELAY_IDE_PORT: '4567',
+      RELAY_IDE_RUNTIME_ID: 'runtime-collaborator',
+    });
+
+    lease.stop();
+  });
+
+  it('never rotates a static lease and lets the credential expire', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const h = harness();
+    const lease = startOrchestratorCredentialLifecycle(
+      {
+        runtimeId: 'runtime-collaborator',
+        channelId: 'channel-A',
+        profileActorId: 'agent-profile:codex:default',
+        port: 4567,
+        leaseKind: 'channel-runtime-read',
+        capabilities: [...READONLY_RUNTIME_ACTOR_CAPABILITIES],
+        rotation: 'static',
+      },
+      h.deps
+    );
+
+    await vi.advanceTimersByTimeAsync(RUNTIME_ACTOR_CREDENTIAL_TTL_MS * 4);
+    // An adapter with no `refreshRuntimeEnv` cannot receive a replacement
+    // token, so re-minting one would only revoke a working credential.
+    await lease.refreshNow();
+
+    expect(h.issueCredential).toHaveBeenCalledTimes(1);
+    expect(h.applyRuntimeEnv).not.toHaveBeenCalled();
+    expect(h.revokeCredential).not.toHaveBeenCalled();
+    expect(h.failClosed).not.toHaveBeenCalled();
+    expect(h.events).toEqual(['issue:credential-1']);
+
+    lease.stop();
+    expect(h.revokeCredential).toHaveBeenCalledWith('credential-1', {
+      revokedBy: 'relay-ide',
+      reason: 'channel-runtime-read-ended',
+    });
+  });
+
+  it('rotates a refresh-capable read lease under its own audit reasons', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const h = harness();
+    const lease = startOrchestratorCredentialLifecycle(
+      {
+        runtimeId: 'runtime-collaborator',
+        channelId: 'channel-A',
+        profileActorId: 'agent-profile:claude:default',
+        port: 4567,
+        leaseKind: 'channel-runtime-read',
+        capabilities: [...READONLY_RUNTIME_ACTOR_CAPABILITIES],
+        rotation: 'refresh',
+      },
+      h.deps
+    );
+
+    await vi.advanceTimersByTimeAsync(7.5 * 60 * 1000);
+
+    expect(h.events).toEqual([
+      'issue:credential-1',
+      'issue:credential-2',
+      'apply',
+      'revoke:credential-1',
+    ]);
+    // A read lease must never borrow the orchestrator's audit identity.
+    expect(h.revokeCredential).toHaveBeenCalledWith('credential-1', {
+      revokedBy: 'relay-ide',
+      reason: 'channel-runtime-read-rotated',
+    });
+    expect(
+      h.issueCredential.mock.calls.map(([input]) => input.capabilities)
+    ).toEqual([
+      ['session:read', 'context:read'],
+      ['session:read', 'context:read'],
+    ]);
+
+    lease.stop();
+  });
+
+  it('keeps failure text free of orchestrator identity and credential material', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const h = harness({
+      issueError: new Error(
+        'issuer failed around relay-sac-v1.private.secret-material'
+      ),
+    });
+
+    expect(() =>
+      startOrchestratorCredentialLifecycle(
+        {
+          runtimeId: 'runtime-collaborator',
+          channelId: 'channel-A',
+          profileActorId: 'agent-profile:codex:default',
+          port: 4567,
+          leaseKind: 'channel-runtime-read',
+          capabilities: [...READONLY_RUNTIME_ACTOR_CAPABILITIES],
+          rotation: 'static',
+        },
+        h.deps
+      )
+    ).toThrowError('Failed to provision channel runtime read actor credential');
   });
 });

--- a/test/relay-mcp-launch.test.ts
+++ b/test/relay-mcp-launch.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Resolver for the local stdio Relay MCP facade (#1410).
+ *
+ * The spec this produces is written into provider argv/config, so the tests
+ * below pin two things: that it points at a file that actually exists, and that
+ * it never grows a field that could carry a credential.
+ */
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  relayMcpLaunchSpec,
+  resolveRelayMcpLaunch,
+} from '../server/relay-mcp-launch.js';
+
+const PACKAGE_MODULE = pathToFileURL(
+  '/opt/relay/dist/server/relay-mcp-launch.js'
+).href;
+const SOURCE_MODULE = pathToFileURL(
+  '/work/relay-ide/server/relay-mcp-launch.ts'
+).href;
+
+describe('relay MCP facade launch resolution', () => {
+  it('runs the compiled bin next to itself in package mode', () => {
+    const spec = resolveRelayMcpLaunch({
+      moduleUrl: PACKAGE_MODULE,
+      execPath: '/usr/bin/node',
+      exists: (candidate) => candidate === '/opt/relay/dist/bin/relay-mcp.js',
+      isExecutableFile: () => false,
+      pathEnv: '/usr/bin',
+    });
+    expect(spec).toEqual({
+      command: '/usr/bin/node',
+      args: ['/opt/relay/dist/bin/relay-mcp.js'],
+    });
+  });
+
+  it('finds the build output from a source checkout', () => {
+    const spec = resolveRelayMcpLaunch({
+      moduleUrl: SOURCE_MODULE,
+      execPath: '/usr/bin/node',
+      exists: (candidate) =>
+        candidate === '/work/relay-ide/dist/bin/relay-mcp.js',
+      isExecutableFile: () => false,
+      pathEnv: '/usr/bin',
+    });
+    expect(spec).toEqual({
+      command: '/usr/bin/node',
+      args: ['/work/relay-ide/dist/bin/relay-mcp.js'],
+    });
+  });
+
+  it('falls back to an installed relay-mcp on PATH', () => {
+    const spec = resolveRelayMcpLaunch({
+      moduleUrl: PACKAGE_MODULE,
+      execPath: '/usr/bin/node',
+      exists: () => false,
+      isExecutableFile: (candidate) =>
+        candidate === '/home/dev/.local/bin/relay-mcp',
+      pathEnv: ['/usr/bin', '/home/dev/.local/bin'].join(path.delimiter),
+    });
+    expect(spec).toEqual({
+      command: '/home/dev/.local/bin/relay-mcp',
+      args: [],
+    });
+  });
+
+  it('skips relative PATH entries instead of mounting a cwd-relative command', () => {
+    // The PROVIDER spawns this command, and it resolves a relative command
+    // against the AGENT's cwd (a workspace repo), not the hub's — so a `.` or
+    // `node_modules/.bin` entry would be checked here and executed somewhere
+    // else entirely. Skipped, never resolved against the hub's cwd.
+    const spec = resolveRelayMcpLaunch({
+      moduleUrl: PACKAGE_MODULE,
+      execPath: '/usr/bin/node',
+      exists: () => false,
+      isExecutableFile: (candidate) =>
+        candidate === path.join('.', 'relay-mcp') ||
+        candidate === path.join('node_modules/.bin', 'relay-mcp') ||
+        candidate === '/home/dev/.local/bin/relay-mcp',
+      pathEnv: ['.', 'node_modules/.bin', '/home/dev/.local/bin'].join(
+        path.delimiter
+      ),
+    });
+    expect(spec).toEqual({
+      command: '/home/dev/.local/bin/relay-mcp',
+      args: [],
+    });
+
+    // With only relative entries there is no mountable facade at all.
+    expect(
+      resolveRelayMcpLaunch({
+        moduleUrl: PACKAGE_MODULE,
+        execPath: '/usr/bin/node',
+        exists: () => false,
+        isExecutableFile: () => true,
+        pathEnv: ['', '.', 'bin'].join(path.delimiter),
+      })
+    ).toBeUndefined();
+  });
+
+  it('resolves to nothing rather than a path that does not exist', () => {
+    // An unbuilt checkout is a normal state. Callers mount nothing; they must
+    // never point a provider at a facade that cannot start.
+    expect(
+      resolveRelayMcpLaunch({
+        moduleUrl: SOURCE_MODULE,
+        execPath: '/usr/bin/node',
+        exists: () => false,
+        isExecutableFile: () => false,
+        pathEnv: '/usr/bin',
+      })
+    ).toBeUndefined();
+    expect(
+      resolveRelayMcpLaunch({
+        moduleUrl: SOURCE_MODULE,
+        execPath: '/usr/bin/node',
+        exists: () => false,
+        isExecutableFile: () => false,
+        pathEnv: undefined,
+      })
+    ).toBeUndefined();
+  });
+
+  it('carries a command and arguments and nothing that could hold a token', () => {
+    const spec = resolveRelayMcpLaunch({
+      moduleUrl: PACKAGE_MODULE,
+      execPath: '/usr/bin/node',
+      exists: () => true,
+      isExecutableFile: () => false,
+      pathEnv: '/usr/bin',
+    });
+    expect(Object.keys(spec ?? {}).sort()).toEqual(['args', 'command']);
+  });
+
+  it('resolves this checkout to a real executable facade when one is built', () => {
+    const spec = relayMcpLaunchSpec();
+    // A source checkout without `npm run build` legitimately has no facade.
+    if (!spec) return;
+    expect(spec.command.length).toBeGreaterThan(0);
+    expect(relayMcpLaunchSpec()).toBe(spec); // memoized
+  });
+});

--- a/test/relay-mcp.test.ts
+++ b/test/relay-mcp.test.ts
@@ -240,6 +240,11 @@ describe('relay-mcp', () => {
   it('fails closed for commands and tool inputs outside the allowlist', async () => {
     expect(RELAY_MCP_CHANNEL_COMMANDS).not.toContain('sessions.input');
     expect(RELAY_MCP_CHANNEL_COMMANDS).not.toContain('files.read');
+    // #1410 opened `channels.search` to in-scope actors on the CLI gateway and
+    // deliberately did NOT widen this tuple. Auto-mounting the facade into every
+    // credentialed runtime makes the tuple the reach of every bound agent's MCP
+    // host, so growing it is a separate decision with its own review.
+    expect(RELAY_MCP_CHANNEL_COMMANDS).not.toContain('channels.search');
     const result = await executeRelayMcpTool(
       'channels.get',
       { channelId: 'topic:one', token: 'never-accepted' },
@@ -266,6 +271,50 @@ describe('relay-mcp', () => {
       error: { code: 'INVALID_ARGUMENT' },
     });
     expect(JSON.stringify(forbidden)).not.toContain('sessions.input');
+  });
+
+  it('turns a read-only lease post refusal into a typed FORBIDDEN envelope (#1410)', async () => {
+    // The facade keeps `relay_channels_post` for credentials that hold the write
+    // bit (the orchestrator lease). A standing read lease reaches the same tool
+    // and must be refused by the GATEWAY, with nothing about the credential in
+    // the answer the MCP host gets to see.
+    const mcp = await openMcp(
+      fakeClient({
+        post: async () => {
+          throw new RelayChannelClientError(403, {
+            code: 'FORBIDDEN',
+            message: 'scoped actor credential lacks context:write',
+            details: {
+              reasonCode: 'CLI_ACTOR_INSUFFICIENT_CAPABILITY',
+              deniedBits: ['context:write'],
+              token: 'relay-sac-v1.credential-1.secret',
+            },
+          });
+        },
+      })
+    );
+    try {
+      const refused = await mcp.request('tools/call', {
+        name: 'relay_channels_post',
+        arguments: { channelId: 'topic:one', text: 'should never land' },
+      });
+      expect(refused.error).toBeUndefined();
+      expect(refused.result).toMatchObject({
+        isError: true,
+        structuredContent: {
+          ok: false,
+          command: 'channels.post',
+          error: {
+            code: 'FORBIDDEN',
+            retryable: false,
+            details: { reasonCode: 'CLI_ACTOR_INSUFFICIENT_CAPABILITY' },
+          },
+        },
+      });
+      expect(JSON.stringify(refused.result)).not.toContain('relay-sac-v1');
+    } finally {
+      await mcp.close();
+    }
   });
 
   it('requires bounded subscribe count and time before opening a stream', async () => {

--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -22,6 +22,18 @@ if (!fs.existsSync(SERVER_SCRIPT)) {
   throw new Error('dist/server/index.js missing — run npm run build first');
 }
 
+/** The stdio MCP facade an agent's provider mounts (#1410). */
+const RELAY_MCP_SCRIPT = path.resolve(
+  import.meta.dirname,
+  '..',
+  'dist',
+  'bin',
+  'relay-mcp.js'
+);
+if (!fs.existsSync(RELAY_MCP_SCRIPT)) {
+  throw new Error('dist/bin/relay-mcp.js missing — run npm run build first');
+}
+
 interface StartServerOpts {
   env: Record<string, string>;
 }
@@ -100,6 +112,86 @@ async function waitForChildExit(
       resolve(code);
     });
   });
+}
+
+interface StdioMcpResponse {
+  id: number;
+  result?: Record<string, unknown>;
+  error?: Record<string, unknown>;
+}
+
+/** Minimal JSON-RPC client for a spawned stdio MCP server. */
+function openStdioMcp(child: ChildProcess): {
+  initialize: () => Promise<void>;
+  request: (
+    method: string,
+    params?: Record<string, unknown>
+  ) => Promise<StdioMcpResponse>;
+} {
+  const pending = new Map<
+    number,
+    { resolve: (value: StdioMcpResponse) => void; reject: (err: Error) => void }
+  >();
+  let buffer = '';
+  let nextId = 1;
+  child.stdout?.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString();
+    let index: number;
+    while ((index = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, index).trim();
+      buffer = buffer.slice(index + 1);
+      if (!line) continue;
+      const message = JSON.parse(line) as StdioMcpResponse;
+      const waiter = typeof message.id === 'number' && pending.get(message.id);
+      if (!waiter) continue;
+      pending.delete(message.id);
+      waiter.resolve(message);
+    }
+  });
+  child.once('exit', () => {
+    for (const waiter of pending.values())
+      waiter.reject(new Error('relay-mcp exited before responding'));
+    pending.clear();
+  });
+  const send = (payload: Record<string, unknown>): void => {
+    child.stdin?.write(`${JSON.stringify({ jsonrpc: '2.0', ...payload })}\n`);
+  };
+  const request = (
+    method: string,
+    params?: Record<string, unknown>
+  ): Promise<StdioMcpResponse> => {
+    const id = nextId++;
+    return new Promise<StdioMcpResponse>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`relay-mcp ${method} timed out`)),
+        10_000
+      );
+      pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+      send({ id, method, ...(params ? { params } : {}) });
+    });
+  };
+  return {
+    request,
+    initialize: async () => {
+      const ready = await request('initialize', {
+        protocolVersion: '2025-11-25',
+        capabilities: {},
+        clientInfo: { name: 'relay-facade-test', version: '0.0.0' },
+      });
+      if (ready.error)
+        throw new Error(`initialize failed: ${JSON.stringify(ready.error)}`);
+      send({ method: 'notifications/initialized' });
+    },
+  };
 }
 
 function cookieFromSetCookie(headers: Headers): string {
@@ -711,6 +803,69 @@ test('real channel middleware enforces registry-issued channel leases and preser
     });
     expect(missingHistory.status).toBe(404);
 
+    // #1410: `channels.search` over the real middleware. An in-scope search
+    // answers, an explicitly out-of-scope channelId is refused, and the verb
+    // must be named honestly — the history command header is a different
+    // route as far as the actor lane is concerned.
+    expect(
+      (
+        await fetch(`${base}/channels/search?q=anything`, {
+          headers: actorHeaders('channels.search'),
+        })
+      ).status
+    ).toBe(200);
+    expect(
+      (
+        await fetch(
+          `${base}/channels/search?q=anything&channelId=${encodeURIComponent(channelA)}`,
+          { headers: actorHeaders('channels.search') }
+        )
+      ).status
+    ).toBe(200);
+    expect(
+      (
+        await fetch(
+          `${base}/channels/search?q=anything&channelId=${encodeURIComponent(channelB)}`,
+          { headers: actorHeaders('channels.search') }
+        )
+      ).status
+    ).toBe(403);
+    expect(
+      (
+        await fetch(`${base}/channels/search?q=anything`, {
+          headers: {
+            ...actorHeaders('channels.search'),
+            'x-relay-cli-command': 'channels.history',
+          },
+        })
+      ).status
+    ).toBe(401);
+
+    // Repeated `channelId` — Express hands the route an ARRAY. The actor-scope
+    // middleware and the route's own `denyOutOfScopeChannel` must parse it
+    // identically (first element wins), or the middleware authorizes one
+    // channel while the route enforces another. The reason code pins WHICH
+    // layer denied: `CLI_ACTOR_WRONG_CHANNEL_SCOPE` means the middleware saw
+    // the same out-of-scope channel the route would have; a route-level
+    // `CHANNEL_OUT_OF_SCOPE` here would mean the two layers disagreed again.
+    const repeatedOutOfScope = await fetch(
+      `${base}/channels/search?q=anything&channelId=${encodeURIComponent(channelB)}&channelId=${encodeURIComponent(channelA)}`,
+      { headers: actorHeaders('channels.search') }
+    );
+    expect(repeatedOutOfScope.status).toBe(403);
+    expect(
+      ((await repeatedOutOfScope.json()) as { error: { reasonCode?: string } })
+        .error.reasonCode
+    ).toBe('CLI_ACTOR_WRONG_CHANNEL_SCOPE');
+    expect(
+      (
+        await fetch(
+          `${base}/channels/search?q=anything&channelId=${encodeURIComponent(channelA)}&channelId=${encodeURIComponent(channelB)}`,
+          { headers: actorHeaders('channels.search') }
+        )
+      ).status
+    ).toBe(200);
+
     const grantRevocation = await fetch(
       `${base}/hub/operator-handshake-grants/${encodeURIComponent(requested.grant.id)}/revoke`,
       {
@@ -1067,5 +1222,229 @@ test('scoped actor sessions.create launches only in-scope terminals and rejects 
     );
     fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.rmSync(outsideDir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * #1410 — the standing read lease, end to end through the MCP facade.
+ *
+ * This is the whole delivery contract in one test: a runtime is handed three
+ * environment variables and a launch path, and the agent's MCP host must be
+ * able to read its own channel's history from that alone — with no Relay URL,
+ * no config file, and no token anywhere but the environment.
+ *
+ * The credential is minted through the operator grant lane because that is the
+ * only issuance surface reachable from outside the process; its capabilities
+ * and scope are exactly `READONLY_RUNTIME_ACTOR_CAPABILITIES` and the
+ * channel-only scope `OrchestratorCredentialLifecycle` mints for a read lease.
+ */
+test('the Relay MCP facade answers a spawned runtime from its injected environment alone (#1410)', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-mcp-facade-'));
+  const configPath = path.join(tmpDir, 'config.json');
+  const pin = '778899';
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      port: 0,
+      host: '127.0.0.1',
+      pinHash: await hashPin(pin),
+      cookieTTL: '1h',
+    })
+  );
+  const child = startServer({
+    env: { RELAY_IDE_CONFIG: configPath, RELAY_IDE_PORT: '0', HOME: tmpDir },
+  });
+  let facade: ChildProcess | undefined;
+  try {
+    const port = await waitForListeningPort(child);
+    const base = `http://127.0.0.1:${port}`;
+    const login = await fetch(`${base}/auth`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pin }),
+    });
+    await expectJsonStatus<{ ok: true }>(login, 200, 'PIN login');
+    const cookie = cookieFromSetCookie(login.headers);
+    const own = (
+      await expectJsonStatus<{ topic: { id: string } }>(
+        await fetch(`${base}/workspace-topics`, {
+          method: 'POST',
+          headers: {
+            cookie,
+            'content-type': 'application/json',
+            'x-relay-capabilities': 'context:write',
+          },
+          body: JSON.stringify({
+            workspaceId: 'workspace:local',
+            title: 'Facade own',
+          }),
+        }),
+        201,
+        'create own channel'
+      )
+    ).topic.id;
+    const other = (
+      await expectJsonStatus<{ topic: { id: string } }>(
+        await fetch(`${base}/workspace-topics`, {
+          method: 'POST',
+          headers: {
+            cookie,
+            'content-type': 'application/json',
+            'x-relay-capabilities': 'context:write',
+          },
+          body: JSON.stringify({
+            workspaceId: 'workspace:local',
+            title: 'Facade other',
+          }),
+        }),
+        201,
+        'create other channel'
+      )
+    ).topic.id;
+    await expectJsonStatus(
+      await fetch(`${base}/channels/${encodeURIComponent(own)}/messages`, {
+        method: 'POST',
+        headers: {
+          cookie,
+          'content-type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({ text: 'handle deref target' }),
+      }),
+      201,
+      'seed own channel history'
+    );
+
+    // Mint the read lease's credential shape: read bits, channel-only scope.
+    const grant = await expectJsonStatus<{ grant: { id: string } }>(
+      await fetch(`${base}/hub/operator-handshake-grants`, {
+        method: 'POST',
+        headers: { cookie, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          actor: { type: 'agent', id: 'agent-profile:claude:default' },
+          issuer: { id: 'relay-ide' },
+          audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+          capabilities: ['session:read', 'context:read'],
+          scope: { channelIds: [own] },
+          ttlMs: 60_000,
+        }),
+      }),
+      201,
+      'read lease grant request'
+    );
+    const approved = await expectJsonStatus<{ handle: string }>(
+      await fetch(
+        `${base}/hub/operator-handshake-grants/${encodeURIComponent(grant.grant.id)}/approve`,
+        {
+          method: 'POST',
+          headers: { cookie, 'content-type': 'application/json' },
+          body: JSON.stringify({ approvedBy: { id: 'browser-operator-test' } }),
+        }
+      ),
+      200,
+      'read lease grant approval'
+    );
+    const issued = await expectJsonStatus<{ token: string }>(
+      await fetch(`${base}/cli-gateway/actor-credentials`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          grantHandle: approved.handle,
+          audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+          actor: { type: 'agent', id: 'agent-profile:claude:default' },
+          capabilities: ['session:read', 'context:read'],
+          scope: { channelIds: [own] },
+          ttlMs: 60_000,
+        }),
+      }),
+      201,
+      'read lease credential mint'
+    );
+
+    // Exactly what ChannelAgentRuntime injects, and nothing else: no
+    // RELAY_IDE_URL, no config directory, no cookie.
+    facade = spawn(process.execPath, [RELAY_MCP_SCRIPT], {
+      env: {
+        PATH: process.env['PATH'] ?? '',
+        HOME: tmpDir,
+        RELAY_IDE_ACTOR_TOKEN: issued.token,
+        RELAY_IDE_PORT: String(port),
+        RELAY_IDE_RUNTIME_ID: 'channel-runtime-facade',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const mcp = openStdioMcp(facade);
+    await mcp.initialize();
+
+    const tools = await mcp.request('tools/list');
+    expect(
+      (tools.result?.['tools'] as Array<{ name: string }>).map(
+        (tool) => tool.name
+      )
+    ).toEqual([
+      'relay_channels_list',
+      'relay_channels_get',
+      'relay_channels_run_get',
+      'relay_channels_history',
+      'relay_channels_subscribe',
+      'relay_channels_threads_history',
+      'relay_channels_roster',
+      'relay_channels_post',
+    ]);
+
+    const history = await mcp.request('tools/call', {
+      name: 'relay_channels_history',
+      arguments: { channelId: own },
+    });
+    const historyEnvelope = history.result?.['structuredContent'] as {
+      ok: boolean;
+      data: { messages: Array<{ body: { text: string } }> };
+    };
+    expect(historyEnvelope.ok).toBe(true);
+    expect(
+      historyEnvelope.data.messages.map((message) => message.body.text)
+    ).toContain('handle deref target');
+    // Provider-runtime locators never cross the facade.
+    const historyJson = JSON.stringify(historyEnvelope);
+    expect(historyJson).not.toContain('runtimeId');
+    expect(historyJson).not.toContain('sessionId');
+    expect(historyJson).not.toContain('relay-sac-v1');
+
+    // Out of scope stays out of scope, even for a tool the agent may call.
+    const crossChannel = await mcp.request('tools/call', {
+      name: 'relay_channels_history',
+      arguments: { channelId: other },
+    });
+    expect(crossChannel.result).toMatchObject({
+      isError: true,
+      structuredContent: { ok: false, error: { code: 'FORBIDDEN' } },
+    });
+
+    // The read lease can never post: the facade keeps the write tool, and the
+    // gateway refuses it for a credential with no write bit.
+    const post = await mcp.request('tools/call', {
+      name: 'relay_channels_post',
+      arguments: { channelId: own, text: 'should never land' },
+    });
+    expect(post.result).toMatchObject({
+      isError: true,
+      structuredContent: { ok: false, error: { code: 'FORBIDDEN' } },
+    });
+    const after = await expectJsonStatus<{
+      messages: Array<{ body: { text: string } }>;
+    }>(
+      await fetch(`${base}/channels/${encodeURIComponent(own)}/messages`, {
+        headers: { cookie, 'x-relay-capabilities': 'context:read' },
+      }),
+      200,
+      'history after refused post'
+    );
+    expect(after.messages.map((message) => message.body.text)).not.toContain(
+      'should never land'
+    );
+  } finally {
+    facade?.kill('SIGKILL');
+    await killAndWait(child);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -242,6 +242,60 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     await adapter.disconnect();
   });
 
+  it('mounts the Relay MCP facade from config.relayMcp without a token or strict mode (#1410)', async () => {
+    const harness = makeHarness();
+    const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
+    await adapter.connect({
+      ...baseConfig({ claudeArgs: ['--keep-me'] }),
+      processEnv: {
+        RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-1.redacted',
+        RELAY_IDE_PORT: '3000',
+        RELAY_IDE_RUNTIME_ID: 'channel-runtime-1',
+      },
+      relayMcp: { command: '/usr/bin/node', args: ['/opt/relay/relay-mcp.js'] },
+    });
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'hello' });
+
+    const { args, options } = harness.latest();
+    const flagIndex = args.indexOf('--mcp-config');
+    expect(flagIndex).toBeGreaterThanOrEqual(0);
+    expect(JSON.parse(args[flagIndex + 1] as string)).toEqual({
+      mcpServers: {
+        relay: {
+          type: 'stdio',
+          command: '/usr/bin/node',
+          args: ['/opt/relay/relay-mcp.js'],
+        },
+      },
+    });
+    // The facade authenticates from the inherited environment. A token written
+    // into the mount would land in argv, which any process on the box can read.
+    expect(args[flagIndex + 1]).not.toContain('relay-sac-v1');
+    expect(args.join(' ')).not.toContain('relay-sac-v1');
+    expect(options.env.RELAY_IDE_ACTOR_TOKEN).toBe(
+      'relay-sac-v1.credential-1.redacted'
+    );
+    // `--mcp-config` is variadic: the next token must be a flag, or it would be
+    // swallowed as a second config.
+    expect(args[flagIndex + 2]).toBe('--permission-mode');
+    // Never strict: that would silently drop the operator's own MCP servers.
+    expect(args).not.toContain('--strict-mcp-config');
+    expect(args).toContain('--keep-me');
+
+    await adapter.disconnect();
+  });
+
+  it('mounts no MCP facade when the runtime holds no credential lease (#1410)', async () => {
+    const harness = makeHarness();
+    const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
+    await adapter.connect(baseConfig());
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'hello' });
+
+    expect(harness.latest().args).not.toContain('--mcp-config');
+
+    await adapter.disconnect();
+  });
+
   it('interrupts and requeues a long active turn before refreshing runtime env', async () => {
     const harness = makeHarness();
     const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());

--- a/test/sessions-orchestrator-credential.test.ts
+++ b/test/sessions-orchestrator-credential.test.ts
@@ -11,6 +11,8 @@ import type {
 import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
 import { ScopedActorCredentialRegistry } from '../shared/scoped-actor-credentials.js';
 import {
+  CLI_GATEWAY_READ_SCOPE_TASK_REF,
+  issueChannelRuntimeReadCliGatewayActorCredential,
   issuePersistentOrchestratorCliGatewayActorCredential,
   validateCliGatewayActorCredential,
 } from '../server/cli-gateway-actor-auth.js';
@@ -274,6 +276,109 @@ describe('channel runtime orchestrator credential integration', () => {
     ).toMatchObject({ ok: false, reason: 'wrong_channel_scope' });
   });
 
+  // Regression guard for #1419, recorded here so the defect cannot hide behind
+  // the hand-built both-dimensions-named shape the rotation test above uses.
+  //
+  // Every assertion below uses the scope a REAL route derives from the request:
+  //  - channel routes (`channelScopeFromParams`, `channelListScopeFromCredential`,
+  //    `channelSearchScopeFromRequest`, the `channels.subscribe` revalidation)
+  //    request `{ channelIds }` and nothing else;
+  //  - sessions / command-center routes (`commandCenterActorCredentialScopeFor`)
+  //    request `{ sessionIds, globalSessionIds }` and nothing else.
+  //
+  // The orchestrator lease pins BOTH dimensions, and `validateCredentialScope`
+  // denies any dimension the request leaves unnamed, so it is currently refused
+  // on both lanes. This test asserts that deny AS THE CURRENT BEHAVIOR: it is
+  // fail-closed (no escalation), and #1419 owns making the lease usable. Flip
+  // these expectations there — do not delete them.
+  it('is denied on every real route scope shape today (#1419)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-08-18T00:00:00.000Z');
+    const credentialRegistry = new ScopedActorCredentialRegistry({
+      now: () => new Date(Date.now()),
+      secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+    });
+    const runtimes = await import('../server/channel-agent-runtime.js');
+    runtimes.configureChannelAgentRuntimes({
+      orchestratorCredentials: {
+        issueCredential: (input) =>
+          issuePersistentOrchestratorCliGatewayActorCredential(
+            credentialRegistry,
+            input
+          ),
+        revokeCredential: (id, input) => credentialRegistry.revoke(id, input),
+      },
+    });
+
+    await runtimes.channelAgentRuntimes.create({
+      id: 'orchestrator-session',
+      channelId: 'channel-A',
+      providerId: 'mock',
+      role: 'orchestrator',
+      profileActorId: 'agent-profile:test',
+      cwd: '/tmp',
+      displayName: 'Product orchestrator',
+      port: 4567,
+      configDir: '/tmp',
+    });
+    const token = connect.mock.calls[0]?.[0].processEnv?.RELAY_IDE_ACTOR_TOKEN;
+    expect(credentialRegistry.listCredentials()[0]!.scope).toMatchObject({
+      sessionIds: ['orchestrator-session'],
+      channelIds: ['channel-A'],
+    });
+
+    // Channel lane: the credential's own channel, requested the way the router
+    // requests it. The unnamed `sessionIds` pin is what denies it.
+    expect(
+      validateCliGatewayActorCredential(credentialRegistry, {
+        token: token!,
+        capabilities: ['context:read'],
+        scope: { channelIds: ['channel-A'] },
+      })
+    ).toMatchObject({ ok: false, reason: 'missing_scope' });
+    // Same lane, write verb (`channels.post`), same deny.
+    expect(
+      validateCliGatewayActorCredential(credentialRegistry, {
+        token: token!,
+        capabilities: ['context:write'],
+        scope: { channelIds: ['channel-A'] },
+      })
+    ).toMatchObject({ ok: false, reason: 'missing_scope' });
+    // Session lane: the credential's OWN runtime id, requested the way the
+    // command-center scope resolver requests it. The unnamed `channelIds` pin
+    // is what denies it.
+    expect(
+      validateCliGatewayActorCredential(credentialRegistry, {
+        token: token!,
+        capabilities: ['session:read'],
+        scope: { sessionIds: ['orchestrator-session'] },
+      })
+    ).toMatchObject({ ok: false, reason: 'missing_scope' });
+    expect(
+      validateCliGatewayActorCredential(credentialRegistry, {
+        token: token!,
+        capabilities: ['session:read'],
+        scope: {
+          sessionIds: ['orchestrator-session'],
+          globalSessionIds: ['orchestrator-session'],
+        },
+      })
+    ).toMatchObject({ ok: false, reason: 'missing_scope' });
+    // The read lease shape #1410 ships — channel only — is the one that works,
+    // which is why the read lane could drop its session pin and this one cannot
+    // (the router binds the orchestrator's brake bypass to `scope.sessionIds`).
+    expect(
+      validateCliGatewayActorCredential(credentialRegistry, {
+        token: token!,
+        capabilities: ['context:read'],
+        scope: {
+          sessionIds: ['orchestrator-session'],
+          channelIds: ['channel-A'],
+        },
+      })
+    ).toMatchObject({ ok: true });
+  });
+
   it('fails before adapter connect when initial minting fails', async () => {
     const runtimes = await import('../server/channel-agent-runtime.js');
     runtimes.configureChannelAgentRuntimes({
@@ -461,5 +566,360 @@ describe('channel runtime orchestrator credential integration', () => {
       revokedBy: 'relay-ide',
       reason: 'orchestrator-runtime-ended',
     });
+  });
+});
+
+describe('standing read-only credential for ordinary bound agents (#1410)', () => {
+  beforeEach(() => {
+    connect.mockReset().mockResolvedValue();
+    disconnect.mockReset().mockResolvedValue();
+    refreshRuntimeEnv.mockReset().mockResolvedValue();
+    supportsRuntimeEnvRefresh = false;
+    adapterStatus = 'connected';
+  });
+
+  afterEach(async () => {
+    const runtimes = await import('../server/channel-agent-runtime.js');
+    await runtimes.channelAgentRuntimes.close();
+    runtimes.configureChannelAgentRuntimes({});
+    vi.useRealTimers();
+  });
+
+  async function configureReadAuthority(
+    registry: ScopedActorCredentialRegistry
+  ): Promise<typeof import('../server/channel-agent-runtime.js')> {
+    const runtimes = await import('../server/channel-agent-runtime.js');
+    runtimes.configureChannelAgentRuntimes({
+      runtimeReadCredentials: {
+        issueCredential: (input) =>
+          issueChannelRuntimeReadCliGatewayActorCredential(registry, input),
+        revokeCredential: (id, input) => registry.revoke(id, input),
+      },
+    });
+    return runtimes;
+  }
+
+  function fixedRegistry(): ScopedActorCredentialRegistry {
+    return new ScopedActorCredentialRegistry({
+      now: () => new Date(Date.now()),
+      secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+    });
+  }
+
+  it('injects a read-only channel-pinned credential and denies channel B', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-08-18T00:00:00.000Z');
+    const registry = fixedRegistry();
+    const runtimes = await configureReadAuthority(registry);
+
+    const runtime = await runtimes.channelAgentRuntimes.create({
+      id: 'collaborator-runtime',
+      channelId: 'channel-A',
+      providerId: 'mock',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 4567,
+      configDir: '/tmp',
+    });
+
+    expect(runtime.role).toBeUndefined();
+    const injected = connect.mock.calls[0]?.[0].processEnv;
+    expect(injected).toEqual({
+      RELAY_IDE_ACTOR_TOKEN: expect.stringMatching(/^relay-sac-v1\./),
+      RELAY_IDE_PORT: '4567',
+      RELAY_IDE_RUNTIME_ID: 'collaborator-runtime',
+    });
+    const token = injected?.RELAY_IDE_ACTOR_TOKEN;
+
+    const record = registry.listCredentials()[0]!;
+    expect(record.capabilities).toEqual(['session:read', 'context:read']);
+    // Channel and nothing else. Every validation below uses the scope a channel
+    // route actually derives from the request — `{ channelIds }` — because a
+    // credential dimension the request does not name is denied `missing_scope`.
+    // A session pin here would therefore deny every `channels.*` call the lease
+    // exists to make.
+    // `taskRefs` is the permissive read marker every `session:read` credential
+    // is stamped with, and validation supplies it on every request. The only
+    // dimension that decides reach here is `channelIds`.
+    expect(record.scope).toEqual({
+      channelIds: ['channel-A'],
+      taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF],
+    });
+    expect(record.metadata).toMatchObject({ reason: 'channel-runtime-read' });
+    expect(Date.parse(record.expiresAt) - Date.parse(record.issuedAt)).toBe(
+      15 * 60 * 1000
+    );
+
+    // Own channel reads pass.
+    expect(
+      validateCliGatewayActorCredential(registry, {
+        token: token!,
+        capabilities: ['context:read'],
+        scope: { channelIds: ['channel-A'] },
+      })
+    ).toMatchObject({ ok: true });
+    // Failing direction: another channel is denied even with the right bit.
+    expect(
+      validateCliGatewayActorCredential(registry, {
+        token: token!,
+        capabilities: ['context:read'],
+        scope: { channelIds: ['channel-B'] },
+      })
+    ).toMatchObject({ ok: false, reason: 'wrong_channel_scope' });
+    // Failing direction: no write bit, so `channels.post` can never authorize.
+    expect(
+      validateCliGatewayActorCredential(registry, {
+        token: token!,
+        capabilities: ['context:write'],
+        scope: { channelIds: ['channel-A'] },
+      })
+    ).toMatchObject({ ok: false, reason: 'insufficient_capability' });
+    // Failing direction, and the property that replaces a session pin: a route
+    // that addresses something other than a channel never names `channelIds`,
+    // so the credential is refused there. `sessions.get` is the sharp case —
+    // the lease carries `session:read`, and only this rule keeps it off other
+    // runtimes' sessions.
+    expect(
+      validateCliGatewayActorCredential(registry, {
+        token: token!,
+        capabilities: ['session:read'],
+        scope: { sessionId: 'other-runtime' },
+      })
+    ).toMatchObject({ ok: false, reason: 'missing_scope' });
+    // Same rule for an unscoped request: no channel named, no access.
+    expect(
+      validateCliGatewayActorCredential(registry, {
+        token: token!,
+        capabilities: ['context:read'],
+        scope: {},
+      })
+    ).toMatchObject({ ok: false, reason: 'missing_scope' });
+
+    await runtimes.channelAgentRuntimes.destroy(runtime.id);
+    expect(registry.getCredential(record.id)).toMatchObject({
+      revokedAt: expect.any(String),
+    });
+    expect(
+      validateCliGatewayActorCredential(registry, {
+        token: token!,
+        capabilities: ['context:read'],
+        scope: { channelIds: ['channel-A'] },
+      })
+    ).toMatchObject({ ok: false });
+  });
+
+  it('expires a static lease instead of rotating it', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-08-18T00:00:00.000Z');
+    const registry = fixedRegistry();
+    const runtimes = await configureReadAuthority(registry);
+
+    await runtimes.channelAgentRuntimes.create({
+      id: 'collaborator-runtime',
+      channelId: 'channel-A',
+      providerId: 'mock',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 4567,
+      configDir: '/tmp',
+    });
+    const token = connect.mock.calls[0]?.[0].processEnv?.RELAY_IDE_ACTOR_TOKEN;
+
+    await vi.advanceTimersByTimeAsync(15 * 60 * 1000 + 1_000);
+
+    expect(refreshRuntimeEnv).not.toHaveBeenCalled();
+    expect(registry.listCredentials()).toHaveLength(1);
+    expect(
+      validateCliGatewayActorCredential(registry, {
+        token: token!,
+        capabilities: ['context:read'],
+        scope: { channelIds: ['channel-A'] },
+      })
+    ).toMatchObject({ ok: false, reason: 'expired' });
+    // The runtime survives its credential expiring: read access is additive.
+    expect(
+      runtimes.channelAgentRuntimes.get('collaborator-runtime')
+    ).toBeDefined();
+  });
+
+  it('rotates the read lease when the adapter can re-receive env', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-08-18T00:00:00.000Z');
+    supportsRuntimeEnvRefresh = true;
+    const registry = fixedRegistry();
+    const runtimes = await configureReadAuthority(registry);
+
+    await runtimes.channelAgentRuntimes.create({
+      id: 'collaborator-runtime',
+      channelId: 'channel-A',
+      providerId: 'mock',
+      profileActorId: 'agent-profile:claude:default',
+      cwd: '/tmp',
+      displayName: '#eng · Claude',
+      port: 4567,
+      configDir: '/tmp',
+    });
+
+    await vi.advanceTimersByTimeAsync(7.5 * 60 * 1000);
+
+    const rotated = refreshRuntimeEnv.mock.calls[0]?.[0];
+    expect(rotated?.RELAY_IDE_RUNTIME_ID).toBe('collaborator-runtime');
+    const records = registry.listCredentials();
+    expect(records).toHaveLength(2);
+    expect(records.map((record) => record.capabilities)).toEqual([
+      ['session:read', 'context:read'],
+      ['session:read', 'context:read'],
+    ]);
+    expect(records.map((record) => record.scope.channelIds)).toEqual([
+      ['channel-A'],
+      ['channel-A'],
+    ]);
+    expect(
+      validateCliGatewayActorCredential(registry, {
+        token: rotated!.RELAY_IDE_ACTOR_TOKEN!,
+        capabilities: ['context:read'],
+        scope: { channelIds: ['channel-B'] },
+      })
+    ).toMatchObject({ ok: false, reason: 'wrong_channel_scope' });
+  });
+
+  it('mints nothing for a gateway-launched provider with no child env', async () => {
+    const registry = fixedRegistry();
+    const runtimes = await configureReadAuthority(registry);
+
+    await runtimes.channelAgentRuntimes.create({
+      id: 'hermes-runtime',
+      channelId: 'channel-A',
+      providerId: 'hermes',
+      profileActorId: 'agent-profile:hermes:default',
+      cwd: '/tmp',
+      displayName: '#eng · Hermes',
+      port: 4567,
+      configDir: '/tmp',
+    });
+
+    expect(registry.listCredentials()).toHaveLength(0);
+    expect(
+      connect.mock.calls[0]?.[0].processEnv?.RELAY_IDE_ACTOR_TOKEN
+    ).toBeUndefined();
+  });
+
+  it('mints nothing for a runtime with no bound channel to scope reads to', async () => {
+    const registry = fixedRegistry();
+    const runtimes = await configureReadAuthority(registry);
+
+    await runtimes.channelAgentRuntimes.create({
+      id: 'unbound-runtime',
+      providerId: 'mock',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: 'unbound',
+      port: 4567,
+      configDir: '/tmp',
+    });
+
+    expect(registry.listCredentials()).toHaveLength(0);
+    expect(
+      connect.mock.calls[0]?.[0].processEnv?.RELAY_IDE_ACTOR_TOKEN
+    ).toBeUndefined();
+  });
+
+  it('refuses to let a profile env shadow the injected actor token', async () => {
+    const registry = fixedRegistry();
+    const runtimes = await configureReadAuthority(registry);
+
+    await runtimes.channelAgentRuntimes.create({
+      id: 'collaborator-runtime',
+      channelId: 'channel-A',
+      providerId: 'mock',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 4567,
+      configDir: '/tmp',
+      processEnv: {
+        RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.forged.attacker-supplied',
+        RELAY_IDE_PORT: '9999',
+        RELAY_IDE_RUNTIME_ID: 'someone-elses-runtime',
+      },
+    });
+
+    const injected = connect.mock.calls[0]?.[0].processEnv;
+    expect(injected?.RELAY_IDE_ACTOR_TOKEN).not.toBe(
+      'relay-sac-v1.forged.attacker-supplied'
+    );
+    expect(injected?.RELAY_IDE_PORT).toBe('4567');
+    expect(injected?.RELAY_IDE_RUNTIME_ID).toBe('collaborator-runtime');
+  });
+
+  it('spawns without a credential when minting fails', async () => {
+    const runtimes = await import('../server/channel-agent-runtime.js');
+    const revokeCredential = vi.fn();
+    runtimes.configureChannelAgentRuntimes({
+      runtimeReadCredentials: {
+        issueCredential: () => {
+          throw new Error('issuer failed around secret material');
+        },
+        revokeCredential,
+      },
+    });
+
+    const runtime = await runtimes.channelAgentRuntimes.create({
+      id: 'collaborator-runtime',
+      channelId: 'channel-A',
+      providerId: 'mock',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 4567,
+      configDir: '/tmp',
+    });
+
+    expect(runtime.status).toBe('active');
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(
+      connect.mock.calls[0]?.[0].processEnv?.RELAY_IDE_ACTOR_TOKEN
+    ).toBeUndefined();
+  });
+
+  it('leaves the orchestrator lease on its own privileged lane', async () => {
+    const registry = fixedRegistry();
+    supportsRuntimeEnvRefresh = true;
+    const runtimes = await import('../server/channel-agent-runtime.js');
+    const readIssue = vi.fn((input) =>
+      issueChannelRuntimeReadCliGatewayActorCredential(registry, input)
+    );
+    runtimes.configureChannelAgentRuntimes({
+      orchestratorCredentials: {
+        issueCredential: (input) =>
+          issuePersistentOrchestratorCliGatewayActorCredential(registry, input),
+        revokeCredential: (id, input) => registry.revoke(id, input),
+      },
+      runtimeReadCredentials: {
+        issueCredential: readIssue,
+        revokeCredential: (id, input) => registry.revoke(id, input),
+      },
+    });
+
+    await runtimes.channelAgentRuntimes.create({
+      id: 'orchestrator-runtime',
+      channelId: 'channel-A',
+      providerId: 'mock',
+      role: 'orchestrator',
+      profileActorId: 'agent-profile:test',
+      cwd: '/tmp',
+      displayName: 'Product orchestrator',
+      port: 4567,
+      configDir: '/tmp',
+    });
+
+    expect(readIssue).not.toHaveBeenCalled();
+    const record = registry.listCredentials()[0]!;
+    expect(record.metadata).toMatchObject({
+      reason: 'persistent-orchestrator',
+    });
+    expect(record.capabilities).toContain('context:write');
   });
 });


### PR DESCRIPTION
## Summary

Closes #1410 — final slice of epic #1406 (native-weight messaging). Three stages, sequential, security-reviewed.

- **Standing read-only credential for every bound agent runtime**: `session:read` + `context:read`, channel-scope pinned, 15-min TTL, half-life rotation via `refreshRuntimeEnv` where supported (claude), spawn-time env injection otherwise. Reuses the orchestrator lease machinery with a distinct `leaseKind` so audit revoke-reasons name the right lane; all lease inputs are required fields, so a future caller can't accidentally mint an orchestrator-privileged lease. Read-lease failure fails closed to *no credential*, never runtime destruction.
- **Handle dereference**: the `[relay channel-id=… trigger-seq=…]` line from #1408 is now chaseable by any bound agent — channel history, thread history, and new `relay-ide v1 channels search` accept in-scope actors via an explicit scoped-actor-readable lane. Cross-channel reads, writes, and private routes stay denied (failing-direction tests). Both test-enforced auth inventories updated (route lanes in `server/auth.ts` + `test/auth.test.ts`, `scopeKinds` in the command manifest).
- **MCP facade auto-mount** for Claude channel agents with env-injected credential; Codex skips (no safe per-runtime stdio config channel — rationale documented). Facade tuple stays closed; provider-runtime-id redaction preserved.

**Cross-stage defect caught and ruled on in-flight**: the lease scope's `sessionIds` pin makes channel routes 403 (`validateCredentialScope` requires every credential dimension be named by the request). The new read lease mints channel-only scope; the persistent-orchestrator lease keeps its pin (the turn-brake bypass binds to `scope.sessionIds[0]`), recorded with a characterization test and follow-up **#1419** instead of a silent behavior change.

Security review findings: 1 P2 (the scope pin, live-reproed) + 3 P3 (repeated-query-param scope bypass shape, facade path hardening, claude MCP env inheritance blast radius) — all four applied, strictest interpretation.

CHANGELOG `[Unreleased]` Added entry included.

## Verification

- `npm run check` exit 0
- `test/auth.test.ts` + adapter/conformance suites: 416 passed, 0 failed
- Full suite: 7078/7079 — sole red is the documented #1415 environmental hang (`could not connect to server on port 19999`)
- Live probe: MCP env inheritance proven with a real one-turn claude spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Adapter generality: quirk — the MCP facade mount is per-adapter wire-specific (claude mounts via --mcp-config, codex documents its refusal); the shared launch resolver lives at the server layer, not copied between adapters.
