### PR TITLE
feat(auth): operator-client channel credentials for non-browser desktop clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ workflow.
 
 #### Added
 
+- Issue revocable, expiring Relay operator-client credentials for non-browser
+  human clients. The separate `relay:operator-client:v1` lane supports the
+  existing stable channel list/get/history/post/subscribe surface with optional
+  exact channel scope, only `context:read`/`context:write`, server-derived human
+  attribution, safe subscription revalidation, metadata-only lifecycle views,
+  and one-time handshake-grant or authenticated-operator issuance.
 - Search durable message history in a complementary right rail while channel
   navigation and threads remain visible. Active channels with resolved human
   metadata seed an editable exact `in:<channel>` scope; unresolved or global

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ workflow.
 
 #### Fixed
 
+- Allow a grant-backed operator-client issue request that omits `scope` to
+  inherit a validated, exact channel-only grant scope, while malformed,
+  wildcard, non-channel, and broader requests continue to fail closed.
 - Filtered channel subscriptions now resume without duplicate delivery by
   applying streamed catch-up state replacements to already-known messages
   (#1398)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ workflow.
   exact channel scope, only `context:read`/`context:write`, server-derived human
   attribution, safe subscription revalidation, metadata-only lifecycle views,
   and one-time handshake-grant or authenticated-operator issuance.
+- Let a still-valid operator-client credential renew itself through
+  `POST /operator-client-credentials/renew`: the successor copies client,
+  device binding, capabilities, channel scope, and originating grant (grant
+  revocation still cascades), while the old token expires naturally so a lost
+  renew response can never lock a client out.
 - Search durable message history in a complementary right rail while channel
   navigation and threads remain visible. Active channels with resolved human
   metadata seed an editable exact `in:<channel>` scope; unresolved or global

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -189,6 +189,9 @@ Commands:
                                        Print a paste-able bash script to install and pair on a remote host via SSH
     link --hub <url>                   Open and hold the persistent /hub/node-link reverse WebSocket (foreground)
     update [--check]                   Update the relay-ide install on this node (--check reports only)
+  operator-client    Mint or revoke a non-browser human channel credential
+    issue --hub <url> --operator-grant <handle> --client-id <id> [--capabilities context:read,context:write] [--channel-id <id>] [--ttl-seconds <n>] [--json]
+    revoke --hub <url> --operator-grant <handle> --credential-id <id> --client-id <id> [--reason <reason>] [--json]
   sessions           Read and control terminal sessions (requires RELAY_IDE_BROWSER_TOKEN)
     get <session-id>                   Print one session descriptor as JSON
     interventions <session-id> [--limit <n>]
@@ -7910,6 +7913,144 @@ function optionalNodeArgBody(
   if (value && value.trim()) body[key] = value.trim();
 }
 
+function operatorClientFlagValues(input: string[], flag: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < input.length; index += 1) {
+    if (input[index] !== flag) continue;
+    const value = input[index + 1];
+    if (!value || value.startsWith('--')) continue;
+    values.push(value);
+    index += 1;
+  }
+  return values;
+}
+
+async function runOperatorClientCommand(operatorArgs: string[]): Promise<void> {
+  const subcommand = operatorArgs[0];
+  const hubUrl = getNodeArg(operatorArgs, '--hub');
+  const grantHandle =
+    getNodeArg(operatorArgs, '--operator-grant') ??
+    getNodeArg(operatorArgs, '--handshake-grant') ??
+    process.env['RELAY_IDE_OPERATOR_GRANT'];
+  const clientId = getNodeArg(operatorArgs, '--client-id');
+  if (
+    (subcommand !== 'issue' && subcommand !== 'revoke') ||
+    !hubUrl ||
+    !grantHandle ||
+    !clientId
+  ) {
+    logger.error(
+      'Usage: relay-ide operator-client <issue|revoke> --hub <url> --operator-grant <handle> --client-id <id> [--json]'
+    );
+    process.exit(1);
+  }
+  try {
+    new URL(hubUrl);
+  } catch {
+    logger.error(`invalid --hub url: ${hubUrl}`);
+    process.exit(1);
+  }
+
+  const body: Record<string, unknown> = {
+    grantHandle,
+    client: {
+      id: clientId,
+      ...(getNodeArg(operatorArgs, '--client-display-name')
+        ? { displayName: getNodeArg(operatorArgs, '--client-display-name') }
+        : {}),
+      ...(getNodeArg(operatorArgs, '--platform')
+        ? { platform: getNodeArg(operatorArgs, '--platform') }
+        : {}),
+    },
+  };
+  const deviceId = getNodeArg(operatorArgs, '--device-id');
+  if (deviceId) {
+    body['device'] = {
+      id: deviceId,
+      ...(getNodeArg(operatorArgs, '--device-display-name')
+        ? { displayName: getNodeArg(operatorArgs, '--device-display-name') }
+        : {}),
+    };
+  }
+  if (subcommand === 'issue') {
+    const capabilityInput =
+      getNodeArg(operatorArgs, '--capabilities') ??
+      'context:read,context:write';
+    body['capabilities'] = capabilityInput
+      .split(',')
+      .map((capability) => capability.trim())
+      .filter(Boolean);
+    const channelIds = operatorClientFlagValues(operatorArgs, '--channel-id');
+    if (channelIds.length) body['scope'] = { channelIds };
+    const ttlSeconds =
+      optionalNodeJsonNumber(operatorArgs, '--ttl-seconds') ?? 900;
+    body['ttlMs'] = ttlSeconds * 1000;
+  } else {
+    const reason = getNodeArg(operatorArgs, '--reason');
+    if (reason) body['reason'] = reason;
+  }
+
+  const credentialId = getNodeArg(operatorArgs, '--credential-id');
+  if (subcommand === 'revoke' && !credentialId) {
+    logger.error('operator-client revoke requires --credential-id <id>');
+    process.exit(1);
+  }
+  const pathName =
+    subcommand === 'issue'
+      ? '/operator-client-credentials'
+      : `/operator-client-credentials/${encodeURIComponent(credentialId!)}/revoke`;
+  let response: Response;
+  try {
+    response = await fetch(nodeEndpoint(hubUrl, pathName), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    logger.error(
+      `OPERATOR_CLIENT_CREDENTIAL_${subcommand.toUpperCase()}_FAILED: ${error instanceof Error ? error.message : String(error)}`
+    );
+    process.exit(1);
+  }
+  const responseText = await response.text();
+  let parsed: unknown;
+  try {
+    parsed = responseText ? JSON.parse(responseText) : {};
+  } catch {
+    parsed = {};
+  }
+  if (!response.ok) {
+    const message =
+      typeof parsed === 'object' && parsed !== null
+        ? ((parsed as { error?: { message?: string } }).error?.message ??
+          `hub returned ${response.status}`)
+        : `hub returned ${response.status}`;
+    logger.error(
+      `OPERATOR_CLIENT_CREDENTIAL_${subcommand.toUpperCase()}_FAILED: ${message}`
+    );
+    process.exit(1);
+  }
+  if (operatorArgs.includes('--json')) {
+    console.log(JSON.stringify(parsed, null, 2));
+    return;
+  }
+  if (subcommand === 'issue') {
+    const token =
+      typeof parsed === 'object' && parsed !== null
+        ? (parsed as { token?: unknown }).token
+        : undefined;
+    if (typeof token !== 'string') {
+      logger.error(
+        'OPERATOR_CLIENT_CREDENTIAL_ISSUE_FAILED: hub response did not include token'
+      );
+      process.exit(1);
+    }
+    console.log(token);
+    return;
+  }
+  console.log(JSON.stringify(parsed, null, 2));
+}
+
 async function runNodeMintPairToken(nodeArgs: string[]): Promise<void> {
   const hubUrl = getNodeArg(nodeArgs, '--hub');
   const operatorGrant =
@@ -8945,6 +9086,11 @@ if (command === 'hub') {
     );
     process.exit(1);
   }
+}
+
+if (command === 'operator-client') {
+  await runOperatorClientCommand(args.slice(1));
+  process.exit(0);
 }
 
 if (command === 'node') {

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -100,7 +100,9 @@ there is no second replay ring. Each frame reports the last safe `durableSeq`.
 Only committed rows advance it, so text deltas can be rendered live without
 moving the reconnect cursor past their owning row. Exact `channelIds` scope and
 `context:read` are checked before registration, and revoked actor credentials
-terminate established streams on their next validation interval.
+terminate established streams on their next validation interval. Operator-client
+credentials use the same stream and revalidation path, but resolve only as the
+server-derived human operator; they never carry actor markers or provider state.
 
 The CLI output is a discriminated v1 frame stream: every `open`, `event`, and
 `closed` frame has `schemaVersion: 1`, `channelId`, `sequence`, `occurredAt`,

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -131,7 +131,10 @@ channels the credential is scoped to: an actor credential with no `channelIds`
 scope is refused, and a `channelId` outside the scope is rejected before any
 read. Browser-only conveniences (attachments, agent commands, interrupt,
 approvals, read-state) remain outside the gateway contract and stay closed to
-scoped actors.
+scoped actors. Non-browser human clients use the separate
+[`operator-client credential`](OPERATOR_CLIENT_CREDENTIALS.md) lane: it accepts
+only list/get/history/post/subscribe, derives `human:operator` on the server,
+and rejects actor-token markers or caller sender/source fields.
 
 ### Local MCP channel facade (#1399)
 

--- a/docs/OPERATOR_CLIENT_CREDENTIALS.md
+++ b/docs/OPERATOR_CLIENT_CREDENTIALS.md
@@ -13,10 +13,13 @@ provider, plugin, agent, node, or session credential.
   `human:operator` / `Operator`. Callers cannot provide a sender, source, or
   principal field.
 - Capability allowlist: only `context:read` and `context:write`.
-- Scope: `scope.channelIds` is optional. When present it is an exact allowlist;
-  when omitted the credential retains the authenticated operator's normal
-  channel reach. Actor credentials remain separately fail-closed without a
-  channel scope.
+- Scope: `scope.channelIds` is optional. When present it is an exact allowlist.
+  Browser-authenticated issuance without it retains the authenticated operator's
+  normal channel reach. Grant-backed issuance without it inherits the exact
+  `channelIds` allowlist from an otherwise channel-only grant; grants without
+  channel ids, with another scope dimension, or with wildcard channel ids fail
+  closed. Actor credentials remain separately fail-closed without a channel
+  scope.
 - Metadata: records retain client id/display name/platform and optional hashed
   device id/display name. Raw device ids and raw credential secrets are not
   listed or returned by revoke operations.
@@ -60,9 +63,11 @@ A grant-backed issue body contains:
 
 The matching handshake grant must use the same audience, a `cli:<client.id>`
 actor binding, requested capability subset, optional device binding, and any
-requested channel scope. It is consumed before the credential is returned.
-A channel-scoped grant cannot mint an unscoped credential. Revoking an
-originating handshake grant revokes credentials minted from it.
+requested channel scope. If the issue body omits `scope`, a channel-only grant's
+exact channel allowlist is inherited before normal grant validation; an explicit
+scope retains the existing exact/subset validation. It is consumed before the
+credential is returned. Revoking an originating handshake grant revokes
+credentials minted from it.
 
 The operator browser lane can revoke with:
 

--- a/docs/OPERATOR_CLIENT_CREDENTIALS.md
+++ b/docs/OPERATOR_CLIENT_CREDENTIALS.md
@@ -84,6 +84,35 @@ POST /operator-client-credentials/:credentialId/revoke
 The latter accepts `grantHandle`, matching `client` metadata, optional matching
 `device`, and optional revocation `reason`; it returns metadata only.
 
+## Renewal / rotation
+
+A still-valid credential can mint its own successor:
+
+```text
+POST /operator-client-credentials/renew
+Authorization: Bearer relay-occ-v1.<id>.<secret>
+x-relay-operator-client-token: v1
+x-relay-cli-gateway: v1
+```
+
+Body is `{ "ttlMs": <positive number> }` (optional; defaults to the 15-minute
+standard) or empty. The response is the same once-only raw-token shape as
+issuance. The new credential copies the old one's client, device binding,
+capabilities, channel scope, and originating `grantId`, so grant revocation
+still cascades across every renewed descendant.
+
+The old credential is deliberately **not** revoked at renewal. It expires
+naturally within its own TTL window, so a lost renew response can never lock a
+client out, and each individual token's blast radius stays unchanged.
+Continuous possession therefore means continuous access — but revocation
+(browser `DELETE`, grant-backed revoke, or originating-grant cascade) cuts
+access immediately regardless of unexpired tokens.
+
+Renewal fails closed like every other lane: expired, revoked, malformed, or
+actor-marker-substituted tokens are rejected with the same failure envelope as
+the command lanes (401/403 with `OPERATOR_CLIENT_*` reason codes). A requested
+`ttlMs` beyond the registry maximum is rejected, not silently clamped.
+
 ## CLI onboarding
 
 Request and approve an operator handshake grant with audience

--- a/docs/OPERATOR_CLIENT_CREDENTIALS.md
+++ b/docs/OPERATOR_CLIENT_CREDENTIALS.md
@@ -1,0 +1,126 @@
+# Operator-client credentials
+
+Operator-client credentials let a non-browser client used by a human operator,
+such as a desktop integration backend, call Relay's existing stable channel
+surface without a browser cookie. This is a Relay product credential, not a
+provider, plugin, agent, node, or session credential.
+
+## Contract
+
+- Audience: `relay:operator-client:v1`.
+- Credential family: `relay-occ-v1.<credential-id>.<secret>`.
+- Principal: every accepted credential is server-attributed as
+  `human:operator` / `Operator`. Callers cannot provide a sender, source, or
+  principal field.
+- Capability allowlist: only `context:read` and `context:write`.
+- Scope: `scope.channelIds` is optional. When present it is an exact allowlist;
+  when omitted the credential retains the authenticated operator's normal
+  channel reach. Actor credentials remain separately fail-closed without a
+  channel scope.
+- Metadata: records retain client id/display name/platform and optional hashed
+  device id/display name. Raw device ids and raw credential secrets are not
+  listed or returned by revoke operations.
+- Supported commands: `channels.list`, `channels.get`, `channels.history`,
+  `channels.post`, and `channels.subscribe`. The stable request and response
+  schemas are unchanged.
+
+The channel client recognizes this family through
+`RELAY_IDE_OPERATOR_CLIENT_TOKEN` or `createRelayChannelClient({ token })` and
+adds `x-relay-operator-client-token: v1` plus the normal versioned command
+marker. Actor markers (`x-relay-cli-actor-token`) and `relay-sac-v1...` token
+substitution are rejected, not reinterpreted.
+
+## Issuance and revocation
+
+`POST /operator-client-credentials` is the only response that returns the raw
+token, once, as `{ token, credential }`. It accepts either the authenticated
+operator browser lane or a previously approved one-time handshake grant.
+`GET /operator-client-credentials` and both revocation responses return
+metadata-only `{ credentials }` or `{ credential }` objects. The registry is
+process-local, matching the existing scoped actor registry: a hub restart drops
+operator-client credentials and therefore fails them closed rather than
+silently retaining an unverified token.
+
+A grant-backed issue body contains:
+
+```json
+{
+  "grantHandle": "relay-ohg-v1.<redacted>",
+  "client": {
+    "id": "desktop-plugin-backend",
+    "displayName": "Desktop plugin backend",
+    "platform": "linux"
+  },
+  "device": { "id": "device-local-id", "displayName": "Operator desktop" },
+  "capabilities": ["context:read", "context:write"],
+  "scope": { "channelIds": ["topic:general"] },
+  "ttlMs": 600000
+}
+```
+
+The matching handshake grant must use the same audience, a `cli:<client.id>`
+actor binding, requested capability subset, optional device binding, and any
+requested channel scope. It is consumed before the credential is returned.
+A channel-scoped grant cannot mint an unscoped credential. Revoking an
+originating handshake grant revokes credentials minted from it.
+
+The operator browser lane can revoke with:
+
+```text
+DELETE /operator-client-credentials/:credentialId
+```
+
+A non-browser client can redeem a fresh grant for revocation instead:
+
+```text
+POST /operator-client-credentials/:credentialId/revoke
+```
+
+The latter accepts `grantHandle`, matching `client` metadata, optional matching
+`device`, and optional revocation `reason`; it returns metadata only.
+
+## CLI onboarding
+
+Request and approve an operator handshake grant with audience
+`relay:operator-client:v1` and the exact requested `context:*` capability bits,
+client actor id, device binding, and channel scope. Then mint once:
+
+```sh
+relay-ide operator-client issue \
+  --hub https://relay.example \
+  --operator-grant '<relay-ohg-v1...>' \
+  --client-id desktop-plugin-backend \
+  --client-display-name 'Desktop plugin backend' \
+  --platform linux \
+  --device-id device-local-id \
+  --channel-id topic:general \
+  --capabilities context:read,context:write
+```
+
+Without `--json`, issue writes only the raw token to stdout. Store it in the
+client's secret store or `RELAY_IDE_OPERATOR_CLIENT_TOKEN`; never put it in a
+configuration file, prompt, artifact, diagnostic, URL, or message body. The
+CLI defaults the requested credential TTL to 900 seconds, bounded by the grant
+and server maximum.
+
+To revoke with a new one-time grant:
+
+```sh
+relay-ide operator-client revoke \
+  --hub https://relay.example \
+  --operator-grant '<relay-ohg-v1...>' \
+  --credential-id '<credential-id>' \
+  --client-id desktop-plugin-backend \
+  --reason 'device retired' --json
+```
+
+## Channel behavior
+
+Posts resolve through Relay's normal server-side human sender derivation and
+have no provider runtime, turn, item, or source identifiers. A caller-supplied
+`sender` or `source` is rejected. Scoped clients cannot use a sibling channel.
+Subscriptions validate the credential before opening and before every streamed
+frame or heartbeat; expiry or revocation closes the NDJSON stream with
+`authorization-revoked` and a safe reconnect cursor. Private channel controls,
+attachments, read-state, runtime operations, and new provider/session endpoints
+remain outside this credential family.

--- a/docs/OPERATOR_HANDSHAKE_GRANTS.md
+++ b/docs/OPERATOR_HANDSHAKE_GRANTS.md
@@ -23,13 +23,14 @@ Suggested minimal approval copy:
 
 The browser session may authorize the approval ceremony, but the returned `relay-ohg-v1.<grant-id>.<secret>` handle is the only grant material for this lane and is consumed once by validation. It must not be accepted as any other credential type.
 
-| Presented material                   | Accepted as handshake grant?                           | Notes                                                               |
-| ------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------------------- |
-| Browser PIN/session cookie           | No                                                     | May authorize ceremony routes only; never reusable automation auth. |
-| `relay-ohg-v1...` handshake grant    | Yes, once, if audience/capability/scope/bindings match | Consumed on successful validation.                                  |
-| `relay-sac-v1...` scoped actor token | No                                                     | Separate scoped actor credential lane.                              |
-| Pair token                           | No                                                     | Node bootstrap only.                                                |
-| Node credential                      | No                                                     | Node heartbeat/link only.                                           |
+| Presented material                           | Accepted as handshake grant?                           | Notes                                                               |
+| -------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------- |
+| Browser PIN/session cookie                   | No                                                     | May authorize ceremony routes only; never reusable automation auth. |
+| `relay-ohg-v1...` handshake grant            | Yes, once, if audience/capability/scope/bindings match | Consumed on successful validation.                                  |
+| `relay-occ-v1...` operator-client credential | No                                                     | Separate human operator-client channel lane.                        |
+| `relay-sac-v1...` scoped actor token         | No                                                     | Separate scoped actor credential lane.                              |
+| Pair token                                   | No                                                     | Node bootstrap only.                                                |
+| Node credential                              | No                                                     | Node heartbeat/link only.                                           |
 
 ## Node pair-token minting grant
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Every doc listed here is linked from this index. If you add a doc, add a row.
 | Provider adapters    | [`provider-guide.md`](provider-guide.md)                                         |
 | Security             | [`SECURITY_POLICY.md`](SECURITY_POLICY.md)                                       |
 | Handshake grants     | [`OPERATOR_HANDSHAKE_GRANTS.md`](OPERATOR_HANDSHAKE_GRANTS.md)                   |
+| Operator clients     | [`OPERATOR_CLIENT_CREDENTIALS.md`](OPERATOR_CLIENT_CREDENTIALS.md)               |
 | Session durability   | [`SESSION_DURABILITY.md`](SESSION_DURABILITY.md)                                 |
 | Terminal backend     | [`TERMINAL_BACKENDS.md`](TERMINAL_BACKENDS.md)                                   |
 | Self-hosting         | [`SELF_HOSTING.md`](SELF_HOSTING.md)                                             |

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -405,10 +405,10 @@ The registry is stored in `<configDir>/hub-node-registry.json` (mode `0600`) wit
 
 ### Auth lane boundary
 
-Federated Relay has separate route lanes for browser sessions, scoped actor credentials, node credentials, pair tokens, public local setup, and denied responses. The inventory is exported from `server/auth.ts` as `AUTH_ROUTE_LANE_INVENTORY` and is the implementation source of truth for route-lane policy.
+Federated Relay has separate route lanes for browser sessions, scoped actor credentials, operator-client credentials, node credentials, pair tokens, public local setup, and denied responses. The inventory is exported from `server/auth.ts` as `AUTH_ROUTE_LANE_INVENTORY` and is the implementation source of truth for route-lane policy.
 
 - Browser/UI routes use the `browser-session` lane: PIN login creates the `token` cookie that drives the React UI and operator browser routes. Dev-instance flags do not mint this cookie or bypass the lane.
-- CLI/agent gateway routes are named as `scoped-actor-credential` plus browser-session compatibility today. The scoped actor credential registry exists as the #802 lifecycle primitive, but command migration is a later slice; adapters must not substitute node credentials, browser UI cookies, or private node-link messages.
+- CLI/agent gateway routes use `scoped-actor-credential` plus browser-session compatibility. The stable channel list/get/history/post/subscribe subset additionally accepts the separate `operator-client-credential` lane; it derives the human operator server-side and accepts only `context:read`/`context:write`, never an actor marker or caller sender/source.
 - `/hub/node-link` and node heartbeat use the `node-credential` lane only.
 - `POST /hub/pairing/exchange` uses the `pair-token` lane only.
 - Setup/login/health routes are `public-local-only` and must not expose private node, session, repo, or credential state.

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -9,6 +9,7 @@ const LOCKOUT_DURATION_MS = 15 * 60 * 1000; // 15 minutes
 export const AUTH_LANES = [
   'browser-session',
   'scoped-actor-credential',
+  'operator-client-credential',
   'node-credential',
   'pair-token',
   'public-local-only',
@@ -129,7 +130,6 @@ export const AUTH_ROUTE_LANE_INVENTORY: AuthRouteLaneInventoryEntry[] = [
       '/inbox/*',
       '/events/*',
       '/handoffs/*',
-      '/channels/*',
       '/nodes',
       '/hub/audit/*',
       '/hub/nodes/:nodeId/logs',
@@ -138,7 +138,19 @@ export const AUTH_ROUTE_LANE_INVENTORY: AuthRouteLaneInventoryEntry[] = [
     acceptedLanes: ['scoped-actor-credential', 'browser-session'],
     middleware: 'requireCliGatewayAuth',
     notes:
-      'CLI gateway calls prefer a scoped actor credential and retain browser-session compatibility for local/dev callers; this does not make browser cookies node credentials. Channel routes sit here too: they mount with requireCliGatewayAuth and gate writes on a context:write capability check rather than on the lane alone.',
+      'CLI gateway calls retain scoped actor and browser-session compatibility; this does not make browser cookies node credentials.',
+  },
+  {
+    surface: 'CLI gateway channel APIs',
+    routes: ['/channels/*'],
+    acceptedLanes: [
+      'scoped-actor-credential',
+      'operator-client-credential',
+      'browser-session',
+    ],
+    middleware: 'requireChannelGatewayAuthForCommand',
+    notes:
+      'The stable channel subset additionally accepts the separate operator-client credential lane. It is server-attributed to the human operator and limited to declared context read/write list/get/history/post/subscribe commands.',
   },
   {
     surface: 'scoped session APIs',

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -6,12 +6,14 @@ import type { Request, RequestHandler, Response } from 'express';
 import multer from 'multer';
 
 import type { RelayCliGatewayErrorCode } from '../shared/cli-gateway-contract.js';
+import { projectRelayChannelPublicValue } from '../shared/channel-client.js';
 import { isDmChannel } from '../shared/dm-channels.js';
 import {
   authenticatedCliGatewayActorCredential,
   type CliGatewayActorReadCommand,
   type CliGatewayActorWriteCommand,
 } from './cli-gateway-actor-auth.js';
+import { authenticatedOperatorClientCredential } from './operator-client-auth.js';
 import {
   CHANNEL_HISTORY_DEFAULT_LIMIT,
   CHANNEL_HISTORY_MAX_LIMIT,
@@ -271,7 +273,15 @@ function requireKnownThreadScope(
  */
 function actorChannelIds(req: Request): readonly string[] | undefined {
   const credential = authenticatedCliGatewayActorCredential(req);
-  return credential?.scope?.channelIds;
+  if (credential) return credential.scope?.channelIds;
+  return authenticatedOperatorClientCredential(req)?.scope?.channelIds;
+}
+
+/** Operator-client responses retain Relay ids but never expose provider correlations. */
+function operatorClientPublicValue<T>(req: Request, value: T): T {
+  return authenticatedOperatorClientCredential(req)
+    ? (projectRelayChannelPublicValue(value) as T)
+    : value;
 }
 
 /** Deny (403) when a scoped actor targets a channel outside its channel scope. */
@@ -281,8 +291,13 @@ function denyOutOfScopeChannel(
   channelId: string
 ): boolean {
   const credential = authenticatedCliGatewayActorCredential(req);
-  if (!credential) return false; // browser/operator lane: existing authority
-  if (credential.scope?.channelIds?.includes(channelId)) return false;
+  if (credential) {
+    if (credential.scope?.channelIds?.includes(channelId)) return false;
+  } else {
+    const operatorClient = authenticatedOperatorClientCredential(req);
+    if (!operatorClient || !operatorClient.scope.channelIds) return false;
+    if (operatorClient.scope.channelIds.includes(channelId)) return false;
+  }
   sendGatewayError(
     res,
     'FORBIDDEN',
@@ -330,7 +345,11 @@ function denyChannelReadWithoutScope(req: Request, res: Response): boolean {
 
 /** Private browser/operator REST surfaces are never part of the actor lane. */
 function denyScopedActorPrivateRoute(req: Request, res: Response): boolean {
-  if (!authenticatedCliGatewayActorCredential(req)) return false;
+  if (
+    !authenticatedCliGatewayActorCredential(req) &&
+    !authenticatedOperatorClientCredential(req)
+  )
+    return false;
   sendGatewayError(
     res,
     'FORBIDDEN',
@@ -394,6 +413,10 @@ function denyMissingCapability(
   for (const capability of actorCredential?.capabilities ?? []) {
     provided.add(capability);
   }
+  const operatorCredential = authenticatedOperatorClientCredential(req);
+  for (const capability of operatorCredential?.capabilities ?? []) {
+    provided.add(capability);
+  }
   const missing = required.filter((capability) => !provided.has(capability));
   if (missing.length === 0) return false;
   sendGatewayError(
@@ -422,7 +445,11 @@ function denyNonOperator(
   res: Response,
   verb: 'read' | 'mark'
 ): boolean {
-  if (deriveSender(req, undefined).kind === 'human') return false;
+  if (
+    !authenticatedCliGatewayActorCredential(req) &&
+    !authenticatedOperatorClientCredential(req)
+  )
+    return false;
   sendGatewayError(
     res,
     'FORBIDDEN',
@@ -508,6 +535,8 @@ function deriveSender(
   req: Request,
   runtime: { profileActorId: string; providerId: string } | undefined
 ): ChannelSenderRef {
+  const operatorClient = authenticatedOperatorClientCredential(req);
+  if (operatorClient) return { ...operatorClient.principal };
   const credential = authenticatedCliGatewayActorCredential(req);
   if (credential) {
     const isPersistentOrchestrator =
@@ -697,7 +726,11 @@ function rejectInvalidActorChannelPostBody(
   req: Request,
   res: Response
 ): boolean {
-  if (!authenticatedCliGatewayActorCredential(req)) return false;
+  if (
+    !authenticatedCliGatewayActorCredential(req) &&
+    !authenticatedOperatorClientCredential(req)
+  )
+    return false;
   if (!isRecord(req.body)) {
     sendGatewayError(
       res,
@@ -824,7 +857,11 @@ function rejectInvalidActorPagination(
   res: Response,
   fields: readonly string[]
 ): boolean {
-  if (!authenticatedCliGatewayActorCredential(req)) return false;
+  if (
+    !authenticatedCliGatewayActorCredential(req) &&
+    !authenticatedOperatorClientCredential(req)
+  )
+    return false;
   const allowed = new Set(fields);
   const undeclared = Object.keys(req.query).find(
     (field) => !allowed.has(field)
@@ -1186,7 +1223,11 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         .map((topic) => channelSummaryView(store, topic));
       // A scoped actor enumerates ONLY its allowed channelIds (Slice 0 gate:
       // an actor scoped to channel A must never see channel B in the list).
-      res.json({ channels: filterChannelListToScope(req, channels) });
+      res.json(
+        operatorClientPublicValue(req, {
+          channels: filterChannelListToScope(req, channels),
+        })
+      );
     } catch (error) {
       mapStoreError(res, error);
     }
@@ -1446,7 +1487,11 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       return;
     }
     try {
-      res.json({ channel: channelSummaryView(store, topic) });
+      res.json(
+        operatorClientPublicValue(req, {
+          channel: channelSummaryView(store, topic),
+        })
+      );
     } catch (error) {
       mapStoreError(res, error);
     }
@@ -1487,12 +1532,14 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         limit,
         deps.historyMaxBytes ?? DEFAULT_HISTORY_MAX_BYTES
       );
-      res.json({
-        messages: budgeted.rows,
-        ...(budgeted.hasMore
-          ? { hasMore: true, nextCursor: budgeted.nextCursor }
-          : {}),
-      });
+      res.json(
+        operatorClientPublicValue(req, {
+          messages: budgeted.rows,
+          ...(budgeted.hasMore
+            ? { hasMore: true, nextCursor: budgeted.nextCursor }
+            : {}),
+        })
+      );
     } catch (error) {
       mapStoreError(res, error);
     }
@@ -1992,10 +2039,12 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       if (result.replayed && steering) {
         deps.binder?.steerExisting(result.message, steering);
       }
-      res.status(result.replayed ? 200 : 201).json({
-        message: result.message,
-        run: result.run,
-      });
+      res.status(result.replayed ? 200 : 201).json(
+        operatorClientPublicValue(req, {
+          message: result.message,
+          run: result.run,
+        })
+      );
     } catch (error) {
       mapStoreError(res, error);
     }

--- a/server/channel-subscription-router.ts
+++ b/server/channel-subscription-router.ts
@@ -9,7 +9,9 @@ import {
   type ChannelEventV1,
   type ChannelSubscriptionFilter,
 } from '../shared/channel-chat-protocol.js';
+import { projectRelayChannelPublicValue } from '../shared/channel-client.js';
 import { authenticatedCliGatewayActorCredential } from './cli-gateway-actor-auth.js';
+import { authenticatedOperatorClientCredential } from './operator-client-auth.js';
 import type {
   ChannelEventSink,
   ChannelHub,
@@ -180,6 +182,8 @@ function projectEvent(
 function requestHasContextRead(req: Request): boolean {
   const actor = authenticatedCliGatewayActorCredential(req);
   if (actor) return actor.capabilities.includes(CONTEXT_READ);
+  const operatorClient = authenticatedOperatorClientCredential(req);
+  if (operatorClient) return operatorClient.capabilities.includes(CONTEXT_READ);
   return (req.header('x-relay-capabilities') ?? '')
     .split(/[\s,]+/)
     .some((capability) => capability === CONTEXT_READ);
@@ -190,7 +194,13 @@ function actorMayReadChannel(req: Request, channelId: string): boolean {
   // Browser/session clients retain their established access lane. A scoped
   // actor with no channelIds is deliberately fail-closed for this enumeration
   // capable, long-lived route.
-  return !actor || actor.scope?.channelIds?.includes(channelId) === true;
+  if (actor) return actor.scope?.channelIds?.includes(channelId) === true;
+  const operatorClient = authenticatedOperatorClientCredential(req);
+  return (
+    !operatorClient ||
+    !operatorClient.scope.channelIds ||
+    operatorClient.scope.channelIds.includes(channelId)
+  );
 }
 
 function advanceDurableCursor(current: number, event: ChannelEventV1): number {
@@ -456,13 +466,16 @@ export function createChannelSubscriptionRouter(
           durableSeq = advanceDurableCursor(durableSeq, event);
           const projected = projectEvent(event, filter);
           if (!projected) return true;
+          const payload = authenticatedOperatorClientCredential(req)
+            ? (projectRelayChannelPublicValue(projected) as ChannelEventV1)
+            : projected;
           return writeFrame({
             frame: 'event',
             schemaVersion: 1,
             channelId,
             sequence: sequence++,
             occurredAt: now().toISOString(),
-            payload: projected,
+            payload,
             durableSeq,
           });
         },

--- a/server/index.ts
+++ b/server/index.ts
@@ -389,6 +389,16 @@ import {
   type CliGatewayActorReadCommand,
 } from './cli-gateway-actor-auth.js';
 import {
+  authenticateOperatorClientCredential,
+  createOperatorClientCredentialRegistry,
+  isOperatorClientChannelCommand,
+  isOperatorClientCredentialRequest,
+  issueOperatorClientCredentialWithGrant,
+  operatorClientAuthFailure,
+  operatorClientCredentialIssueInput,
+  revokeOperatorClientCredentialWithGrant,
+} from './operator-client-auth.js';
+import {
   RELAY_CAPABILITY_BITS,
   type RelayCapabilityBit,
 } from '../shared/security-policy.js';
@@ -403,6 +413,8 @@ const localRelayNode = createLocalRelayNode();
 const cliGatewayActorRegistry = createCliGatewayActorRegistry();
 const cliGatewayHandshakeGrantRegistry =
   createCliGatewayHandshakeGrantRegistry();
+const operatorClientCredentialRegistry =
+  createOperatorClientCredentialRegistry();
 
 // When run via the CLI bin or the dev runner, RELAY_IDE_CONFIG is set
 // explicitly. When run directly from source (e.g. `node dist/server/index.js`),
@@ -1988,6 +2000,57 @@ async function main(): Promise<void> {
     };
   };
 
+  /**
+   * Stable channel commands admit either the established scoped actor lane or
+   * the deliberately separate human operator-client lane. The latter is
+   * checked first so an operator credential carrying an actor marker fails
+   * closed instead of falling into agent attribution.
+   */
+  const requireChannelGatewayAuthForCommand = (
+    expectedCommand: CliGatewayActorCommand,
+    options: {
+      capabilities?: readonly RelayCapabilityBit[];
+      scopeForRequest?: (
+        req: express.Request
+      ) => { channelIds?: string[] } | undefined;
+    } = {}
+  ): express.RequestHandler => {
+    const actorAuth = requireCliGatewayAuthForActorCommand(
+      expectedCommand,
+      options
+    );
+    return (req, res, next) => {
+      if (!isOperatorClientCredentialRequest(req)) {
+        actorAuth(req, res, next);
+        return;
+      }
+      const channelId = options.scopeForRequest?.(req)?.channelIds?.[0];
+      if (!isOperatorClientChannelCommand(expectedCommand)) {
+        const failure = operatorClientAuthFailure({
+          reason: 'unsupported_command',
+        });
+        res
+          .status(failure.code === 'FORBIDDEN' ? 403 : 401)
+          .json({ error: failure });
+        return;
+      }
+      const validation = authenticateOperatorClientCredential(
+        operatorClientCredentialRegistry,
+        req,
+        expectedCommand,
+        channelId
+      );
+      if (!validation.ok) {
+        const failure = operatorClientAuthFailure(validation);
+        res
+          .status(failure.code === 'FORBIDDEN' ? 403 : 401)
+          .json({ error: failure });
+        return;
+      }
+      next();
+    };
+  };
+
   const requireCliGatewayAuth: express.RequestHandler = (req, res, next) => {
     if (isCliGatewayActorTokenRequest(req)) {
       requireCliGatewayReadAuth()(req, res, next);
@@ -2462,6 +2525,122 @@ async function main(): Promise<void> {
     }
   });
 
+  const operatorClientLifecycleAuth: express.RequestHandler = (
+    req,
+    res,
+    next
+  ) => {
+    const body = isRecord(req.body) ? req.body : {};
+    if (typeof body['grantHandle'] === 'string') {
+      next();
+      return;
+    }
+    requireAuth(req, res, next);
+  };
+  const operatorClientLifecycleError = (
+    res: express.Response,
+    error: unknown
+  ) => {
+    const reason =
+      error instanceof Error &&
+      'reason' in error &&
+      typeof error.reason === 'string'
+        ? error.reason
+        : 'issue_failed';
+    res.status(reason === 'credential_not_found' ? 404 : 400).json({
+      error: {
+        code: `OPERATOR_CLIENT_CREDENTIAL_${reason.toUpperCase()}`,
+        message: error instanceof Error ? error.message : String(error),
+        retryable: false,
+      },
+    });
+  };
+
+  // A raw operator-client token is returned only from this issue response.
+  // Enumeration and revocation project credential metadata only.
+  app.post(
+    '/operator-client-credentials',
+    operatorClientLifecycleAuth,
+    (req, res) => {
+      try {
+        const body = isRecord(req.body) ? req.body : {};
+        const issued =
+          typeof body['grantHandle'] === 'string'
+            ? issueOperatorClientCredentialWithGrant(
+                operatorClientCredentialRegistry,
+                cliGatewayHandshakeGrantRegistry,
+                body
+              )
+            : operatorClientCredentialRegistry.issue(
+                operatorClientCredentialIssueInput(body)
+              );
+        res
+          .status(201)
+          .json({ token: issued.token, credential: issued.credential });
+      } catch (error) {
+        operatorClientLifecycleError(res, error);
+      }
+    }
+  );
+  app.get('/operator-client-credentials', requireAuth, (_req, res) => {
+    res.json({
+      credentials: operatorClientCredentialRegistry.listCredentials(),
+    });
+  });
+  app.delete('/operator-client-credentials/:id', requireAuth, (req, res) => {
+    const id = req.params['id'];
+    if (!id) {
+      res.status(400).json({
+        error: {
+          code: 'OPERATOR_CLIENT_CREDENTIAL_ID_REQUIRED',
+          message: 'credential id is required',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    const body = isRecord(req.body) ? req.body : {};
+    const credential = operatorClientCredentialRegistry.revoke(id, {
+      revokedBy: 'browser-operator',
+      ...(typeof body['reason'] === 'string' ? { reason: body['reason'] } : {}),
+    });
+    if (!credential) {
+      res.status(404).json({
+        error: {
+          code: 'OPERATOR_CLIENT_CREDENTIAL_NOT_FOUND',
+          message: 'credential not found',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    res.json({ credential });
+  });
+  app.post('/operator-client-credentials/:id/revoke', (req, res) => {
+    const id = req.params['id'];
+    if (!id) {
+      res.status(400).json({
+        error: {
+          code: 'OPERATOR_CLIENT_CREDENTIAL_ID_REQUIRED',
+          message: 'credential id is required',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    try {
+      const credential = revokeOperatorClientCredentialWithGrant(
+        operatorClientCredentialRegistry,
+        cliGatewayHandshakeGrantRegistry,
+        id,
+        isRecord(req.body) ? req.body : {}
+      );
+      res.json({ credential });
+    } catch (error) {
+      operatorClientLifecycleError(res, error);
+    }
+  });
+
   const collectLocalInventory = () =>
     collectLocalRepoInventory({
       config: getConfig(),
@@ -2483,6 +2662,10 @@ async function main(): Promise<void> {
           ...(input.correlationId
             ? { correlationId: input.correlationId }
             : {}),
+        });
+        operatorClientCredentialRegistry.revokeByGrantId(input.grantId, {
+          revokedBy: `grant:${input.grantId}`,
+          reason: input.reason ?? 'originating operator grant revoked',
         });
       },
       scopedSessionAuth: requireScopedSessionAuth,
@@ -2664,7 +2847,7 @@ async function main(): Promise<void> {
       },
       requireAuth: requireCliGatewayAuth,
       requireReadActorAuth: (command, options) =>
-        requireCliGatewayAuthForActorCommand(command, {
+        requireChannelGatewayAuthForCommand(command, {
           ...(command === 'channels.list'
             ? { scopeForRequest: channelListScopeFromCredential }
             : command === 'channels.search'
@@ -2679,7 +2862,7 @@ async function main(): Promise<void> {
           ...(options ?? {}),
         }),
       requireWriteActorAuth: (command, options) =>
-        requireCliGatewayAuthForActorCommand(command, {
+        requireChannelGatewayAuthForCommand(command, {
           ...(command === 'channels.post'
             ? { scopeForRequest: channelScopeFromParams }
             : {}),
@@ -2690,11 +2873,19 @@ async function main(): Promise<void> {
   app.use(
     createChannelSubscriptionRouter({
       hub: channelHub,
-      requireSubscribeAuth: requireCliGatewayAuthForActorCommand(
+      requireSubscribeAuth: requireChannelGatewayAuthForCommand(
         'channels.subscribe',
         { scopeForRequest: channelScopeFromParams }
       ),
       isStillAuthorized: (req, channelId) => {
+        if (isOperatorClientCredentialRequest(req)) {
+          return authenticateOperatorClientCredential(
+            operatorClientCredentialRegistry,
+            req,
+            'channels.subscribe',
+            channelId
+          ).ok;
+        }
         if (!isCliGatewayActorTokenRequest(req)) return true;
         const validation = validateCliGatewayActorCredential(
           cliGatewayActorRegistry,

--- a/server/index.ts
+++ b/server/index.ts
@@ -390,12 +390,14 @@ import {
 } from './cli-gateway-actor-auth.js';
 import {
   authenticateOperatorClientCredential,
+  authenticateOperatorClientCredentialForRenew,
   createOperatorClientCredentialRegistry,
   isOperatorClientChannelCommand,
   isOperatorClientCredentialRequest,
   issueOperatorClientCredentialWithGrant,
   operatorClientAuthFailure,
   operatorClientCredentialIssueInput,
+  renewOperatorClientCredential,
   revokeOperatorClientCredentialWithGrant,
 } from './operator-client-auth.js';
 import {
@@ -2582,6 +2584,31 @@ async function main(): Promise<void> {
       }
     }
   );
+  // Renewal: the still-valid credential itself mints its successor. Defined
+  // before the parameterized /:id/revoke route; express matches the literal
+  // path first regardless, but keeping lifecycle routes together reads better.
+  app.post('/operator-client-credentials/renew', (req, res) => {
+    const auth = authenticateOperatorClientCredentialForRenew(
+      operatorClientCredentialRegistry,
+      req
+    );
+    if (!auth.ok) {
+      res.status(401).json(operatorClientAuthFailure({ reason: auth.reason }));
+      return;
+    }
+    try {
+      const issued = renewOperatorClientCredential(
+        operatorClientCredentialRegistry,
+        auth.credential,
+        isRecord(req.body) ? req.body : {}
+      );
+      res
+        .status(201)
+        .json({ token: issued.token, credential: issued.credential });
+    } catch (error) {
+      operatorClientLifecycleError(res, error);
+    }
+  });
   app.get('/operator-client-credentials', requireAuth, (_req, res) => {
     res.json({
       credentials: operatorClientCredentialRegistry.listCredentials(),

--- a/server/operator-client-auth.ts
+++ b/server/operator-client-auth.ts
@@ -1,0 +1,485 @@
+import type { Request } from 'express';
+import {
+  HandshakeGrantRegistry,
+  type HandshakeGrantActor,
+} from '../shared/operator-handshake-grants.js';
+import {
+  OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+  OPERATOR_CLIENT_CREDENTIAL_TOKEN_PREFIX,
+  OperatorClientCredentialRegistry,
+  type IssueOperatorClientCredentialInput,
+  type OperatorClientCredentialRecord,
+  type OperatorClientCredentialScope,
+  type OperatorClientCredentialValidationFailureReason,
+} from '../shared/operator-client-credentials.js';
+
+export const OPERATOR_CLIENT_TOKEN_HEADER =
+  'x-relay-operator-client-token' as const;
+export const OPERATOR_CLIENT_COMMAND_HEADER = 'x-relay-cli-command' as const;
+export const OPERATOR_CLIENT_GATEWAY_HEADER = 'x-relay-cli-gateway' as const;
+export const OPERATOR_CLIENT_CHANNEL_COMMANDS = [
+  'channels.list',
+  'channels.get',
+  'channels.history',
+  'channels.subscribe',
+  'channels.post',
+] as const;
+
+export type OperatorClientChannelCommand =
+  (typeof OPERATOR_CLIENT_CHANNEL_COMMANDS)[number];
+export type OperatorClientAuthFailureReason =
+  | OperatorClientCredentialValidationFailureReason
+  | 'marker_required'
+  | 'actor_marker_forbidden'
+  | 'token_substitution'
+  | 'command_mismatch'
+  | 'gateway_marker_required'
+  | 'unsupported_command';
+
+export class OperatorClientCredentialError extends Error {
+  constructor(
+    public readonly reason:
+      | OperatorClientAuthFailureReason
+      | 'grant_required'
+      | 'grant_rejected'
+      | 'credential_not_found'
+      | 'client_mismatch',
+    message: string
+  ) {
+    super(message);
+    this.name = 'OperatorClientCredentialError';
+  }
+}
+
+const AUTHENTICATED_OPERATOR_CLIENT_CREDENTIAL = Symbol(
+  'relay.operatorClientCredential'
+);
+
+type RequestWithOperatorClientCredential = Request & {
+  [AUTHENTICATED_OPERATOR_CLIENT_CREDENTIAL]?: OperatorClientCredentialRecord;
+};
+
+export function createOperatorClientCredentialRegistry(): OperatorClientCredentialRegistry {
+  return new OperatorClientCredentialRegistry();
+}
+
+export function bearerOperatorClientToken(req: Request): string {
+  const authorization = req.header('authorization') ?? '';
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() ?? '';
+}
+
+/** A presented marker or family token always selects this lane, including misuse. */
+export function isOperatorClientCredentialRequest(req: Request): boolean {
+  return (
+    req.header(OPERATOR_CLIENT_TOKEN_HEADER) !== undefined ||
+    bearerOperatorClientToken(req).startsWith(
+      `${OPERATOR_CLIENT_CREDENTIAL_TOKEN_PREFIX}.`
+    )
+  );
+}
+
+export function authenticatedOperatorClientCredential(
+  req: Request
+): OperatorClientCredentialRecord | undefined {
+  return (req as RequestWithOperatorClientCredential)[
+    AUTHENTICATED_OPERATOR_CLIENT_CREDENTIAL
+  ];
+}
+
+export function authenticateOperatorClientCredential(
+  registry: OperatorClientCredentialRegistry,
+  req: Request,
+  command: OperatorClientChannelCommand,
+  channelId?: string
+):
+  | { ok: true; credential: OperatorClientCredentialRecord }
+  | {
+      ok: false;
+      reason: OperatorClientAuthFailureReason;
+      credentialId?: string;
+      deniedBits?: string[];
+    } {
+  if (!isOperatorClientChannelCommand(command)) {
+    return { ok: false, reason: 'unsupported_command' };
+  }
+  if (req.header(OPERATOR_CLIENT_GATEWAY_HEADER) !== 'v1') {
+    return { ok: false, reason: 'gateway_marker_required' };
+  }
+  if (req.header(OPERATOR_CLIENT_TOKEN_HEADER) !== 'v1') {
+    return { ok: false, reason: 'marker_required' };
+  }
+  if (req.header('x-relay-cli-actor-token') !== undefined) {
+    return { ok: false, reason: 'actor_marker_forbidden' };
+  }
+  if (req.header(OPERATOR_CLIENT_COMMAND_HEADER) !== command) {
+    return { ok: false, reason: 'command_mismatch' };
+  }
+  const token = bearerOperatorClientToken(req);
+  if (!token.startsWith(`${OPERATOR_CLIENT_CREDENTIAL_TOKEN_PREFIX}.`)) {
+    return { ok: false, reason: 'token_substitution' };
+  }
+  const capabilities =
+    command === 'channels.post' ? ['context:write'] : ['context:read'];
+  const validation = registry.validate(token, {
+    audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+    requiredCapabilities: capabilities,
+    ...(channelId ? { channelId } : {}),
+  });
+  if (!validation.ok) {
+    return {
+      ok: false,
+      reason: validation.reason,
+      ...(validation.credentialId
+        ? { credentialId: validation.credentialId }
+        : {}),
+      deniedBits: validation.deniedBits,
+    };
+  }
+  (req as RequestWithOperatorClientCredential)[
+    AUTHENTICATED_OPERATOR_CLIENT_CREDENTIAL
+  ] = validation.credential;
+  return validation;
+}
+
+export function operatorClientAuthFailure(input: {
+  reason: OperatorClientAuthFailureReason;
+  credentialId?: string;
+  deniedBits?: string[];
+}): {
+  code: 'UNAUTHORIZED' | 'FORBIDDEN';
+  reasonCode: string;
+  message: string;
+  retryable: false;
+  lane: 'denied';
+  acceptedLanes: ['operator-client-credential'];
+  audience: typeof OPERATOR_CLIENT_CREDENTIAL_AUDIENCE;
+  credentialId?: string;
+  deniedBits?: string[];
+} {
+  const forbidden = new Set<OperatorClientAuthFailureReason>([
+    'wrong_audience',
+    'wrong_channel_scope',
+    'unknown_capability',
+    'insufficient_capability',
+    'actor_marker_forbidden',
+    'token_substitution',
+    'command_mismatch',
+    'unsupported_command',
+  ]);
+  return {
+    code: forbidden.has(input.reason) ? 'FORBIDDEN' : 'UNAUTHORIZED',
+    reasonCode: `OPERATOR_CLIENT_${input.reason.toUpperCase()}`,
+    message: operatorClientFailureMessage(input.reason),
+    retryable: false,
+    lane: 'denied',
+    acceptedLanes: ['operator-client-credential'],
+    audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+    ...(input.credentialId ? { credentialId: input.credentialId } : {}),
+    ...(input.deniedBits?.length ? { deniedBits: input.deniedBits } : {}),
+  };
+}
+
+export function issueOperatorClientCredentialWithGrant(
+  registry: OperatorClientCredentialRegistry,
+  grants: HandshakeGrantRegistry,
+  value: unknown
+): { token: string; credential: OperatorClientCredentialRecord } {
+  const input = operatorClientCredentialIssueInput(value);
+  const grantHandle = requiredGrantHandle(value);
+  const grantInput = grantValidationInput(input);
+  const preflight = grants.validate(grantHandle, {
+    ...grantInput,
+    consume: false,
+  });
+  if (!preflight.ok) throw grantRejected();
+  requireGrantScope(preflight.grant.scope.channelIds, input.scope?.channelIds);
+  const issued = registry.issue({
+    ...input,
+    grantId: preflight.grant.id,
+    notAfter: preflight.grant.expiresAt,
+  });
+  const consumed = grants.validate(grantHandle, {
+    ...grantInput,
+    consume: true,
+  });
+  if (!consumed.ok) {
+    registry.revoke(issued.credential.id, {
+      revokedBy: 'grant-validation-failed',
+      reason: 'grant validation changed before credential issue completed',
+    });
+    throw grantRejected();
+  }
+  return issued;
+}
+
+export function revokeOperatorClientCredentialWithGrant(
+  registry: OperatorClientCredentialRegistry,
+  grants: HandshakeGrantRegistry,
+  credentialId: string,
+  value: unknown
+): OperatorClientCredentialRecord {
+  const credential = registry.getCredential(credentialId);
+  if (!credential) {
+    throw new OperatorClientCredentialError(
+      'credential_not_found',
+      'operator client credential not found'
+    );
+  }
+  const input = strictRevokeInput(value, credential);
+  const grantHandle = requiredGrantHandle(value);
+  const grantInput = grantValidationInput(input, credential.capabilities);
+  const preflight = grants.validate(grantHandle, {
+    ...grantInput,
+    consume: false,
+  });
+  if (!preflight.ok) throw grantRejected();
+  requireGrantScope(
+    preflight.grant.scope.channelIds,
+    credential.scope.channelIds
+  );
+  const consumed = grants.validate(grantHandle, {
+    ...grantInput,
+    consume: true,
+  });
+  if (!consumed.ok) throw grantRejected();
+  const revoked = registry.revoke(credentialId, {
+    revokedBy: `grant:${preflight.grant.id}`,
+    ...(isRecord(value) && typeof value['reason'] === 'string'
+      ? { reason: value['reason'] }
+      : {}),
+  });
+  if (!revoked) {
+    throw new OperatorClientCredentialError(
+      'credential_not_found',
+      'operator client credential disappeared during revocation'
+    );
+  }
+  return revoked;
+}
+
+export function isOperatorClientChannelCommand(
+  value: string
+): value is OperatorClientChannelCommand {
+  return (OPERATOR_CLIENT_CHANNEL_COMMANDS as readonly string[]).includes(
+    value
+  );
+}
+
+export function operatorClientCredentialIssueInput(
+  value: unknown
+): IssueOperatorClientCredentialInput {
+  if (!isRecord(value)) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'operator client credential issue requires an object body'
+    );
+  }
+  const client = strictClient(value['client']);
+  const capabilities = strictCapabilities(value['capabilities']);
+  const scope = strictScope(value['scope']);
+  const ttlMs = typeof value['ttlMs'] === 'number' ? value['ttlMs'] : undefined;
+  const expiresAt =
+    typeof value['expiresAt'] === 'string' ? value['expiresAt'] : undefined;
+  const device = isRecord(value['device'])
+    ? strictDevice(value['device'])
+    : undefined;
+  return {
+    client,
+    capabilities,
+    scope,
+    ...(device ? { device } : {}),
+    ...(ttlMs !== undefined ? { ttlMs } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+    ...(typeof value['correlationId'] === 'string'
+      ? { correlationId: value['correlationId'] }
+      : {}),
+  };
+}
+
+function strictRevokeInput(
+  value: unknown,
+  credential: OperatorClientCredentialRecord
+): IssueOperatorClientCredentialInput {
+  if (!isRecord(value)) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'operator client credential revoke requires an object body'
+    );
+  }
+  const client = strictClient(value['client']);
+  if (client.id !== credential.client.id) {
+    throw new OperatorClientCredentialError(
+      'client_mismatch',
+      'operator client metadata does not match this credential'
+    );
+  }
+  const device = isRecord(value['device'])
+    ? strictDevice(value['device'])
+    : undefined;
+  return {
+    client,
+    capabilities: credential.capabilities,
+    scope: credential.scope,
+    ...(device ? { device } : {}),
+    ttlMs: 1,
+  };
+}
+
+function grantValidationInput(
+  input: Pick<
+    IssueOperatorClientCredentialInput,
+    'client' | 'device' | 'capabilities' | 'scope'
+  >,
+  capabilities = input.capabilities
+): {
+  audience: typeof OPERATOR_CLIENT_CREDENTIAL_AUDIENCE;
+  requiredCapabilities: string[];
+  actor: HandshakeGrantActor;
+  deviceId?: string;
+  scope?: { channelIds?: string[] };
+} {
+  return {
+    audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+    requiredCapabilities: [...capabilities],
+    actor: {
+      type: 'cli',
+      id: input.client.id,
+      ...(input.client.displayName
+        ? { displayName: input.client.displayName }
+        : {}),
+    },
+    ...(input.device ? { deviceId: input.device.id } : {}),
+    ...(input.scope?.channelIds ? { scope: input.scope } : {}),
+  };
+}
+
+function requireGrantScope(
+  grantChannelIds: readonly string[] | undefined,
+  credentialChannelIds: readonly string[] | undefined
+): void {
+  if (grantChannelIds?.length && !credentialChannelIds?.length) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'a channel-scoped handshake grant cannot mint an unscoped operator client credential'
+    );
+  }
+}
+
+function requiredGrantHandle(value: unknown): string {
+  const grantHandle = isRecord(value) ? value['grantHandle'] : undefined;
+  if (typeof grantHandle !== 'string' || !grantHandle.trim()) {
+    throw new OperatorClientCredentialError(
+      'grant_required',
+      'operator client grant-backed lifecycle requires a handshake grant handle'
+    );
+  }
+  return grantHandle.trim();
+}
+
+function strictClient(value: unknown): {
+  id: string;
+  displayName?: string;
+  platform?: string;
+} {
+  if (
+    !isRecord(value) ||
+    typeof value['id'] !== 'string' ||
+    !value['id'].trim()
+  ) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'operator client credential requires client.id'
+    );
+  }
+  return {
+    id: value['id'].trim(),
+    ...(typeof value['displayName'] === 'string' && value['displayName'].trim()
+      ? { displayName: value['displayName'].trim() }
+      : {}),
+    ...(typeof value['platform'] === 'string' && value['platform'].trim()
+      ? { platform: value['platform'].trim() }
+      : {}),
+  };
+}
+
+function strictDevice(value: Record<string, unknown>): {
+  id: string;
+  displayName?: string;
+} {
+  if (typeof value['id'] !== 'string' || !value['id'].trim()) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'operator client device metadata requires device.id'
+    );
+  }
+  return {
+    id: value['id'].trim(),
+    ...(typeof value['displayName'] === 'string' && value['displayName'].trim()
+      ? { displayName: value['displayName'].trim() }
+      : {}),
+  };
+}
+
+function strictCapabilities(value: unknown): string[] {
+  if (
+    !Array.isArray(value) ||
+    value.some((capability) => typeof capability !== 'string')
+  ) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'operator client credential requires explicit capability bits'
+    );
+  }
+  return [...value];
+}
+
+function strictScope(value: unknown): OperatorClientCredentialScope {
+  if (value === undefined) return {};
+  if (!isRecord(value)) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'operator client scope must be an object'
+    );
+  }
+  if (value['channelIds'] === undefined) return {};
+  if (!Array.isArray(value['channelIds'])) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'operator client scope.channelIds must be an array'
+    );
+  }
+  return { channelIds: value['channelIds'] as string[] };
+}
+
+function grantRejected(): OperatorClientCredentialError {
+  return new OperatorClientCredentialError(
+    'grant_rejected',
+    'handshake grant does not authorize this operator client credential lifecycle operation'
+  );
+}
+
+function operatorClientFailureMessage(
+  reason: OperatorClientAuthFailureReason
+): string {
+  switch (reason) {
+    case 'marker_required':
+      return 'operator client credentials require x-relay-operator-client-token: v1';
+    case 'actor_marker_forbidden':
+      return 'actor-token markers are not accepted for operator client credentials';
+    case 'token_substitution':
+      return 'operator client credentials do not accept another credential family';
+    case 'command_mismatch':
+      return 'operator client credential command marker does not match this route';
+    case 'gateway_marker_required':
+      return 'operator client credentials require x-relay-cli-gateway: v1';
+    case 'unsupported_command':
+      return 'operator client credentials are limited to stable channel commands';
+    default:
+      return `operator client credential rejected: ${reason}`;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/server/operator-client-auth.ts
+++ b/server/operator-client-auth.ts
@@ -187,15 +187,22 @@ export function issueOperatorClientCredentialWithGrant(
 ): { token: string; credential: OperatorClientCredentialRecord } {
   const input = operatorClientCredentialIssueInput(value);
   const grantHandle = requiredGrantHandle(value);
-  const grantInput = grantValidationInput(input);
+  const inheritedScope = issueScopeIsOmitted(value)
+    ? exactChannelScopeForGrantHandle(grants, grantHandle)
+    : undefined;
+  const issueInput = inheritedScope ? { ...input, scope: inheritedScope } : input;
+  const grantInput = grantValidationInput(issueInput);
   const preflight = grants.validate(grantHandle, {
     ...grantInput,
     consume: false,
   });
   if (!preflight.ok) throw grantRejected();
-  requireGrantScope(preflight.grant.scope.channelIds, input.scope?.channelIds);
+  requireGrantScope(
+    preflight.grant.scope.channelIds,
+    issueInput.scope?.channelIds
+  );
   const issued = registry.issue({
-    ...input,
+    ...issueInput,
     grantId: preflight.grant.id,
     notAfter: preflight.grant.expiresAt,
   });
@@ -364,6 +371,42 @@ function requireGrantScope(
       'a channel-scoped handshake grant cannot mint an unscoped operator client credential'
     );
   }
+}
+
+/**
+ * A scope-less grant-backed issue can only inherit a complete, literal channel
+ * allowlist. The subsequent registry validation still authenticates the handle
+ * and checks the copied scope against every grant scope dimension.
+ */
+function exactChannelScopeForGrantHandle(
+  grants: HandshakeGrantRegistry,
+  grantHandle: string
+): OperatorClientCredentialScope | undefined {
+  const grantId = grantIdFromHandle(grantHandle);
+  const scope = grantId ? grants.getGrant(grantId)?.scope : undefined;
+  if (!scope || Object.keys(scope).some((key) => key !== 'channelIds')) {
+    return undefined;
+  }
+  const channelIds = scope.channelIds;
+  if (
+    !channelIds?.length ||
+    channelIds.some((channelId) => !channelId.trim() || channelId === '*')
+  ) {
+    return undefined;
+  }
+  return { channelIds: [...channelIds] };
+}
+
+function grantIdFromHandle(grantHandle: string): string | undefined {
+  const [prefix, id, secret, ...rest] = grantHandle.split('.');
+  if (prefix !== 'relay-ohg-v1' || !id || !secret || rest.length > 0) {
+    return undefined;
+  }
+  return id;
+}
+
+function issueScopeIsOmitted(value: unknown): boolean {
+  return isRecord(value) && value['scope'] === undefined;
 }
 
 function requiredGrantHandle(value: unknown): string {

--- a/server/operator-client-auth.ts
+++ b/server/operator-client-auth.ts
@@ -142,6 +142,92 @@ export function authenticateOperatorClientCredential(
   return validation;
 }
 
+/**
+ * Renewal auth: the CURRENT still-valid credential itself authorizes minting
+ * its successor. Lifecycle route — the per-command header is not required, but
+ * both v1 markers are, and actor-marker substitution stays forbidden.
+ */
+export function authenticateOperatorClientCredentialForRenew(
+  registry: OperatorClientCredentialRegistry,
+  req: Request
+):
+  | { ok: true; credential: OperatorClientCredentialRecord }
+  | { ok: false; reason: OperatorClientAuthFailureReason } {
+  if (req.header(OPERATOR_CLIENT_GATEWAY_HEADER) !== 'v1') {
+    return { ok: false, reason: 'gateway_marker_required' };
+  }
+  if (req.header(OPERATOR_CLIENT_TOKEN_HEADER) !== 'v1') {
+    return { ok: false, reason: 'marker_required' };
+  }
+  if (req.header('x-relay-cli-actor-token') !== undefined) {
+    return { ok: false, reason: 'actor_marker_forbidden' };
+  }
+  const token = bearerOperatorClientToken(req);
+  if (!token.startsWith(`${OPERATOR_CLIENT_CREDENTIAL_TOKEN_PREFIX}.`)) {
+    return { ok: false, reason: 'token_substitution' };
+  }
+  const validation = registry.validate(token, {
+    audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+    requiredCapabilities: ['context:read'],
+  });
+  if (!validation.ok) {
+    return { ok: false, reason: validation.reason };
+  }
+  return { ok: true, credential: validation.credential };
+}
+
+const DEFAULT_RENEW_TTL_MS = 15 * 60 * 1000;
+
+function renewTtlMs(value: unknown): number | undefined {
+  const body = value;
+  if (!isRecord(body)) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'operator client renewal requires an object body'
+    );
+  }
+  for (const key of Object.keys(body)) {
+    if (key !== 'ttlMs') {
+      throw new OperatorClientCredentialError(
+        'grant_rejected',
+        `unexpected renewal field '${key}'`
+      );
+    }
+  }
+  const ttlMs = body['ttlMs'];
+  if (ttlMs === undefined) return undefined;
+  if (typeof ttlMs !== 'number' || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new OperatorClientCredentialError(
+      'grant_rejected',
+      'renewal ttlMs must be a positive finite number'
+    );
+  }
+  return ttlMs;
+}
+
+/**
+ * Mint a successor credential copying the old record's identity dimensions.
+ * The old credential is deliberately NOT revoked: it expires naturally within
+ * its own TTL window, so a lost renew response can never lock the client out,
+ * and revocation (explicit or grant-cascade) still cuts access immediately.
+ */
+export function renewOperatorClientCredential(
+  registry: OperatorClientCredentialRegistry,
+  previous: OperatorClientCredentialRecord,
+  value: unknown
+): { token: string; credential: OperatorClientCredentialRecord } {
+  return registry.issue({
+    client: { ...previous.client },
+    ...(previous.device ? { deviceHash: { ...previous.device } } : {}),
+    capabilities: [...previous.capabilities],
+    scope: previous.scope.channelIds
+      ? { channelIds: [...previous.scope.channelIds] }
+      : {},
+    ...(previous.grantId ? { grantId: previous.grantId } : {}),
+    ttlMs: renewTtlMs(value) ?? DEFAULT_RENEW_TTL_MS,
+  });
+}
+
 export function operatorClientAuthFailure(input: {
   reason: OperatorClientAuthFailureReason;
   credentialId?: string;
@@ -190,7 +276,9 @@ export function issueOperatorClientCredentialWithGrant(
   const inheritedScope = issueScopeIsOmitted(value)
     ? exactChannelScopeForGrantHandle(grants, grantHandle)
     : undefined;
-  const issueInput = inheritedScope ? { ...input, scope: inheritedScope } : input;
+  const issueInput = inheritedScope
+    ? { ...input, scope: inheritedScope }
+    : input;
   const grantInput = grantValidationInput(issueInput);
   const preflight = grants.validate(grantHandle, {
     ...grantInput,

--- a/shared/channel-client.ts
+++ b/shared/channel-client.ts
@@ -68,7 +68,7 @@ export type RelayChannelReducerState = Omit<
 export interface RelayChannelClientConfig {
   /** Relay hub URL. Defaults to RELAY_IDE_URL or the local RELAY_IDE_PORT hub. */
   baseUrl?: string;
-  /** Construction-only bearer credential. Defaults to actor then browser env credential. */
+  /** Construction-only bearer credential. Defaults to operator-client, actor, then browser env credential. */
   token?: string;
   /** Construction-only headers, useful for an already-authenticated proxy. */
   headers?: HeadersInit;
@@ -455,11 +455,21 @@ function projectPublicValueWithNeedles(
 }
 
 /** Project every message-bearing response at the client boundary. */
+export function projectRelayChannelPublicValue(
+  value: unknown,
+  configuredToken?: string
+): unknown {
+  return projectPublicValue(value, configuredToken);
+}
+
 export function projectRelayChannelMessage(
   message: ChannelMessage,
   configuredToken?: string
 ): RelayChannelMessage {
-  return projectPublicValue(message, configuredToken) as RelayChannelMessage;
+  return projectRelayChannelPublicValue(
+    message,
+    configuredToken
+  ) as RelayChannelMessage;
 }
 
 function projectChannelEvent(
@@ -768,18 +778,28 @@ export function createRelayChannelClient(
 ): RelayChannelClient {
   const env = config.env ?? (typeof process === 'undefined' ? {} : process.env);
   const baseUrl = trimBaseUrl(config.baseUrl ?? defaultBaseUrl(env));
-  // A browser bearer is accepted by the ordinary HTTP auth lane.  Advertising
-  // it as an actor credential would switch server-side scope semantics, so the
-  // actor marker is emitted only for a known actor credential/env lane.
+  // Browser bearers are accepted by the ordinary HTTP auth lane. A scoped actor
+  // or human operator-client credential needs its own explicit marker so Relay
+  // never confuses a human post with an agent post.
   const configuredToken = config.token;
-  const configuredActor = configuredToken?.startsWith('relay-sac-v1.')
+  const configuredOperatorClient = configuredToken?.startsWith('relay-occ-v1.')
     ? configuredToken
     : undefined;
-  const actorToken = configuredActor ?? env['RELAY_IDE_ACTOR_TOKEN'];
-  const browserToken = configuredActor
-    ? undefined
-    : (configuredToken ?? env['RELAY_IDE_BROWSER_TOKEN']);
-  const token = actorToken ?? browserToken;
+  const operatorClientToken =
+    configuredOperatorClient ?? env['RELAY_IDE_OPERATOR_CLIENT_TOKEN'];
+  const configuredActor =
+    !configuredOperatorClient && configuredToken?.startsWith('relay-sac-v1.')
+      ? configuredToken
+      : undefined;
+  const actorToken =
+    configuredActor ??
+    (operatorClientToken ? undefined : env['RELAY_IDE_ACTOR_TOKEN']);
+  const browserToken =
+    configuredOperatorClient || configuredActor
+      ? undefined
+      : (configuredToken ??
+        (operatorClientToken ? undefined : env['RELAY_IDE_BROWSER_TOKEN']));
+  const token = operatorClientToken ?? actorToken ?? browserToken;
   const fetcher = config.fetch ?? globalThis.fetch;
   const staticHeaders = new Headers(config.headers);
 
@@ -794,6 +814,10 @@ export function createRelayChannelClient(
     );
     if (token && !headers.has('authorization'))
       headers.set('authorization', `Bearer ${token}`);
+    if (operatorClientToken) {
+      headers.delete('x-relay-cli-actor-token');
+      headers.set('x-relay-operator-client-token', 'v1');
+    }
     if (actorToken && !headers.has('x-relay-cli-actor-token'))
       headers.set('x-relay-cli-actor-token', 'v1');
     return headers;

--- a/shared/operator-client-credentials.ts
+++ b/shared/operator-client-credentials.ts
@@ -1,0 +1,493 @@
+import * as crypto from 'node:crypto';
+
+export const OPERATOR_CLIENT_CREDENTIAL_AUDIENCE =
+  'relay:operator-client:v1' as const;
+export const OPERATOR_CLIENT_CREDENTIAL_TOKEN_PREFIX = 'relay-occ-v1' as const;
+export const OPERATOR_CLIENT_CREDENTIAL_CAPABILITIES = [
+  'context:read',
+  'context:write',
+] as const;
+export const DEFAULT_OPERATOR_CLIENT_CREDENTIAL_MAX_TTL_MS = 15 * 60 * 1000;
+
+export type OperatorClientCredentialCapability =
+  (typeof OPERATOR_CLIENT_CREDENTIAL_CAPABILITIES)[number];
+
+/** The local Relay operator is the only principal this credential family can represent. */
+export interface OperatorClientCredentialPrincipal {
+  kind: 'human';
+  id: 'human:operator';
+  displayName: 'Operator';
+}
+
+export interface OperatorClientCredentialClient {
+  id: string;
+  displayName?: string;
+  platform?: string;
+}
+
+export interface OperatorClientCredentialDeviceInput {
+  id: string;
+  displayName?: string;
+}
+
+export interface OperatorClientCredentialDevice {
+  idHash: string;
+  displayName?: string;
+}
+
+export interface OperatorClientCredentialScope {
+  /** Omitted means the authenticated human principal has no channel narrowing. */
+  channelIds?: string[];
+}
+
+export interface OperatorClientCredentialRecord {
+  id: string;
+  audience: typeof OPERATOR_CLIENT_CREDENTIAL_AUDIENCE;
+  principal: OperatorClientCredentialPrincipal;
+  client: OperatorClientCredentialClient;
+  device?: OperatorClientCredentialDevice;
+  capabilities: OperatorClientCredentialCapability[];
+  scope: OperatorClientCredentialScope;
+  grantId?: string;
+  issuedAt: string;
+  expiresAt: string;
+  revokedAt?: string;
+  revokedBy?: string;
+  revocationReason?: string;
+  correlationId: string;
+}
+
+interface InternalOperatorClientCredentialRecord extends OperatorClientCredentialRecord {
+  secretHash: string;
+}
+
+export interface IssueOperatorClientCredentialInput {
+  client: OperatorClientCredentialClient;
+  device?: OperatorClientCredentialDeviceInput;
+  capabilities: string[];
+  scope?: OperatorClientCredentialScope;
+  ttlMs?: number;
+  expiresAt?: string | Date;
+  notAfter?: string | Date;
+  grantId?: string;
+  correlationId?: string;
+}
+
+export interface IssuedOperatorClientCredential {
+  token: string;
+  credential: OperatorClientCredentialRecord;
+}
+
+export type OperatorClientCredentialValidationFailureReason =
+  | 'malformed_credential'
+  | 'wrong_audience'
+  | 'expired'
+  | 'revoked'
+  | 'wrong_channel_scope'
+  | 'unknown_capability'
+  | 'insufficient_capability';
+
+export type OperatorClientCredentialValidationResult =
+  | {
+      ok: true;
+      credential: OperatorClientCredentialRecord;
+      grantedBits: OperatorClientCredentialCapability[];
+    }
+  | {
+      ok: false;
+      reason: OperatorClientCredentialValidationFailureReason;
+      credentialId?: string;
+      deniedBits: string[];
+    };
+
+export interface ValidateOperatorClientCredentialInput {
+  audience: string;
+  requiredCapabilities: string[];
+  channelId?: string;
+}
+
+export interface RevokeOperatorClientCredentialInput {
+  revokedBy: string;
+  reason?: string;
+}
+
+export class OperatorClientCredentialRegistryError extends Error {
+  constructor(
+    public readonly code:
+      | 'CLIENT_REQUIRED'
+      | 'CAPABILITY_REQUIRED'
+      | 'UNKNOWN_CAPABILITY'
+      | 'EXPIRY_REQUIRED'
+      | 'EXPIRY_EXCEEDS_MAX_TTL'
+      | 'SCOPE_INVALID',
+    message: string
+  ) {
+    super(`${code}: ${message}`);
+    this.name = 'OperatorClientCredentialRegistryError';
+  }
+}
+
+const OPERATOR_PRINCIPAL: OperatorClientCredentialPrincipal = {
+  kind: 'human',
+  id: 'human:operator',
+  displayName: 'Operator',
+};
+
+export class OperatorClientCredentialRegistry {
+  private readonly credentials = new Map<
+    string,
+    InternalOperatorClientCredentialRecord
+  >();
+  private readonly maxTtlMs: number;
+  private readonly now: () => Date;
+  private readonly secretBytes: () => Buffer;
+
+  constructor(
+    options: {
+      maxTtlMs?: number;
+      now?: () => Date;
+      secretBytes?: () => Buffer;
+    } = {}
+  ) {
+    this.maxTtlMs =
+      options.maxTtlMs ?? DEFAULT_OPERATOR_CLIENT_CREDENTIAL_MAX_TTL_MS;
+    this.now = options.now ?? (() => new Date());
+    this.secretBytes = options.secretBytes ?? (() => crypto.randomBytes(32));
+  }
+
+  issue(
+    input: IssueOperatorClientCredentialInput
+  ): IssuedOperatorClientCredential {
+    const issuedAt = this.now();
+    const client = normalizeClient(input.client);
+    const device = normalizeDevice(input.device);
+    const capabilities = normalizeCapabilities(input.capabilities);
+    const scope = normalizeScope(input.scope);
+    const expiresAt = resolveExpiry(input, issuedAt, this.maxTtlMs);
+    const grantId = safeString(input.grantId);
+    const id = crypto.randomUUID();
+    const secret = this.secretBytes().toString('hex');
+    const credential: InternalOperatorClientCredentialRecord = {
+      id,
+      audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+      principal: { ...OPERATOR_PRINCIPAL },
+      client,
+      ...(device ? { device } : {}),
+      capabilities,
+      scope,
+      ...(grantId ? { grantId } : {}),
+      issuedAt: issuedAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+      correlationId: safeString(input.correlationId) ?? crypto.randomUUID(),
+      secretHash: sha256(secret),
+    };
+    this.credentials.set(id, credential);
+    return {
+      token: `${OPERATOR_CLIENT_CREDENTIAL_TOKEN_PREFIX}.${id}.${secret}`,
+      credential: publicCredential(credential),
+    };
+  }
+
+  validate(
+    token: string,
+    input: ValidateOperatorClientCredentialInput
+  ): OperatorClientCredentialValidationResult {
+    const parsed = parseToken(token);
+    if (!parsed) return deny('malformed_credential', undefined, []);
+    const credential = this.credentials.get(parsed.id);
+    if (
+      !credential ||
+      !sameHash(credential.secretHash, sha256(parsed.secret))
+    ) {
+      return deny('malformed_credential', parsed.id, []);
+    }
+    if (input.audience !== OPERATOR_CLIENT_CREDENTIAL_AUDIENCE) {
+      return deny('wrong_audience', credential.id, input.requiredCapabilities);
+    }
+    if (new Date(credential.expiresAt).getTime() <= this.now().getTime()) {
+      return deny('expired', credential.id, input.requiredCapabilities);
+    }
+    if (credential.revokedAt) {
+      return deny('revoked', credential.id, input.requiredCapabilities);
+    }
+    const unknown = input.requiredCapabilities.find(
+      (capability) => !isOperatorClientCredentialCapability(capability)
+    );
+    if (unknown) return deny('unknown_capability', credential.id, [unknown]);
+    const missing = input.requiredCapabilities.filter(
+      (capability) =>
+        !credential.capabilities.includes(
+          capability as OperatorClientCredentialCapability
+        )
+    );
+    if (missing.length)
+      return deny('insufficient_capability', credential.id, missing);
+    if (
+      input.channelId &&
+      credential.scope.channelIds &&
+      !credential.scope.channelIds.includes(input.channelId)
+    ) {
+      return deny(
+        'wrong_channel_scope',
+        credential.id,
+        input.requiredCapabilities
+      );
+    }
+    return {
+      ok: true,
+      credential: publicCredential(credential),
+      grantedBits:
+        input.requiredCapabilities as OperatorClientCredentialCapability[],
+    };
+  }
+
+  revoke(
+    credentialId: string,
+    input: RevokeOperatorClientCredentialInput
+  ): OperatorClientCredentialRecord | null {
+    const credential = this.credentials.get(credentialId);
+    if (!credential) return null;
+    if (!credential.revokedAt) {
+      credential.revokedAt = this.now().toISOString();
+      credential.revokedBy = safeString(input.revokedBy) ?? 'operator';
+      const reason = safeString(input.reason);
+      if (reason) credential.revocationReason = reason;
+    }
+    return publicCredential(credential);
+  }
+
+  revokeByGrantId(
+    grantId: string,
+    input: RevokeOperatorClientCredentialInput
+  ): OperatorClientCredentialRecord[] {
+    const revoked: OperatorClientCredentialRecord[] = [];
+    for (const credential of this.credentials.values()) {
+      if (credential.grantId !== grantId || credential.revokedAt) continue;
+      const result = this.revoke(credential.id, input);
+      if (result) revoked.push(result);
+    }
+    return revoked;
+  }
+
+  getCredential(credentialId: string): OperatorClientCredentialRecord | null {
+    const credential = this.credentials.get(credentialId);
+    return credential ? publicCredential(credential) : null;
+  }
+
+  listCredentials(): OperatorClientCredentialRecord[] {
+    return [...this.credentials.values()].map(publicCredential);
+  }
+}
+
+export function isOperatorClientCredentialCapability(
+  value: unknown
+): value is OperatorClientCredentialCapability {
+  return (
+    typeof value === 'string' &&
+    (OPERATOR_CLIENT_CREDENTIAL_CAPABILITIES as readonly string[]).includes(
+      value
+    )
+  );
+}
+
+function normalizeClient(
+  input: OperatorClientCredentialClient
+): OperatorClientCredentialClient {
+  if (!input || typeof input !== 'object') {
+    throw new OperatorClientCredentialRegistryError(
+      'CLIENT_REQUIRED',
+      'operator client credentials require client metadata'
+    );
+  }
+  const id = safeString(input.id);
+  if (!id) {
+    throw new OperatorClientCredentialRegistryError(
+      'CLIENT_REQUIRED',
+      'operator client credentials require a client id'
+    );
+  }
+  const displayName = safeString(input.displayName);
+  const platform = safeString(input.platform);
+  return {
+    id,
+    ...(displayName ? { displayName } : {}),
+    ...(platform ? { platform } : {}),
+  };
+}
+
+function normalizeDevice(
+  input: OperatorClientCredentialDeviceInput | undefined
+): OperatorClientCredentialDevice | undefined {
+  if (!input) return undefined;
+  const id = safeString(input.id);
+  if (!id) {
+    throw new OperatorClientCredentialRegistryError(
+      'CLIENT_REQUIRED',
+      'operator client device metadata requires a device id'
+    );
+  }
+  const displayName = safeString(input.displayName);
+  return {
+    idHash: sha256(id),
+    ...(displayName ? { displayName } : {}),
+  };
+}
+
+function normalizeCapabilities(
+  input: string[]
+): OperatorClientCredentialCapability[] {
+  if (!Array.isArray(input) || input.length === 0) {
+    throw new OperatorClientCredentialRegistryError(
+      'CAPABILITY_REQUIRED',
+      'operator client credentials require context:read and/or context:write'
+    );
+  }
+  const capabilities: OperatorClientCredentialCapability[] = [];
+  for (const value of input) {
+    if (!isOperatorClientCredentialCapability(value)) {
+      throw new OperatorClientCredentialRegistryError(
+        'UNKNOWN_CAPABILITY',
+        'operator client credentials are limited to context:read and context:write'
+      );
+    }
+    if (!capabilities.includes(value)) capabilities.push(value);
+  }
+  return capabilities;
+}
+
+function normalizeScope(
+  input: OperatorClientCredentialScope | undefined
+): OperatorClientCredentialScope {
+  if (input === undefined) return {};
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new OperatorClientCredentialRegistryError(
+      'SCOPE_INVALID',
+      'operator client channel scope must be an object'
+    );
+  }
+  if (input.channelIds === undefined) return {};
+  if (!Array.isArray(input.channelIds)) {
+    throw new OperatorClientCredentialRegistryError(
+      'SCOPE_INVALID',
+      'operator client channelIds must be an array'
+    );
+  }
+  const channelIds = uniqueStrings(input.channelIds);
+  if (channelIds.length === 0) {
+    throw new OperatorClientCredentialRegistryError(
+      'SCOPE_INVALID',
+      'operator client channelIds must contain at least one channel id'
+    );
+  }
+  return { channelIds };
+}
+
+function resolveExpiry(
+  input: IssueOperatorClientCredentialInput,
+  issuedAt: Date,
+  maxTtlMs: number
+): Date {
+  if (input.ttlMs === undefined && input.expiresAt === undefined) {
+    throw new OperatorClientCredentialRegistryError(
+      'EXPIRY_REQUIRED',
+      'operator client credentials require ttlMs or expiresAt'
+    );
+  }
+  let expiresAt = input.expiresAt
+    ? new Date(input.expiresAt)
+    : new Date(issuedAt.getTime() + (input.ttlMs ?? 0));
+  if (!Number.isFinite(expiresAt.getTime()) || expiresAt <= issuedAt) {
+    throw new OperatorClientCredentialRegistryError(
+      'EXPIRY_REQUIRED',
+      'operator client credential expiry must be in the future'
+    );
+  }
+  if (expiresAt.getTime() - issuedAt.getTime() > maxTtlMs) {
+    throw new OperatorClientCredentialRegistryError(
+      'EXPIRY_EXCEEDS_MAX_TTL',
+      'operator client credential ttl exceeds registry maximum'
+    );
+  }
+  if (input.notAfter) {
+    const notAfter = new Date(input.notAfter);
+    if (!Number.isFinite(notAfter.getTime()) || notAfter <= issuedAt) {
+      throw new OperatorClientCredentialRegistryError(
+        'EXPIRY_REQUIRED',
+        'operator client credential expiry ceiling must be in the future'
+      );
+    }
+    if (expiresAt > notAfter) expiresAt = notAfter;
+  }
+  return expiresAt;
+}
+
+function parseToken(value: unknown): { id: string; secret: string } | null {
+  if (typeof value !== 'string') return null;
+  const [prefix, id, secret, ...rest] = value.split('.');
+  if (
+    prefix !== OPERATOR_CLIENT_CREDENTIAL_TOKEN_PREFIX ||
+    !id ||
+    !secret ||
+    rest.length > 0
+  ) {
+    return null;
+  }
+  return { id, secret };
+}
+
+function publicCredential(
+  credential: InternalOperatorClientCredentialRecord
+): OperatorClientCredentialRecord {
+  const { secretHash: _secretHash, ...record } = credential;
+  return {
+    ...record,
+    principal: { ...record.principal },
+    client: { ...record.client },
+    ...(record.device ? { device: { ...record.device } } : {}),
+    capabilities: [...record.capabilities],
+    scope: record.scope.channelIds
+      ? { channelIds: [...record.scope.channelIds] }
+      : {},
+  };
+}
+
+function deny(
+  reason: OperatorClientCredentialValidationFailureReason,
+  credentialId: string | undefined,
+  deniedBits: string[]
+): OperatorClientCredentialValidationResult {
+  return {
+    ok: false,
+    reason,
+    ...(credentialId ? { credentialId } : {}),
+    deniedBits,
+  };
+}
+
+function safeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function uniqueStrings(values: readonly unknown[]): string[] {
+  const unique = new Set<string>();
+  for (const value of values) {
+    const normalized = safeString(value);
+    if (normalized) unique.add(normalized);
+  }
+  return [...unique];
+}
+
+function sha256(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function sameHash(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left, 'hex');
+  const rightBytes = Buffer.from(right, 'hex');
+  return (
+    leftBytes.length === rightBytes.length &&
+    crypto.timingSafeEqual(leftBytes, rightBytes)
+  );
+}

--- a/shared/operator-client-credentials.ts
+++ b/shared/operator-client-credentials.ts
@@ -64,6 +64,12 @@ interface InternalOperatorClientCredentialRecord extends OperatorClientCredentia
 export interface IssueOperatorClientCredentialInput {
   client: OperatorClientCredentialClient;
   device?: OperatorClientCredentialDeviceInput;
+  /**
+   * Renewal passthrough: an already-hashed device binding copied from the
+   * credential being renewed. Mutually exclusive with `device` — raw ids only
+   * enter through issuance, hashes only through renewal.
+   */
+  deviceHash?: OperatorClientCredentialDevice;
   capabilities: string[];
   scope?: OperatorClientCredentialScope;
   ttlMs?: number;
@@ -160,7 +166,15 @@ export class OperatorClientCredentialRegistry {
   ): IssuedOperatorClientCredential {
     const issuedAt = this.now();
     const client = normalizeClient(input.client);
-    const device = normalizeDevice(input.device);
+    if (input.device && input.deviceHash) {
+      throw new OperatorClientCredentialRegistryError(
+        'CLIENT_REQUIRED',
+        'operator client credentials accept either device or deviceHash, not both'
+      );
+    }
+    const device =
+      normalizeDevice(input.device) ??
+      (input.deviceHash ? { ...input.deviceHash } : undefined);
     const capabilities = normalizeCapabilities(input.capabilities);
     const scope = normalizeScope(input.scope);
     const expiresAt = resolveExpiry(input, issuedAt, this.maxTtlMs);

--- a/shared/operator-handshake-grants.ts
+++ b/shared/operator-handshake-grants.ts
@@ -32,6 +32,7 @@ export type HandshakeGrantActorType =
 export const HANDSHAKE_GRANT_AUDIENCES = [
   'relay:operator-handshake:v1',
   'relay:cli-gateway:v1',
+  'relay:operator-client:v1',
   NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
   'relay:registry-test',
 ] as const;

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -301,12 +301,21 @@ const expectedInventoryCoverage = [
       '/inbox/*',
       '/events/*',
       '/handoffs/*',
-      '/channels/*',
       '/nodes',
       '/hub/audit/*',
       '/hub/nodes/:nodeId/logs',
       '/hub/nodes/:nodeId/sessions',
     ],
+  },
+  {
+    surface: 'CLI gateway channel APIs',
+    middleware: 'requireChannelGatewayAuthForCommand',
+    acceptedLanes: [
+      'scoped-actor-credential',
+      'operator-client-credential',
+      'browser-session',
+    ],
+    routes: ['/channels/*'],
   },
   {
     surface: 'scoped session APIs',
@@ -397,6 +406,7 @@ test('auth route lane inventory covers browser, scoped, node, pair, public, and 
     new Set([
       'browser-session',
       'scoped-actor-credential',
+      'operator-client-credential',
       'node-credential',
       'pair-token',
       'public-local-only',
@@ -430,6 +440,11 @@ test('auth route lane inventory keeps credential classes distinct', () => {
   ]);
   expect(routeToLanes.get('/sessions (GET/POST)')).toEqual([
     'scoped-actor-credential',
+    'browser-session',
+  ]);
+  expect(routeToLanes.get('/channels/*')).toEqual([
+    'scoped-actor-credential',
+    'operator-client-credential',
     'browser-session',
   ]);
   expect(routeToLanes.get('POST /webhooks/manage/setup')).toEqual([

--- a/test/channel-client.test.ts
+++ b/test/channel-client.test.ts
@@ -170,6 +170,27 @@ describe('relay-ide/channel-client', () => {
     expect(JSON.stringify(requests)).not.toContain('secret-never-in-input');
   });
 
+  it('selects the human operator-client marker without changing stable request schemas', async () => {
+    const requests: RequestInit[] = [];
+    const client = createRelayChannelClient({
+      baseUrl: 'http://relay.test',
+      token: 'relay-occ-v1.credential-id.raw-secret',
+      fetch: async (_url, init) => {
+        requests.push(init ?? {});
+        return Response.json({ channels: [] });
+      },
+    });
+
+    await client.list();
+    const headers = new Headers(requests[0]?.headers);
+    expect(headers.get('authorization')).toBe(
+      'Bearer relay-occ-v1.credential-id.raw-secret'
+    );
+    expect(headers.get('x-relay-operator-client-token')).toBe('v1');
+    expect(headers.get('x-relay-cli-actor-token')).toBeNull();
+    expect(headers.get('x-relay-cli-command')).toBe('channels.list');
+  });
+
   it('keeps concurrent run lookups isolated and preserves sibling denial envelopes', async () => {
     const client = createRelayChannelClient({
       baseUrl: 'http://relay.test',

--- a/test/operator-client-channel.test.ts
+++ b/test/operator-client-channel.test.ts
@@ -1,0 +1,301 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import express, { type RequestHandler } from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createChannelChatRouter } from '../server/channel-chat-router.js';
+import { createChannelHub } from '../server/channel-hub.js';
+import { createChannelMessageStore } from '../server/channel-message-store.js';
+import { createChannelSubscriptionRouter } from '../server/channel-subscription-router.js';
+import {
+  authenticateOperatorClientCredential,
+  operatorClientAuthFailure,
+} from '../server/operator-client-auth.js';
+import { createWorkspaceTopicStore } from '../server/workspace-topics.js';
+import { OperatorClientCredentialRegistry } from '../shared/operator-client-credentials.js';
+
+const cleanup: Array<() => void> = [];
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+async function fixture(): Promise<{
+  port: number;
+  registry: OperatorClientCredentialRegistry;
+  store: ReturnType<typeof createChannelMessageStore>;
+  hub: ReturnType<typeof createChannelHub>;
+  channelId: string;
+  otherChannelId: string;
+}> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-operator-client-'));
+  cleanup.push(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = createChannelMessageStore(path.join(root, 'channels.db'));
+  cleanup.push(() => store.close());
+  const topics = createWorkspaceTopicStore({
+    dbPath: path.join(root, 'topics.db'),
+  });
+  cleanup.push(() => topics.close());
+  const topic = topics.create({ workspaceId: 'workspace', title: 'Operator' });
+  const other = topics.create({ workspaceId: 'workspace', title: 'Other' });
+  const hub = createChannelHub({
+    store,
+    channelExists: (channelId) => Boolean(topics.get(channelId)),
+  });
+  cleanup.push(() => hub.close());
+  const registry = new OperatorClientCredentialRegistry({
+    secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+  });
+
+  const authFor =
+    (command: string): RequestHandler =>
+    (req, res, next) => {
+      const result = authenticateOperatorClientCredential(
+        registry,
+        req,
+        command as
+          | 'channels.list'
+          | 'channels.get'
+          | 'channels.history'
+          | 'channels.subscribe'
+          | 'channels.post',
+        typeof req.params['id'] === 'string' ? req.params['id'] : undefined
+      );
+      if (result.ok) return next();
+      const failure = operatorClientAuthFailure(result);
+      return res
+        .status(failure.code === 'FORBIDDEN' ? 403 : 401)
+        .json({ error: failure });
+    };
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createChannelChatRouter({
+      store,
+      hub,
+      topicStore: topics,
+      requireAuth: (_req, res) => res.sendStatus(401),
+      requireReadActorAuth: (command) => authFor(command),
+      requireWriteActorAuth: (command) => authFor(command),
+    })
+  );
+  app.use(
+    createChannelSubscriptionRouter({
+      hub,
+      requireSubscribeAuth: authFor('channels.subscribe'),
+      heartbeatMs: 5,
+      isStillAuthorized: (req, channelId) =>
+        authenticateOperatorClientCredential(
+          registry,
+          req,
+          'channels.subscribe',
+          channelId
+        ).ok,
+    })
+  );
+  const server = http.createServer(app);
+  cleanup.push(() => server.close());
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string')
+    throw new Error('server unavailable');
+  return {
+    port: address.port,
+    registry,
+    store,
+    hub,
+    channelId: topic.id,
+    otherChannelId: other.id,
+  };
+}
+
+function headers(token: string, command: string): HeadersInit {
+  return {
+    authorization: `Bearer ${token}`,
+    'content-type': 'application/json',
+    'x-relay-cli-gateway': 'v1',
+    'x-relay-operator-client-token': 'v1',
+    'x-relay-cli-command': command,
+  };
+}
+
+function frameReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>
+): () => Promise<unknown> {
+  const decoder = new TextDecoder();
+  let buffered = '';
+  return async () => {
+    while (true) {
+      const newline = buffered.indexOf('\n');
+      if (newline !== -1) {
+        const frame = buffered.slice(0, newline);
+        buffered = buffered.slice(newline + 1);
+        if (frame) return JSON.parse(frame) as unknown;
+        continue;
+      }
+      const { done, value } = await reader.read();
+      if (done) throw new Error('stream closed before frame');
+      buffered += decoder.decode(value, { stream: true });
+    }
+  };
+}
+
+async function nextMatchingFrame(
+  nextFrame: () => Promise<unknown>,
+  predicate: (frame: Record<string, unknown>) => boolean
+): Promise<Record<string, unknown>> {
+  for (let index = 0; index < 8; index += 1) {
+    const frame = await nextFrame();
+    if (
+      typeof frame === 'object' &&
+      frame !== null &&
+      !Array.isArray(frame) &&
+      predicate(frame as Record<string, unknown>)
+    ) {
+      return frame as Record<string, unknown>;
+    }
+  }
+  throw new Error('subscription did not emit the expected frame');
+}
+
+describe('operator client channel lane', () => {
+  it('preserves stable channel schemas, attributes posts to the server-derived human, and rejects sender/source injection', async () => {
+    const { port, registry, store, channelId, otherChannelId } =
+      await fixture();
+    const issued = registry.issue({
+      client: { id: 'desktop-plugin' },
+      capabilities: ['context:read', 'context:write'],
+      scope: { channelIds: [channelId] },
+      ttlMs: 60_000,
+    });
+
+    const listed = await fetch(`http://127.0.0.1:${port}/channels`, {
+      headers: headers(issued.token, 'channels.list'),
+    });
+    expect(listed.status).toBe(200);
+    expect((await listed.json()).channels).toHaveLength(1);
+
+    const posted = await fetch(
+      `http://127.0.0.1:${port}/channels/${encodeURIComponent(channelId)}/messages`,
+      {
+        method: 'POST',
+        headers: headers(issued.token, 'channels.post'),
+        body: JSON.stringify({
+          text: 'human operator post',
+          clientMessageId: 'operator-post-1',
+        }),
+      }
+    );
+    expect(posted.status).toBe(201);
+    expect((await posted.json()).message.sender).toEqual({
+      kind: 'human',
+      id: 'human:operator',
+      displayName: 'Operator',
+    });
+
+    store.appendComplete({
+      channelId,
+      sender: {
+        kind: 'agent',
+        id: 'agent:provider',
+        runtimeId: 'runtime-private',
+      },
+      source: { runtimeId: 'runtime-private' },
+      text: 'provider response',
+    });
+    const history = await fetch(
+      `http://127.0.0.1:${port}/channels/${encodeURIComponent(channelId)}/messages`,
+      { headers: headers(issued.token, 'channels.history') }
+    );
+    expect(history.status).toBe(200);
+    expect(JSON.stringify(await history.json())).not.toContain(
+      'runtime-private'
+    );
+
+    const injected = await fetch(
+      `http://127.0.0.1:${port}/channels/${encodeURIComponent(channelId)}/messages`,
+      {
+        method: 'POST',
+        headers: headers(issued.token, 'channels.post'),
+        body: JSON.stringify({
+          text: 'forged attribution',
+          sender: { kind: 'agent', id: 'agent:forged' },
+          source: { runtimeId: 'runtime-private' },
+        }),
+      }
+    );
+    expect(injected.status).toBe(400);
+
+    const sibling = await fetch(
+      `http://127.0.0.1:${port}/channels/${encodeURIComponent(otherChannelId)}`,
+      { headers: headers(issued.token, 'channels.get') }
+    );
+    expect(sibling.status).toBe(403);
+
+    const actorMarker = await fetch(`http://127.0.0.1:${port}/channels`, {
+      headers: {
+        ...headers(issued.token, 'channels.list'),
+        'x-relay-cli-actor-token': 'v1',
+      },
+    });
+    expect(actorMarker.status).toBe(403);
+
+    const tokenSubstitution = await fetch(`http://127.0.0.1:${port}/channels`, {
+      headers: headers(
+        'relay-sac-v1.actor-token.substitution',
+        'channels.list'
+      ),
+    });
+    expect(tokenSubstitution.status).toBe(403);
+  });
+
+  it('revalidates a subscription and closes after credential revocation', async () => {
+    const { port, registry, store, hub, channelId } = await fixture();
+    const issued = registry.issue({
+      client: { id: 'desktop-plugin' },
+      capabilities: ['context:read'],
+      scope: { channelIds: [channelId] },
+      ttlMs: 60_000,
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/${encodeURIComponent(channelId)}/subscribe`,
+      { headers: headers(issued.token, 'channels.subscribe') }
+    );
+    expect(response.status).toBe(200);
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('subscription body unavailable');
+    const nextFrame = frameReader(reader);
+    expect(await nextFrame()).toMatchObject({ frame: 'open' });
+    const providerMessage = store.appendComplete({
+      channelId,
+      sender: {
+        kind: 'agent',
+        id: 'agent:provider',
+        runtimeId: 'runtime-private',
+      },
+      source: { runtimeId: 'runtime-private' },
+      text: 'provider response',
+    });
+    hub.broadcastCreated(providerMessage);
+    const providerFrame = await nextMatchingFrame(
+      nextFrame,
+      (frame) =>
+        frame['frame'] === 'event' &&
+        typeof frame['payload'] === 'object' &&
+        frame['payload'] !== null &&
+        (frame['payload'] as Record<string, unknown>)['type'] ===
+          'channel-message-created-v1'
+    );
+    expect(JSON.stringify(providerFrame)).not.toContain('runtime-private');
+    registry.revoke(issued.credential.id, { revokedBy: 'browser-operator' });
+    await expect(
+      nextMatchingFrame(nextFrame, (frame) => frame['frame'] === 'closed')
+    ).resolves.toMatchObject({
+      frame: 'closed',
+      reason: 'authorization-revoked',
+      retryable: false,
+    });
+  });
+});

--- a/test/operator-client-channel.test.ts
+++ b/test/operator-client-channel.test.ts
@@ -12,10 +12,15 @@ import { createChannelMessageStore } from '../server/channel-message-store.js';
 import { createChannelSubscriptionRouter } from '../server/channel-subscription-router.js';
 import {
   authenticateOperatorClientCredential,
+  issueOperatorClientCredentialWithGrant,
   operatorClientAuthFailure,
 } from '../server/operator-client-auth.js';
 import { createWorkspaceTopicStore } from '../server/workspace-topics.js';
-import { OperatorClientCredentialRegistry } from '../shared/operator-client-credentials.js';
+import {
+  OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+  OperatorClientCredentialRegistry,
+} from '../shared/operator-client-credentials.js';
+import { HandshakeGrantRegistry } from '../shared/operator-handshake-grants.js';
 
 const cleanup: Array<() => void> = [];
 afterEach(() => {
@@ -161,6 +166,68 @@ async function nextMatchingFrame(
 }
 
 describe('operator client channel lane', () => {
+  it('inherits a grant channel scope omitted by the client and authorizes stable channel commands only within it', async () => {
+    const { port, registry, channelId, otherChannelId } = await fixture();
+    const grantRegistry = new HandshakeGrantRegistry({
+      secretBytes: () => Buffer.from('abcdef0123456789abcdef0123456789'),
+    });
+    const client = { id: 'desktop-plugin' };
+    const requested = grantRegistry.request({
+      actor: { type: 'cli', id: client.id },
+      issuer: { id: 'browser-operator' },
+      audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+      capabilities: ['context:read', 'context:write'],
+      scope: { channelIds: [channelId] },
+      ttlMs: 60_000,
+    });
+    const approved = grantRegistry.approve(requested.id, {
+      approvedBy: { id: 'browser-operator' },
+    });
+    const issued = issueOperatorClientCredentialWithGrant(
+      registry,
+      grantRegistry,
+      {
+        grantHandle: approved.handle,
+        client,
+        capabilities: ['context:read', 'context:write'],
+        ttlMs: 60_000,
+      }
+    );
+
+    expect(issued.credential.scope).toEqual({ channelIds: [channelId] });
+    const listed = await fetch(`http://127.0.0.1:${port}/channels`, {
+      headers: headers(issued.token, 'channels.list'),
+    });
+    expect(listed.status).toBe(200);
+    expect((await listed.json()).channels).toHaveLength(1);
+
+    const posted = await fetch(
+      `http://127.0.0.1:${port}/channels/${encodeURIComponent(channelId)}/messages`,
+      {
+        method: 'POST',
+        headers: headers(issued.token, 'channels.post'),
+        body: JSON.stringify({ text: 'grant-backed operator post' }),
+      }
+    );
+    expect(posted.status).toBe(201);
+
+    const history = await fetch(
+      `http://127.0.0.1:${port}/channels/${encodeURIComponent(channelId)}/messages`,
+      { headers: headers(issued.token, 'channels.history') }
+    );
+    expect(history.status).toBe(200);
+
+    const siblingPost = await fetch(
+      `http://127.0.0.1:${port}/channels/${encodeURIComponent(otherChannelId)}/messages`,
+      {
+        method: 'POST',
+        headers: headers(issued.token, 'channels.post'),
+        body: JSON.stringify({ text: 'outside inherited scope' }),
+      }
+    );
+    expect(siblingPost.status).toBe(403);
+  });
+
   it('preserves stable channel schemas, attributes posts to the server-derived human, and rejects sender/source injection', async () => {
     const { port, registry, store, channelId, otherChannelId } =
       await fixture();

--- a/test/operator-client-cli.test.ts
+++ b/test/operator-client-cli.test.ts
@@ -1,0 +1,97 @@
+import * as http from 'node:http';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { expect, test } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const CLI = new URL('../dist/bin/relay-ide.js', import.meta.url);
+
+test('operator-client CLI issues once and revokes through the grant-backed API', async () => {
+  const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk: Buffer) => {
+      raw += chunk.toString();
+    });
+    req.on('end', () => {
+      requests.push({
+        url: req.url ?? '',
+        body: raw ? (JSON.parse(raw) as Record<string, unknown>) : {},
+      });
+      res.setHeader('content-type', 'application/json');
+      if (req.url === '/operator-client-credentials') {
+        res.end(
+          JSON.stringify({
+            token: 'relay-occ-v1.credential-id.raw-token',
+            credential: { id: 'credential-id', principal: { kind: 'human' } },
+          })
+        );
+        return;
+      }
+      res.end(
+        JSON.stringify({
+          credential: { id: 'credential-id', revokedAt: 'now' },
+        })
+      );
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string')
+    throw new Error('server unavailable');
+  const hub = `http://127.0.0.1:${address.port}`;
+
+  try {
+    const issue = await execFileAsync(process.execPath, [
+      CLI.pathname,
+      'operator-client',
+      'issue',
+      '--hub',
+      hub,
+      '--operator-grant',
+      'relay-ohg-v1.grant-id.grant-secret',
+      '--client-id',
+      'desktop-plugin',
+      '--channel-id',
+      'topic:operator',
+    ]);
+    expect(issue.stdout.trim()).toBe('relay-occ-v1.credential-id.raw-token');
+    expect(requests[0]).toMatchObject({
+      url: '/operator-client-credentials',
+      body: {
+        grantHandle: 'relay-ohg-v1.grant-id.grant-secret',
+        client: { id: 'desktop-plugin' },
+        capabilities: ['context:read', 'context:write'],
+        scope: { channelIds: ['topic:operator'] },
+      },
+    });
+
+    const revoke = await execFileAsync(process.execPath, [
+      CLI.pathname,
+      'operator-client',
+      'revoke',
+      '--hub',
+      hub,
+      '--operator-grant',
+      'relay-ohg-v1.revoke-grant.revoke-secret',
+      '--credential-id',
+      'credential-id',
+      '--client-id',
+      'desktop-plugin',
+      '--json',
+    ]);
+    expect(revoke.stdout).toContain('revokedAt');
+    expect(revoke.stdout).not.toContain('raw-token');
+    expect(requests[1]).toMatchObject({
+      url: '/operator-client-credentials/credential-id/revoke',
+      body: {
+        grantHandle: 'relay-ohg-v1.revoke-grant.revoke-secret',
+        client: { id: 'desktop-plugin' },
+      },
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    );
+  }
+});

--- a/test/operator-client-credentials.test.ts
+++ b/test/operator-client-credentials.test.ts
@@ -165,4 +165,100 @@ describe('operator client credential registry', () => {
     expect(revoked).not.toHaveProperty('token');
     expect(revoked.revokedAt).toBeDefined();
   });
+
+  it('does not inherit a non-channel or wildcard grant scope', () => {
+    const registry = credentials(() => NOW);
+    const grantRegistry = grants(() => NOW);
+    const input = issueInput();
+    for (const [id, scope] of [
+      ['repo-only', { repoIds: ['repo-a'] }],
+      ['wildcard-channel', { channelIds: ['*'] }],
+    ]) {
+      const requested = grantRegistry.request({
+        id,
+        actor: { type: 'cli', id: input.client.id },
+        issuer: { id: 'browser-operator' },
+        audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+        capabilities: input.capabilities,
+        scope,
+        ttlMs: 120_000,
+      });
+      const approved = grantRegistry.approve(requested.id, {
+        approvedBy: { id: 'browser-operator' },
+      });
+
+      expect(() =>
+        issueOperatorClientCredentialWithGrant(registry, grantRegistry, {
+          grantHandle: approved.handle,
+          client: input.client,
+          capabilities: input.capabilities,
+          ttlMs: input.ttlMs,
+        })
+      ).toThrow(/handshake grant does not authorize/);
+    }
+    expect(registry.listCredentials()).toEqual([]);
+  });
+
+  it('fails closed without leaking grant metadata for tampered or unknown handles', () => {
+    const registry = credentials(() => NOW);
+    const grantRegistry = grants(() => NOW);
+    const input = issueInput();
+    const requested = grantRegistry.request({
+      actor: { type: 'cli', id: input.client.id },
+      issuer: { id: 'browser-operator' },
+      audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+      capabilities: input.capabilities,
+      scope: input.scope,
+      ttlMs: 120_000,
+    });
+    const approved = grantRegistry.approve(requested.id, {
+      approvedBy: { id: 'browser-operator' },
+    });
+
+    for (const grantHandle of [
+      `${approved.handle}tampered`,
+      'relay-ohg-v1.unknown-grant.unknown-secret',
+    ]) {
+      let rejected: unknown;
+      try {
+        issueOperatorClientCredentialWithGrant(registry, grantRegistry, {
+          grantHandle,
+          client: input.client,
+          capabilities: input.capabilities,
+          ttlMs: input.ttlMs,
+        });
+      } catch (error) {
+        rejected = error;
+      }
+      expect(String(rejected)).toMatch(/handshake grant does not authorize/);
+      expect(String(rejected)).not.toContain('topic:operator');
+    }
+    expect(registry.listCredentials()).toEqual([]);
+  });
+
+  it('rejects an explicit channel scope that is wider than the grant', () => {
+    const registry = credentials(() => NOW);
+    const grantRegistry = grants(() => NOW);
+    const input = issueInput();
+    const requested = grantRegistry.request({
+      actor: { type: 'cli', id: input.client.id },
+      issuer: { id: 'browser-operator' },
+      audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+      capabilities: input.capabilities,
+      scope: input.scope,
+      ttlMs: 120_000,
+    });
+    const approved = grantRegistry.approve(requested.id, {
+      approvedBy: { id: 'browser-operator' },
+    });
+
+    expect(() =>
+      issueOperatorClientCredentialWithGrant(registry, grantRegistry, {
+        ...input,
+        scope: { channelIds: ['topic:operator', 'topic:outside-grant'] },
+        grantHandle: approved.handle,
+      })
+    ).toThrow(/handshake grant does not authorize/);
+    expect(registry.listCredentials()).toEqual([]);
+  });
 });

--- a/test/operator-client-credentials.test.ts
+++ b/test/operator-client-credentials.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+  OperatorClientCredentialRegistry,
+} from '../shared/operator-client-credentials.js';
+import { HandshakeGrantRegistry } from '../shared/operator-handshake-grants.js';
+import {
+  issueOperatorClientCredentialWithGrant,
+  revokeOperatorClientCredentialWithGrant,
+} from '../server/operator-client-auth.js';
+
+const NOW = new Date('2026-08-21T00:00:00.000Z');
+
+function credentials(now: () => Date): OperatorClientCredentialRegistry {
+  return new OperatorClientCredentialRegistry({
+    now,
+    secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+  });
+}
+
+function grants(now: () => Date): HandshakeGrantRegistry {
+  return new HandshakeGrantRegistry({
+    now,
+    secretBytes: () => Buffer.from('abcdef0123456789abcdef0123456789'),
+  });
+}
+
+function issueInput() {
+  return {
+    client: {
+      id: 'desktop-plugin-backend',
+      displayName: 'Desktop plugin backend',
+      platform: 'linux',
+    },
+    device: { id: 'device-opaque-id', displayName: 'Operator desktop' },
+    capabilities: ['context:read', 'context:write'],
+    scope: { channelIds: ['topic:operator'] },
+    ttlMs: 60_000,
+  };
+}
+
+describe('operator client credential registry', () => {
+  it('issues one raw token while list metadata stays human-derived and secret-free', () => {
+    const registry = credentials(() => NOW);
+    const issued = registry.issue(issueInput());
+
+    expect(issued.token).toMatch(/^relay-occ-v1\.[a-z0-9-]+\.[a-f0-9]+$/);
+    expect(issued.credential).toMatchObject({
+      audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+      principal: {
+        kind: 'human',
+        id: 'human:operator',
+        displayName: 'Operator',
+      },
+      client: { id: 'desktop-plugin-backend', platform: 'linux' },
+      scope: { channelIds: ['topic:operator'] },
+      capabilities: ['context:read', 'context:write'],
+    });
+    const listed = registry.listCredentials();
+    expect(JSON.stringify(listed)).not.toContain(issued.token);
+    expect(JSON.stringify(listed)).not.toContain('device-opaque-id');
+    expect(listed[0]?.device?.idHash).toBeDefined();
+  });
+
+  it('fails closed for scope/capability misuse, expiry, and revocation', () => {
+    let now = NOW;
+    const registry = credentials(() => now);
+    const issued = registry.issue(issueInput());
+
+    expect(
+      registry.validate(issued.token, {
+        audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+        requiredCapabilities: ['context:read'],
+        channelId: 'topic:other',
+      })
+    ).toMatchObject({ ok: false, reason: 'wrong_channel_scope' });
+    expect(
+      registry.validate(issued.token, {
+        audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+        requiredCapabilities: ['session:read'],
+        channelId: 'topic:operator',
+      })
+    ).toMatchObject({ ok: false, reason: 'unknown_capability' });
+
+    now = new Date(NOW.getTime() + 60_000);
+    expect(
+      registry.validate(issued.token, {
+        audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+        requiredCapabilities: ['context:read'],
+        channelId: 'topic:operator',
+      })
+    ).toMatchObject({ ok: false, reason: 'expired' });
+
+    now = NOW;
+    const revocable = registry.issue(issueInput());
+    registry.revoke(revocable.credential.id, {
+      revokedBy: 'browser-operator',
+      reason: 'operator requested revocation',
+    });
+    expect(
+      registry.validate(revocable.token, {
+        audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+        requiredCapabilities: ['context:write'],
+        channelId: 'topic:operator',
+      })
+    ).toMatchObject({ ok: false, reason: 'revoked' });
+  });
+
+  it('mints and revokes through single-use handshake grants without exposing a token on revoke', () => {
+    const registry = credentials(() => NOW);
+    const grantRegistry = grants(() => NOW);
+    const input = issueInput();
+    const requested = grantRegistry.request({
+      actor: { type: 'cli', id: input.client.id },
+      issuer: { id: 'browser-operator' },
+      audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+      capabilities: input.capabilities,
+      scope: input.scope,
+      device: input.device,
+      ttlMs: 120_000,
+    });
+    const approved = grantRegistry.approve(requested.id, {
+      approvedBy: { id: 'browser-operator' },
+    });
+    const issued = issueOperatorClientCredentialWithGrant(
+      registry,
+      grantRegistry,
+      {
+        ...input,
+        grantHandle: approved.handle,
+      }
+    );
+    expect(issued.credential.grantId).toBe(requested.id);
+    expect(
+      grantRegistry.validate(approved.handle, {
+        audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+        requiredCapabilities: ['context:read'],
+      })
+    ).toMatchObject({ ok: false, reason: 'replayed' });
+
+    const revokeGrant = grantRegistry.request({
+      actor: { type: 'cli', id: input.client.id },
+      issuer: { id: 'browser-operator' },
+      audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+      capabilities: input.capabilities,
+      scope: input.scope,
+      device: input.device,
+      ttlMs: 120_000,
+    });
+    const revokeHandle = grantRegistry.approve(revokeGrant.id, {
+      approvedBy: { id: 'browser-operator' },
+    }).handle;
+    const revoked = revokeOperatorClientCredentialWithGrant(
+      registry,
+      grantRegistry,
+      issued.credential.id,
+      {
+        grantHandle: revokeHandle,
+        client: input.client,
+        device: input.device,
+        reason: 'lost device',
+      }
+    );
+    expect(revoked).not.toHaveProperty('token');
+    expect(revoked.revokedAt).toBeDefined();
+  });
+});

--- a/test/operator-client-renew.test.ts
+++ b/test/operator-client-renew.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+  OperatorClientCredentialRegistry,
+} from '../shared/operator-client-credentials.js';
+import {
+  authenticateOperatorClientCredentialForRenew,
+  renewOperatorClientCredential,
+} from '../server/operator-client-auth.js';
+
+const NOW = new Date('2026-08-21T00:00:00.000Z');
+
+function credentials(now: () => Date): OperatorClientCredentialRegistry {
+  return new OperatorClientCredentialRegistry({
+    now,
+    secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+  });
+}
+
+function issueInput() {
+  return {
+    client: {
+      id: 'desktop-plugin-backend',
+      displayName: 'Desktop plugin backend',
+      platform: 'linux',
+    },
+    device: { id: 'device-opaque-id', displayName: 'Operator desktop' },
+    capabilities: ['context:read', 'context:write'],
+    scope: { channelIds: ['topic:operator'] },
+    ttlMs: 60_000,
+  };
+}
+
+function renewRequest(
+  token: string,
+  headers: Record<string, string | undefined> = {}
+): Parameters<typeof authenticateOperatorClientCredentialForRenew>[1] {
+  const store: Record<string, string> = {
+    authorization: `Bearer ${token}`,
+    'x-relay-operator-client-token': 'v1',
+    'x-relay-cli-gateway': 'v1',
+    ...headers,
+  };
+  return {
+    header: (name: string) => store[name.toLowerCase()],
+  } as never;
+}
+
+describe('operator client credential renewal', () => {
+  it('mints a successor copying identity dimensions while the old token stays valid', () => {
+    const registry = credentials(() => NOW);
+    const issued = registry.issue(issueInput());
+    const renewed = renewOperatorClientCredential(
+      registry,
+      issued.credential,
+      {}
+    );
+
+    expect(renewed.token).not.toBe(issued.token);
+    expect(renewed.token).toMatch(/^relay-occ-v1\./);
+    expect(renewed.credential).toMatchObject({
+      client: issued.credential.client,
+      capabilities: issued.credential.capabilities,
+      scope: issued.credential.scope,
+      device: issued.credential.device,
+    });
+    // Old token is deliberately not revoked: a lost renew response can never
+    // lock the client out, and per-token blast radius is unchanged.
+    expect(
+      registry.validate(issued.token, {
+        audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+        requiredCapabilities: ['context:read'],
+      })
+    ).toMatchObject({ ok: true });
+  });
+
+  it('preserves the originating grantId so grant revocation cascades', () => {
+    const registry = credentials(() => NOW);
+    const issued = registry.issue({ ...issueInput(), grantId: 'grant-1' });
+    const renewed = renewOperatorClientCredential(
+      registry,
+      issued.credential,
+      {}
+    );
+
+    expect(renewed.credential.grantId).toBe('grant-1');
+    const cascaded = registry.revokeByGrantId('grant-1', {
+      revokedBy: 'grant:grant-1',
+    });
+    expect(cascaded).toHaveLength(2);
+    expect(
+      registry.validate(renewed.token, {
+        audience: OPERATOR_CLIENT_CREDENTIAL_AUDIENCE,
+        requiredCapabilities: ['context:read'],
+      })
+    ).toMatchObject({ ok: false, reason: 'revoked' });
+  });
+
+  it('rejects an expired credential', () => {
+    let now = NOW;
+    const registry = credentials(() => now);
+    const issued = registry.issue(issueInput());
+    now = new Date(NOW.getTime() + 61_000);
+
+    const auth = authenticateOperatorClientCredentialForRenew(
+      registry,
+      renewRequest(issued.token)
+    );
+    expect(auth).toMatchObject({ ok: false, reason: 'expired' });
+  });
+
+  it('rejects a revoked credential', () => {
+    const registry = credentials(() => NOW);
+    const issued = registry.issue(issueInput());
+    registry.revoke(issued.credential.id, { revokedBy: 'operator' });
+
+    const auth = authenticateOperatorClientCredentialForRenew(
+      registry,
+      renewRequest(issued.token)
+    );
+    expect(auth).toMatchObject({ ok: false, reason: 'revoked' });
+  });
+
+  it('requires both v1 marker headers', () => {
+    const registry = credentials(() => NOW);
+    const issued = registry.issue(issueInput());
+
+    const noTokenMarker = authenticateOperatorClientCredentialForRenew(
+      registry,
+      renewRequest(issued.token, { 'x-relay-operator-client-token': undefined })
+    );
+    expect(noTokenMarker).toMatchObject({
+      ok: false,
+      reason: 'marker_required',
+    });
+
+    const noGatewayMarker = authenticateOperatorClientCredentialForRenew(
+      registry,
+      renewRequest(issued.token, { 'x-relay-cli-gateway': undefined })
+    );
+    expect(noGatewayMarker).toMatchObject({
+      ok: false,
+      reason: 'gateway_marker_required',
+    });
+  });
+
+  it('rejects actor-marker substitution on the renewal lane', () => {
+    const registry = credentials(() => NOW);
+    const issued = registry.issue(issueInput());
+
+    const auth = authenticateOperatorClientCredentialForRenew(
+      registry,
+      renewRequest(issued.token, {
+        'x-relay-cli-actor-token': 'relay-sac-v1.x.y',
+      })
+    );
+    expect(auth).toMatchObject({ ok: false, reason: 'actor_marker_forbidden' });
+  });
+
+  it('rejects a malformed bearer token', () => {
+    const registry = credentials(() => NOW);
+
+    const auth = authenticateOperatorClientCredentialForRenew(
+      registry,
+      renewRequest('relay-sac-v1.not.ours')
+    );
+    expect(auth).toMatchObject({ ok: false, reason: 'token_substitution' });
+  });
+
+  it('rejects a requested ttl beyond the registry maximum', () => {
+    const registry = credentials(() => NOW);
+    const issued = registry.issue(issueInput());
+
+    // resolveExpiry fails closed rather than silently clamping: an oversized
+    // ask is a client bug, and a silent clamp would mint something longer
+    // than the operator policy allows.
+    expect(() =>
+      renewOperatorClientCredential(registry, issued.credential, {
+        ttlMs: 24 * 60 * 60 * 1000,
+      })
+    ).toThrow('ttl exceeds registry maximum');
+  });
+
+  it('rejects unknown body fields', () => {
+    const registry = credentials(() => NOW);
+    const issued = registry.issue(issueInput());
+
+    expect(() =>
+      renewOperatorClientCredential(registry, issued.credential, {
+        ttlMs: 1000,
+        scope: { channelIds: ['topic:other'] },
+      })
+    ).toThrow('unexpected renewal field');
+  });
+
+  it('renews a credential without device or channel scope', () => {
+    const registry = credentials(() => NOW);
+    const issued = registry.issue({
+      client: { id: 'desktop-plugin-backend' },
+      capabilities: ['context:read'],
+      ttlMs: 60_000,
+    });
+    const renewed = renewOperatorClientCredential(
+      registry,
+      issued.credential,
+      {}
+    );
+
+    expect(renewed.credential.device).toBeUndefined();
+    expect(renewed.credential.scope).toEqual({});
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ const SERIAL_SUBPROCESS_FILES = [
   'test/cli-gateway-hermes-tools.test.ts',
   'test/cli-gateway-sessions-wait.test.ts',
   'test/cli-gateway-workflow.test.ts',
+  'test/operator-client-cli.test.ts',
   'test/cli-gateway/channels-post.test.ts',
   'test/cli-gateway/events.test.ts',
   'test/hub-node-packaging.test.ts',


### PR DESCRIPTION
# feat(auth): operator-client channel credentials for non-browser desktop clients

## Why

A native Desktop client (hermes-plugin-relay) needs to read and post to Relay channels without a browser session. The existing lanes don't fit:

- **Browser session** requires an interactive PIN login in the hub UI — wrong shape for a plugin backend process.
- **Scoped actor credentials** are agent automation credentials with actor semantics — deliberately not reusable as a human-operator client lane.

This adds a third, minimal lane: short-lived, channel-scoped, revocable **operator-client credentials**, minted once from an approved handshake grant.

## What it does

- `POST /operator-client-credentials` issues a `relay-occ-v1.<id>.<secret>` token. Two issuance lanes:
  - **browser-authenticated** (operator logged into the hub), or
  - **grant-backed**: body carries a one-time `relay-ohg-v1...` `grantHandle` whose audience is `relay:operator-client:v1`, actor binding matches `cli:<client.id>`, and capabilities are a subset of the grant's.
- Token grants exactly two capabilities: `context:read`, `context:write`. No admin surface, no runtime control.
- Channel scope: explicit `scope.channelIds` subset of the grant, or — **grant-backed issuance only** — omitted scope inherits the grant's exact validated `channelIds` (fixes the bootstrap deadlock where a client can't list channels before it has a credential). Inheritance is strict: channel IDs only, no wildcards, no broadening; malformed/tampered handles fail closed.
- Scoped commands: `channels.list`, `channels.get`, `channels.history`, `channels.post`, `channels.subscribe`. Posts are server-attributed `human:operator`; callers cannot set `sender`/`source`.
- Subscriptions revalidate expiry/revocation before opening and before every streamed frame/heartbeat.
- Actor markers (`x-relay-cli-actor-token`, `relay-sac-v1…`) presented on this lane are rejected, not reinterpreted — no lane mixing.
- Revocation: browser lane via `DELETE /operator-client-credentials/:id`; non-browser lane via a fresh one-time grant (`POST /operator-client-credentials/:id/revoke`). Revoking an originating grant revokes credentials minted from it.

## Known debt (explicit)

The credential registry is **process-local**. A hub restart fails all operator-client credentials closed and clients must re-authorize. Documented in `docs/OPERATOR_CLIENT_CREDENTIALS.md`. Durable persistence is deferred until there's a real multi-process deployment that needs it.

Client-side TTL is capped at 15 minutes by the plugin's own policy (separate repo); the Relay side honors any TTL bounded by the server maximum.

## Verification

- Focused suites: `operator-client-credentials.test.ts`, `operator-client-channel.test.ts`, `operator-client-cli.test.ts` — 10 passed after the scope-inheritance fix (55 passed across the broader focused set including `channel-client`, `auth`, `server-startup`).
- `npm run build:server`, `tsc --noEmit` (app + test configs): clean.
- Full suite at this head: 7,225/7,226 — the single failure is `test/hermes-image-input.test.ts`, a live-network test requiring a local Hermes gateway on :3000; reproduces on unmodified `nightly`.
- Adversarial cross-repo review (Fugu) returned PASS with no first-slice release blockers after the loopback hardening landed plugin-side.
- Live end-to-end on the devbox hub: PIN setup → grant request/approval → mint → scoped `channels.list` → scoped `channels.post` (server-derived human sender, idempotent `clientMessageId`) → grant revoke invalidates credential.

## Docs

New `docs/OPERATOR_CLIENT_CREDENTIALS.md`; updates to `CHANNEL_CHAT.md`, `CLI_GATEWAY.md`, `OPERATOR_HANDSHAKE_GRANTS.md`, `federated-relay.md`, CHANGELOG.
